### PR TITLE
Restrict Vulkan builds to host mode and expand Vulkan deps

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -240,6 +240,10 @@ func (b *Builder) Build(ctx context.Context, profile string, gitRef string, tag 
 		return nil, fmt.Errorf("unknown profile: %s", profile)
 	}
 
+	if prof.Backend == "vulkan" && RunningInContainer() {
+		return nil, fmt.Errorf("vulkan builds are only supported in host mode, not inside containers")
+	}
+
 	tag = strings.ToLower(strings.TrimSpace(tag))
 	if tag != "" && !validTagRE.MatchString(tag) {
 		return nil, fmt.Errorf("invalid tag %q: only lowercase letters, digits, and hyphens are allowed", tag)

--- a/internal/builder/detect.go
+++ b/internal/builder/detect.go
@@ -1,10 +1,25 @@
 package builder
 
 import (
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 )
+
+// RunningInContainer reports whether the current process is running inside a
+// Docker- or Podman-style container. Docker creates /.dockerenv at the
+// container root; Podman/CRI-O create /run/.containerenv. Either marker is
+// sufficient; we don't fall back to /proc/1/cgroup parsing because cgroup v2
+// no longer reliably names the runtime.
+func RunningInContainer() bool {
+	for _, p := range []string{"/.dockerenv", "/run/.containerenv"} {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
 
 // Backend represents a detected GPU compute backend.
 type Backend struct {
@@ -86,6 +101,13 @@ func detectCUDA() Backend {
 
 func detectVulkan() Backend {
 	b := Backend{Name: "vulkan"}
+
+	// Vulkan in containers requires careful host driver/ICD passthrough that
+	// we don't manage; restrict the profile to host-mode installs.
+	if RunningInContainer() {
+		b.Info = "vulkan builds are only supported in host mode"
+		return b
+	}
 
 	if _, err := exec.LookPath("vulkaninfo"); err != nil {
 		b.Info = "vulkaninfo not found"

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -122,10 +122,27 @@ host_missing_gpu_sdk_packages() {
             command -v nvcc >/dev/null 2>&1 || need+=("cuda-toolkit")
             ;;
         vulkan)
-            # The shader compiler is the only build-time piece we strictly
-            # need; the Vulkan headers + loader are usually already
-            # installed by the GPU driver package.
-            command -v glslc >/dev/null 2>&1 || need+=("glslc")
+            # llama.cpp's Vulkan backend pulls in the Vulkan loader/headers
+            # AND the SPIR-V C++ headers (spirv/unified1/spirv.hpp). The GPU
+            # driver typically lays down the runtime loader, but the dev
+            # headers and shader compiler need to be requested explicitly.
+            case "$DISTRO_FAMILY" in
+                fedora)
+                    for pkg in glslc vulkan-headers vulkan-loader-devel spirv-headers-devel; do
+                        rpm -q "$pkg" >/dev/null 2>&1 || need+=("$pkg")
+                    done
+                    ;;
+                debian)
+                    for pkg in glslang-tools libvulkan-dev spirv-headers; do
+                        dpkg -s "$pkg" >/dev/null 2>&1 || need+=("$pkg")
+                    done
+                    ;;
+                *)
+                    # Best-effort fallback for unknown distros: at least flag
+                    # the shader compiler if it's missing.
+                    command -v glslc >/dev/null 2>&1 || need+=("glslc")
+                    ;;
+            esac
             ;;
         cpu|metal)
             : # nothing extra


### PR DESCRIPTION
## Summary

- Refuse the Vulkan build profile when running inside a container. Vulkan needs careful host driver/ICD passthrough that this project doesn't manage; the failure mode without it is confusing. Detected via `/.dockerenv` and `/run/.containerenv`.
- The check fires both at detect time (so the UI shows "vulkan builds are only supported in host mode") and at `Build()` time as a defense in depth.
- Expand the Vulkan host-install dependency list. llama.cpp's Vulkan backend pulls in the loader, dev headers, and SPIR-V C++ headers (`spirv/unified1/spirv.hpp`) — not just the shader compiler. Per-distro:
  - **Fedora**: `glslc`, `vulkan-headers`, `vulkan-loader-devel`, `spirv-headers-devel`
  - **Debian/Ubuntu**: `glslang-tools`, `libvulkan-dev`, `spirv-headers`
  - **Other**: best-effort `glslc` fallback (matches the previous behavior)

## Files

- `internal/builder/detect.go` — adds `RunningInContainer()` helper; `detectVulkan()` early-returns when in a container.
- `internal/builder/builder.go` — `Build()` rejects the Vulkan profile in a container with a clear error.
- `scripts/lib/host.sh` — per-distro Vulkan dep checks in `host_missing_gpu_sdk_packages`.

## Test plan

- [ ] On a host (no container): `--host` install with the Vulkan profile reports the right missing packages on Fedora and on Debian/Ubuntu, and reports nothing missing once they're installed.
- [ ] On a host: Vulkan build succeeds end-to-end (assuming the deps are installed).
- [ ] Inside a container: detect surfaces "vulkan builds are only supported in host mode" instead of attempting the build.
- [ ] Inside a container: invoking `Build("vulkan", ...)` returns the expected error rather than failing partway through.
- [ ] Other build profiles (cuda, rocm, cpu) are unaffected in both host and container modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)