### PR TITLE
Host install improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Click this screenshot to watch the explainer video:
 
 A web-based management interface for [llama.cpp](https://github.com/ggerganov/llama.cpp) inference servers. Build llama.cpp from source, download models from HuggingFace, configure and run inference, and expose an OpenAI-compatible API — all from a single containerized application.
 
-**Linux only.** Supports NVIDIA CUDA, AMD ROCm, and CPU backends. Works with Docker and Podman on all major Linux distributions. GPU passthrough to containers is not available on macOS or Windows.
+**Linux only.** Supports NVIDIA CUDA, AMD ROCm, Vulkan (host install only), and CPU backends. Works with Docker and Podman on all major Linux distributions. GPU passthrough to containers is not available on macOS or Windows.
 
 ## Features
 
-- **Build Management** — Clone and compile llama.cpp inside the container with CUDA, ROCm, or CPU backends. Toggleable build options including OpenSSL for HTTPS support. View real-time build logs via SSE streaming.
+- **Build Management** — Clone and compile llama.cpp with CUDA, ROCm, Vulkan (host only), or CPU backends. Toggleable build options including OpenSSL for HTTPS support. View real-time build logs via SSE streaming.
 - **Model Management** — Download GGUF models directly from HuggingFace. Search repos, browse available quantizations, and track download progress. Configure per-model inference parameters. Scan directories for existing GGUF files.
 - **Multi-Model Loading** — Run multiple models simultaneously via llama.cpp's native router mode. Each model runs in its own isolated subprocess with per-model configuration. LRU eviction automatically unloads least-used models when VRAM limits are reached.
 - **Per-Model Configuration** — Each model can have its own context size, KV cache quantization, GPU layers, tensor split, split mode (layer/tensor parallelism), flash attention, direct I/O, sampling parameters, user-defined aliases, and speculative decoding draft model. Settings are stored in the registry and translated to llama.cpp preset INI format.
@@ -60,6 +60,16 @@ The management UI will be available at `http://localhost:3000`.
 | `--host --from-source` | You're testing uncommitted changes from the source tree. | Builds the binary via `go build` and drops it in `~/.local/bin/llama-toolchest`. Otherwise the same flow. |
 
 Host mode is managed via `systemctl --user start|stop|status llama-toolchest` (user install) or `sudo systemctl ...` (system install). The container `up`/`down`/`logs`/`enable`/`disable` commands are container-mode-only.
+
+### Backend SDK selection (host mode)
+
+By default `--host` auto-detects your primary GPU and asks whether to also install the Vulkan SDK as a portable fallback. To pick explicitly — including stacking multiple SDKs in one install — pass any combination of `--cuda`, `--rocm`, `--vulkan`. Each implies `--host`. Examples:
+
+```bash
+./setup.sh install --rocm --vulkan    # AMD GPU + Vulkan as a fallback
+./setup.sh install --vulkan           # Vulkan-only (cross-vendor)
+./setup.sh install --cuda             # NVIDIA only, skip the Vulkan prompt
+```
 
 ### Manual install (no setup.sh)
 
@@ -111,9 +121,12 @@ You can rerun `./setup.sh install --host` later if you'd rather have the script 
 
 | GPU | Backend | Build Profiles | Notes |
 |-----|---------|---------------|-------|
-| NVIDIA (Maxwell+) | CUDA 12.8 | cuda, cpu | GTX 900 series and newer. Requires driver >= 570. |
-| AMD | ROCm 7.2 | rocm, cpu | RDNA and newer. |
+| NVIDIA (Maxwell+) | CUDA 12.8 | cuda, cpu, vulkan† | GTX 900 series and newer. Requires driver >= 570. |
+| AMD | ROCm 7.2 | rocm, cpu, vulkan† | RDNA and newer. |
+| Other (Intel Arc, etc.) | Vulkan† | vulkan, cpu | Cross-vendor backend; install with `./setup.sh install --vulkan`. |
 | None | CPU-only | cpu | No GPU required. |
+
+† Vulkan is host-install only — see [GPU Backend Notes → Vulkan](#vulkan) below.
 
 **NVIDIA generation support (CUDA 12.8):**
 
@@ -127,7 +140,7 @@ You can rerun `./setup.sh install --host` later if you'd rather have the script 
 | Maxwell (900) | GTX 970–980 | Yes (driver >= 570) |
 | Kepler and older | GTX 700 and below | No (dropped in CUDA 12) |
 
-**Backend performance:** CUDA and ROCm provide native GPU compute for best performance. Each container image supports multiple build profiles — an NVIDIA user can build with CUDA or CPU from the same container.
+**Backend performance:** CUDA and ROCm provide native GPU compute for best performance; Vulkan is portable across vendors but typically slower than the vendor-specific backend on the same hardware. Each container image supports multiple build profiles — an NVIDIA user can build with CUDA or CPU from the same container.
 
 ### Supported Distros
 
@@ -162,16 +175,18 @@ Auto-start:
 
 Info:
   status      Show detected environment and planned actions
-  detect      Print detected GPU backend (cuda/rocm/cpu)
+  detect      Print detected GPU backend (cuda/rocm/vulkan/cpu)
   help        Show full help with details
 ```
 
 Override detection with environment variables:
 
 ```bash
-GPU=cpu ./setup.sh install          # force CPU-only backend
+GPU=cpu ./setup.sh install          # force CPU-only backend (single-backend)
 RUNTIME=podman ./setup.sh install   # force Podman runtime
 ```
+
+For host installs that need multiple GPU SDKs, prefer the additive flags (`--cuda`, `--rocm`, `--vulkan`) over `GPU=` — see "Backend SDK selection" above.
 
 ### First Run
 
@@ -231,6 +246,19 @@ The setup script auto-detects the AMD GPU architecture and sets `HSA_OVERRIDE_GF
 ### CUDA
 
 CUDA 12.8 requires an NVIDIA driver >= 570. The llama.cpp CUDA build auto-detects the GPU architecture at compile time — no manual target configuration is needed (unlike ROCm's `AMDGPU_TARGETS`).
+
+### Vulkan
+
+Vulkan is **host-install only** — container mode requires GPU driver / ICD passthrough that this project doesn't manage, so the `vulkan` profile is rejected at build time inside containers. Use it as a portable fallback alongside CUDA or ROCm, or as the sole backend on hardware where the vendor SDK isn't a fit.
+
+`./setup.sh install --vulkan` (or `--rocm --vulkan`) installs the SDK packages needed by llama.cpp's Vulkan backend:
+
+| Distro | Packages |
+|--------|----------|
+| Debian / Ubuntu | `glslang-tools libvulkan-dev spirv-headers vulkan-tools` |
+| Fedora / RHEL | `glslc vulkan-headers vulkan-loader-devel spirv-headers-devel vulkan-tools` |
+
+`vulkan-tools` provides `vulkaninfo`, which the backend probe uses to enumerate hardware Vulkan devices — without it the UI marks the backend unavailable. The runtime loader (`libvulkan1` on Debian, `vulkan-loader` on Fedora) is typically already laid down by your GPU driver.
 
 ### Multi-GPU Configuration
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Vulkan is **host-install only** — container mode requires GPU driver / ICD pas
 
 | Distro | Packages |
 |--------|----------|
-| Debian / Ubuntu | `glslang-tools libvulkan-dev spirv-headers vulkan-tools` |
+| Debian / Ubuntu | `glslc libvulkan-dev spirv-headers vulkan-tools` |
 | Fedora / RHEL | `glslc vulkan-headers vulkan-loader-devel spirv-headers-devel vulkan-tools` |
 
 `vulkan-tools` provides `vulkaninfo`, which the backend probe uses to enumerate hardware Vulkan devices — without it the UI marks the backend unavailable. The runtime loader (`libvulkan1` on Debian, `vulkan-loader` on Fedora) is typically already laid down by your GPU driver.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ Auto-start:
 
 Info:
   status      Show detected environment and planned actions
+  deps        Verify all packages needed to build and run; print
+              copy-paste install commands for anything missing
+              (--host for host install, default container)
   detect      Print detected GPU backend (cuda/rocm/vulkan/cpu)
   help        Show full help with details
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ The management UI will be available at `http://localhost:3000`.
 
 Host mode is managed via `systemctl --user start|stop|status llama-toolchest` (user install) or `sudo systemctl ...` (system install). The container `up`/`down`/`logs`/`enable`/`disable` commands are container-mode-only.
 
+### Switching modes
+
+If you change your mind after install, `./setup.sh migrate` moves your model registry, per-model configs, benchmarks, and main settings between sides:
+
+```bash
+./setup.sh migrate --to-host         # container → host
+./setup.sh migrate --to-container    # host → container
+```
+
+Migration refuses to run if the destination side is already populated — uninstall the unwanted side first (`./setup.sh uninstall` or `./setup.sh uninstall --host`). The source's snapshot is kept at `~/llt-migrate-<timestamp>` and the source install is left in place as a safety net (`docker volume rm llama-toolchest-data` once you're confident; or `./setup.sh uninstall --host` for the reverse).
+
+`builds.json` is wiped during migration: container-built `llama-server` binaries don't run on the host (different glibc/CUDA/ROCm runtime) and vice versa, so a fresh llama.cpp build is required after switching. Open the **Builds** page after the migration finishes and rebuild.
+
 ### Backend SDK selection (host mode)
 
 By default `--host` auto-detects your primary GPU and asks whether to also install the Vulkan SDK as a portable fallback. To pick explicitly — including stacking multiple SDKs in one install — pass any combination of `--cuda`, `--rocm`, `--vulkan`. Each implies `--host`. Examples:
@@ -161,6 +174,8 @@ Both Docker and Podman (including rootless) are supported on all distros.
 Lifecycle:
   install     Detect environment, install prerequisites, build & start
   uninstall   Stop container, disable auto-start, remove container + image
+  migrate     Move state between container and host installs
+              (--to-host or --to-container required)
   quick       Fast rebuild (recompile Go code only, reuse cached base)
   rebuild     Full rebuild with no cache, then start
 

--- a/internal/models/preset.go
+++ b/internal/models/preset.go
@@ -126,28 +126,42 @@ func writeConfigParams(b *strings.Builder, cfg *ModelConfig, isEmbedding bool) {
 		if cfg.MmprojPath != "" {
 			b.WriteString(fmt.Sprintf("mmproj = %s\n", cfg.MmprojPath))
 		}
-		// Speculative decoding
-		if cfg.SpecType == "draft" && cfg.DraftModelPath != "" {
-			b.WriteString(fmt.Sprintf("model-draft = %s\n", cfg.DraftModelPath))
-		} else if cfg.SpecType != "" && cfg.SpecType != "draft" {
-			b.WriteString(fmt.Sprintf("spec-type = %s\n", cfg.SpecType))
-			if cfg.NgramSizeN > 0 {
-				b.WriteString(fmt.Sprintf("spec-ngram-size-n = %d\n", cfg.NgramSizeN))
+		// Speculative decoding. llama.cpp split the legacy mode-agnostic
+		// flags (--draft-max, --draft-min, --spec-ngram-size-n/m) into
+		// mode-specific flags. Emit the right name based on SpecType.
+		switch cfg.SpecType {
+		case "draft":
+			if cfg.DraftModelPath != "" {
+				b.WriteString(fmt.Sprintf("model-draft = %s\n", cfg.DraftModelPath))
 			}
-			if cfg.NgramSizeM > 0 {
-				b.WriteString(fmt.Sprintf("spec-ngram-size-m = %d\n", cfg.NgramSizeM))
-			}
-		}
-		if cfg.SpecType != "" {
 			if cfg.DraftMax > 0 {
-				b.WriteString(fmt.Sprintf("draft-max = %d\n", cfg.DraftMax))
+				b.WriteString(fmt.Sprintf("spec-draft-n-max = %d\n", cfg.DraftMax))
 			}
 			if cfg.DraftMin > 0 {
-				b.WriteString(fmt.Sprintf("draft-min = %d\n", cfg.DraftMin))
+				b.WriteString(fmt.Sprintf("spec-draft-n-min = %d\n", cfg.DraftMin))
 			}
 			if cfg.DraftPMin != "" {
-				b.WriteString(fmt.Sprintf("draft-p-min = %s\n", cfg.DraftPMin))
+				b.WriteString(fmt.Sprintf("spec-draft-p-min = %s\n", cfg.DraftPMin))
 			}
+		case "ngram-mod":
+			b.WriteString(fmt.Sprintf("spec-type = %s\n", cfg.SpecType))
+			if cfg.DraftMax > 0 {
+				b.WriteString(fmt.Sprintf("spec-ngram-mod-n-max = %d\n", cfg.DraftMax))
+			}
+			if cfg.DraftMin > 0 {
+				b.WriteString(fmt.Sprintf("spec-ngram-mod-n-min = %d\n", cfg.DraftMin))
+			}
+		case "ngram-simple", "ngram-map-k", "ngram-map-k4v":
+			b.WriteString(fmt.Sprintf("spec-type = %s\n", cfg.SpecType))
+			prefix := "spec-" + cfg.SpecType
+			if cfg.NgramSizeN > 0 {
+				b.WriteString(fmt.Sprintf("%s-size-n = %d\n", prefix, cfg.NgramSizeN))
+			}
+			if cfg.NgramSizeM > 0 {
+				b.WriteString(fmt.Sprintf("%s-size-m = %d\n", prefix, cfg.NgramSizeM))
+			}
+		case "ngram-cache":
+			b.WriteString(fmt.Sprintf("spec-type = %s\n", cfg.SpecType))
 		}
 	}
 

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -180,28 +180,42 @@ func (c *ModelConfig) EffectiveFlagsFor(isEmbedding bool) string {
 		if c.MmprojPath != "" {
 			parts = append(parts, "--mmproj", c.MmprojPath)
 		}
-		// Speculative decoding
-		if c.SpecType == "draft" && c.DraftModelPath != "" {
-			parts = append(parts, "--model-draft", c.DraftModelPath)
-		} else if c.SpecType != "" && c.SpecType != "draft" {
-			parts = append(parts, "--spec-type", c.SpecType)
-			if c.NgramSizeN > 0 {
-				parts = append(parts, "--spec-ngram-size-n", strconv.Itoa(c.NgramSizeN))
+		// Speculative decoding. llama.cpp split the legacy mode-agnostic
+		// flags (--draft-max, --draft-min, --spec-ngram-size-n/m) into
+		// mode-specific flags. Emit the right name based on SpecType.
+		switch c.SpecType {
+		case "draft":
+			if c.DraftModelPath != "" {
+				parts = append(parts, "--model-draft", c.DraftModelPath)
 			}
-			if c.NgramSizeM > 0 {
-				parts = append(parts, "--spec-ngram-size-m", strconv.Itoa(c.NgramSizeM))
-			}
-		}
-		if c.SpecType != "" {
 			if c.DraftMax > 0 {
-				parts = append(parts, "--draft-max", strconv.Itoa(c.DraftMax))
+				parts = append(parts, "--spec-draft-n-max", strconv.Itoa(c.DraftMax))
 			}
 			if c.DraftMin > 0 {
-				parts = append(parts, "--draft-min", strconv.Itoa(c.DraftMin))
+				parts = append(parts, "--spec-draft-n-min", strconv.Itoa(c.DraftMin))
 			}
 			if c.DraftPMin != "" {
-				parts = append(parts, "--draft-p-min", c.DraftPMin)
+				parts = append(parts, "--spec-draft-p-min", c.DraftPMin)
 			}
+		case "ngram-mod":
+			parts = append(parts, "--spec-type", c.SpecType)
+			if c.DraftMax > 0 {
+				parts = append(parts, "--spec-ngram-mod-n-max", strconv.Itoa(c.DraftMax))
+			}
+			if c.DraftMin > 0 {
+				parts = append(parts, "--spec-ngram-mod-n-min", strconv.Itoa(c.DraftMin))
+			}
+		case "ngram-simple", "ngram-map-k", "ngram-map-k4v":
+			parts = append(parts, "--spec-type", c.SpecType)
+			prefix := "--spec-" + c.SpecType
+			if c.NgramSizeN > 0 {
+				parts = append(parts, prefix+"-size-n", strconv.Itoa(c.NgramSizeN))
+			}
+			if c.NgramSizeM > 0 {
+				parts = append(parts, prefix+"-size-m", strconv.Itoa(c.NgramSizeM))
+			}
+		case "ngram-cache":
+			parts = append(parts, "--spec-type", c.SpecType)
 		}
 	}
 	if c.ExtraFlags != "" {

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -126,14 +126,18 @@ host_missing_gpu_sdk_packages() {
             # AND the SPIR-V C++ headers (spirv/unified1/spirv.hpp). The GPU
             # driver typically lays down the runtime loader, but the dev
             # headers and shader compiler need to be requested explicitly.
+            # vulkan-tools provides vulkaninfo, which the post-install
+            # backend probe (internal/builder/detect.go) uses to enumerate
+            # GPUs — without it the UI marks the vulkan backend unavailable
+            # even after a clean SDK install.
             case "$DISTRO_FAMILY" in
                 fedora)
-                    for pkg in glslc vulkan-headers vulkan-loader-devel spirv-headers-devel; do
+                    for pkg in glslc vulkan-headers vulkan-loader-devel spirv-headers-devel vulkan-tools; do
                         rpm -q "$pkg" >/dev/null 2>&1 || need+=("$pkg")
                     done
                     ;;
                 debian)
-                    for pkg in glslang-tools libvulkan-dev spirv-headers; do
+                    for pkg in glslang-tools libvulkan-dev spirv-headers vulkan-tools; do
                         dpkg -s "$pkg" >/dev/null 2>&1 || need+=("$pkg")
                     done
                     ;;
@@ -409,14 +413,26 @@ host_install() {
     local mode="${HOST_INSTALL_MODE:-package}"
     log "Host install — scope: $(host_scope), mode: $mode"
     log "GPU backend: ${GPU_VENDOR:-unknown} (${GPU_INFO:-no description})"
+    # HOST_SDK_BACKENDS may carry multiple entries (e.g. rocm + vulkan); fall
+    # back to GPU_VENDOR for callers that don't populate it.
+    local -a sdk_backends=("${HOST_SDK_BACKENDS[@]:-}")
+    if [[ ${#sdk_backends[@]} -eq 0 || -z "${sdk_backends[0]}" ]]; then
+        sdk_backends=()
+        [[ -n "${GPU_VENDOR:-}" ]] && sdk_backends=("$GPU_VENDOR")
+    fi
+    if [[ ${#sdk_backends[@]} -gt 1 ]]; then
+        log "Host SDKs to install: ${sdk_backends[*]}"
+    fi
     echo ""
 
     # GPU SDK packages so llama.cpp builds from the UI succeed first try.
-    # Same step for both install modes.
-    if [[ -n "${GPU_VENDOR:-}" ]]; then
-        host_install_gpu_sdk "$GPU_VENDOR" || \
-            warn "GPU SDK install reported issues; continuing with binary install."
-    fi
+    # Same step for both install modes; install each backend independently
+    # so a failure in one (e.g. vulkan headers missing from a stale repo)
+    # doesn't block the others.
+    for backend in "${sdk_backends[@]}"; do
+        host_install_gpu_sdk "$backend" || \
+            warn "GPU SDK ($backend) install reported issues; continuing."
+    done
 
     case "$mode" in
         package)

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -567,6 +567,115 @@ host_uninstall() {
     ok "Host uninstall complete."
 }
 
+# Whether a backend is applicable to this host. Used by deps/status to
+# avoid reporting "missing cuda-toolkit" on a machine that has no NVIDIA
+# GPU. Vulkan is always applicable — it's the cross-vendor fallback.
+host_backend_applicable() {
+    case "$1" in
+        cuda)   command -v nvidia-smi >/dev/null 2>&1 || [[ -e /dev/nvidia0 ]] ;;
+        rocm)   [[ -e /dev/kfd ]] ;;
+        vulkan) return 0 ;;
+        *)      return 1 ;;
+    esac
+}
+
+# Per-backend SDK report. Echoes one line per backend with state +
+# remediation command. Skips backends that aren't applicable on this
+# host (e.g. cuda when there's no NVIDIA GPU). Returns non-zero if any
+# applicable backend has missing packages.
+host_report_sdk_deps() {
+    local exit_code=0
+    local backend missing inst_cmd
+    case "$DISTRO_FAMILY" in
+        debian) inst_cmd="sudo apt-get install -y" ;;
+        fedora) inst_cmd="sudo dnf install -y" ;;
+        *)      inst_cmd="<distro $DISTRO_FAMILY: install manually>" ;;
+    esac
+    for backend in cuda rocm vulkan; do
+        if ! host_backend_applicable "$backend"; then
+            printf "    %-7s %s\n" "$backend" "n/a (no matching GPU detected)"
+            continue
+        fi
+        missing="$(host_missing_gpu_sdk_packages "$backend")"
+        if [[ -z "$missing" ]]; then
+            printf "    %-7s %s\n" "$backend" "OK"
+        else
+            printf "    %-7s missing: %s\n" "$backend" "$missing"
+            printf "            %s %s\n" "$inst_cmd" "$missing"
+            exit_code=1
+        fi
+    done
+    return $exit_code
+}
+
+# Build/runtime toolchain verification. cmake/ninja/git are pulled in as
+# package depends by the .deb/.rpm so they should always be present after
+# a from-package install; we still re-check because users on from-source
+# may have skipped the install dance.
+host_report_toolchain_deps() {
+    local exit_code=0
+    local item bin pkgs_debian pkgs_fedora
+    # name | binary | debian package | fedora package
+    local -a checks=(
+        "cmake|cmake|cmake|cmake"
+        "ninja|ninja|ninja-build|ninja-build"
+        "git|git|git|git"
+        "gcc|cc|build-essential|gcc-c++ make"
+    )
+    local inst_cmd
+    case "$DISTRO_FAMILY" in
+        debian) inst_cmd="sudo apt-get install -y" ;;
+        fedora) inst_cmd="sudo dnf install -y" ;;
+        *)      inst_cmd="<distro $DISTRO_FAMILY>" ;;
+    esac
+    for c in "${checks[@]}"; do
+        IFS='|' read -r name bin pkg_d pkg_f <<<"$c"
+        if command -v "$bin" >/dev/null 2>&1; then
+            printf "    %-7s %s\n" "$name" "OK"
+        else
+            local pkg="$pkg_d"
+            [[ "$DISTRO_FAMILY" == "fedora" ]] && pkg="$pkg_f"
+            printf "    %-7s missing\n" "$name"
+            printf "            %s %s\n" "$inst_cmd" "$pkg"
+            exit_code=1
+        fi
+    done
+    return $exit_code
+}
+
+# Top-level `deps --host` entry point. Returns 0 if everything's healthy,
+# 1 if anything's missing.
+host_deps() {
+    local rc=0
+    echo "Host install dependencies (scope: $(host_scope), distro: ${DISTRO_FAMILY:-unknown}):"
+    echo ""
+    echo "  Package:"
+    if dpkg -s llama-toolchest >/dev/null 2>&1; then
+        printf "    %-20s %s\n" "llama-toolchest" "OK ($(dpkg-query -W -f='${Version}' llama-toolchest))"
+    elif rpm -q llama-toolchest >/dev/null 2>&1; then
+        printf "    %-20s %s\n" "llama-toolchest" "OK ($(rpm -q --qf '%{VERSION}' llama-toolchest))"
+    elif [[ -x "$(host_binary_path)" ]]; then
+        printf "    %-20s %s\n" "llama-toolchest" "OK (from-source: $(host_binary_path))"
+    else
+        printf "    %-20s %s\n" "llama-toolchest" "not installed"
+        echo "            ./setup.sh install --host"
+        rc=1
+    fi
+    echo ""
+    echo "  Build toolchain (for compiling llama.cpp from the UI):"
+    host_report_toolchain_deps || rc=1
+    echo ""
+    echo "  Backend SDKs:"
+    host_report_sdk_deps || rc=1
+    echo ""
+    if [[ $rc -eq 0 ]]; then
+        ok "All host dependencies satisfied."
+    else
+        warn "One or more dependencies are missing — see commands above."
+    fi
+    return $rc
+}
+
 host_status() {
     echo "Scope:       $(host_scope)"
 
@@ -592,6 +701,9 @@ host_status() {
     echo "Config:      $(host_config_path)$( [[ -f "$(host_config_path)" ]] && echo "" || echo "  (missing)")"
     echo "Data dir:    $(host_data_dir)"
     echo "Service:     $(service_unit_path)"
+    echo ""
+    echo "Backend SDKs:"
+    host_report_sdk_deps || true
     echo ""
     service_status
 }

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -137,7 +137,10 @@ host_missing_gpu_sdk_packages() {
                     done
                     ;;
                 debian)
-                    for pkg in glslang-tools libvulkan-dev spirv-headers vulkan-tools; do
+                    # glslc is its own package on Debian (frontend to
+                    # shaderc); glslang-tools ships glslangValidator
+                    # which find_package(Vulkan) does not use.
+                    for pkg in glslc libvulkan-dev spirv-headers vulkan-tools; do
                         dpkg -s "$pkg" >/dev/null 2>&1 || need+=("$pkg")
                     done
                     ;;

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -489,9 +489,13 @@ host_install() {
 
     host_write_unit_override
 
-    # If the service is already running, restart so the new binary takes
-    # effect.
-    if service_is_active; then
+    # MIGRATE_SKIP_START: when set, the migrate command takes ownership of
+    # service start/stop sequencing (it needs to write the translated
+    # config + restored registry before first start). Don't prompt and
+    # don't restart here — the caller will handle it.
+    if [[ "${MIGRATE_SKIP_START:-0}" == "1" ]]; then
+        log "Skipping service start (caller will handle)."
+    elif service_is_active; then
         log "Service is running; restarting to pick up the new binary..."
         service_restart
         ok "llama-toolchest service restarted"

--- a/scripts/lib/migrate.sh
+++ b/scripts/lib/migrate.sh
@@ -166,6 +166,44 @@ migrate_write_translated_config() {
     unset -f _migrate_get
 }
 
+# Translate path-shaped fields inside models.json (.configs[*].mmproj_path
+# and .configs[*].draft_model_path) when the source and destination
+# models_dir differ. The main file_path on each .models[*] entry gets
+# refreshed by the post-migration scanner; per-config paths don't, so
+# we rewrite them here. Requires jq; bails with a warning if missing.
+#
+# Args: <models.json path> <src prefix> <dst prefix>
+migrate_translate_model_paths() {
+    local file="$1" src="$2" dst="$3"
+    if ! command -v jq >/dev/null 2>&1; then
+        warn "jq not installed — skipping mmproj/draft path translation."
+        log "If your models include vision (mmproj) or speculative-decoding (draft) entries, you may need to fix paths by hand."
+        log "  apt-get install jq   /   dnf install jq"
+        return 0
+    fi
+    [[ -f "$file" ]] || return 0
+
+    # Normalize trailing slashes — both prefixes should end in '/' so the
+    # jq sub() doesn't accidentally rewrite mid-path substrings.
+    src="${src%/}/"
+    dst="${dst%/}/"
+
+    local tmp; tmp=$(mktemp)
+    jq --arg src "$src" --arg dst "$dst" '
+        .configs |= (map_values(
+            (if .mmproj_path and (.mmproj_path | startswith($src))
+                then .mmproj_path = ($dst + (.mmproj_path | ltrimstr($src)))
+                else . end)
+            |
+            (if .draft_model_path and (.draft_model_path | startswith($src))
+                then .draft_model_path = ($dst + (.draft_model_path | ltrimstr($src)))
+                else . end)
+        ))
+    ' "$file" > "$tmp" && mv "$tmp" "$file" \
+        || { rm -f "$tmp"; warn "jq translation failed; left $file unchanged"; return 1; }
+    ok "Translated mmproj/draft paths: $src → $dst"
+}
+
 # ─── Forward: container → host ───────────────────────────────────────────────
 
 migrate_to_host() {
@@ -211,6 +249,14 @@ migrate_to_host() {
     done
     echo "[]" > "$cfg_dir/builds.json"
     ok "Registry restored. builds.json wiped — rebuild llama.cpp from the UI."
+
+    # Per-config mmproj_path / draft_model_path were stored at /data/models/...
+    # inside the container; rewrite to the host's models_dir so vision and
+    # speculative-decoding configs work post-migration.
+    local host_models_dir; host_models_dir=$(grep '^models_dir:' "$(host_config_path)" \
+        | sed 's/^models_dir: *"//; s/" *$//')
+    [[ -z "$host_models_dir" ]] && host_models_dir="$(host_data_dir)/models"
+    migrate_translate_model_paths "$cfg_dir/models.json" "/data/models" "$host_models_dir"
 
     log "Starting service..."
     service_enable
@@ -270,6 +316,14 @@ migrate_to_container() {
         "$staging/llama-toolchest.yaml" \
         "$tmp_cfg" \
         "to-container"
+
+    # Per-config mmproj_path / draft_model_path on the host point at the
+    # host's models_dir; rewrite them to the container's /data/models so
+    # vision and speculative configs work post-migration.
+    local src_models_dir; src_models_dir=$(grep '^models_dir:' "$staging/llama-toolchest.yaml" \
+        | sed 's/^models_dir: *"//; s/" *$//')
+    [[ -z "$src_models_dir" ]] && src_models_dir="${HOME}/.local/share/llama-toolchest/models"
+    migrate_translate_model_paths "$staging/models.json" "$src_models_dir" "/data/models"
 
     write_env_file
     log "Building and starting container..."

--- a/scripts/lib/migrate.sh
+++ b/scripts/lib/migrate.sh
@@ -1,0 +1,323 @@
+# scripts/lib/migrate.sh
+#
+# Bidirectional migration between container and host installs. Sourced by
+# setup.sh after host.sh; relies on globals set by setup.sh's detect_*
+# helpers (CONTAINER_CMD, GPU_VENDOR, LLAMA_TOOLCHEST_PORT, …) and on
+# host.sh / service.sh helpers.
+#
+# Public functions:
+#   migrate_to_host       Container → host. Snapshots registry, stops
+#                         container, installs the .deb/.rpm, restores
+#                         registry (sans builds.json), starts service.
+#   migrate_to_container  Reverse. Snapshots host registry, stops the
+#                         systemd service, builds + starts a fresh
+#                         container, populates the volume.
+#
+# In both directions builds.json is wiped: container-built llama-server
+# binaries don't run on the host (different glibc/CUDA/ROCm runtime)
+# and vice versa, so every migration requires a fresh llama.cpp build.
+
+# ─── Pre-flight ──────────────────────────────────────────────────────────────
+
+# Refuse when the target side already has state. Symmetric in both
+# directions: forces the user to explicitly uninstall first, so we never
+# clobber config or merge state in surprising ways.
+
+migrate_check_no_host_install() {
+    if dpkg -s llama-toolchest >/dev/null 2>&1 \
+       || rpm -q llama-toolchest >/dev/null 2>&1 \
+       || [[ -f "$(host_config_path)" ]]; then
+        err "A host install is already present."
+        log "Run './setup.sh uninstall --host' first if you want to redo the migration."
+        return 1
+    fi
+}
+
+migrate_check_no_container() {
+    [[ -z "${CONTAINER_CMD:-}" ]] && return 0
+    if $CONTAINER_CMD inspect llama-toolchest >/dev/null 2>&1; then
+        err "A 'llama-toolchest' container already exists (running or stopped)."
+        log "Run './setup.sh uninstall' first."
+        return 1
+    fi
+    if $CONTAINER_CMD volume inspect llama-toolchest-data >/dev/null 2>&1; then
+        err "Container volume 'llama-toolchest-data' already exists."
+        log "Remove with: $CONTAINER_CMD volume rm llama-toolchest-data"
+        return 1
+    fi
+}
+
+# ─── Snapshot ────────────────────────────────────────────────────────────────
+
+# Copy the four registry files plus the YAML config into <staging>. Per-file
+# failures are warned (the file may not exist yet on a fresh install) but
+# don't abort. Returns 1 only if nothing was copied.
+migrate_snapshot_from_container() {
+    local staging="$1"; mkdir -p "$staging"
+    local copied=0
+    for f in models.json builds.json preset.ini benchmarks.json llama-toolchest.yaml; do
+        if $CONTAINER_CMD cp "llama-toolchest:/data/config/$f" "$staging/$f" 2>/dev/null; then
+            copied=$((copied + 1))
+        else
+            warn "Could not snapshot $f (may not exist)"
+        fi
+    done
+    if [[ $copied -eq 0 ]]; then
+        err "No registry files could be copied from container."
+        return 1
+    fi
+    ok "Snapshotted $copied file(s) from container"
+}
+
+migrate_snapshot_from_host() {
+    local staging="$1"; mkdir -p "$staging"
+    local cfg_dir; cfg_dir="$(host_data_dir)/config"
+    local copied=0
+    for f in models.json builds.json preset.ini benchmarks.json; do
+        if [[ -f "$cfg_dir/$f" ]]; then
+            cp "$cfg_dir/$f" "$staging/$f"
+            copied=$((copied + 1))
+        fi
+    done
+    if [[ -f "$(host_config_path)" ]]; then
+        cp "$(host_config_path)" "$staging/llama-toolchest.yaml"
+        copied=$((copied + 1))
+    fi
+    if [[ $copied -eq 0 ]]; then
+        err "No registry files found in host install."
+        return 1
+    fi
+    ok "Snapshotted $copied file(s) from host"
+}
+
+# ─── Config translation ──────────────────────────────────────────────────────
+
+# Read flat YAML scalar fields from <src>, translate the path/port-shaped
+# ones for <direction>, write to <dst>. Bash sed-based — assumes the
+# config follows the format setup.sh writes (no anchors, no multiline,
+# no inline comments after values). Anything beyond that is undefined.
+migrate_write_translated_config() {
+    local src="$1" dst="$2" direction="$3"
+
+    # Helper: extract a top-level scalar field, stripping surrounding quotes.
+    _migrate_get() {
+        grep "^$1:" "$src" 2>/dev/null | head -1 | sed "s/^$1: *//; s/^\"//; s/\"$//"
+    }
+
+    local models_dir external_url hf_token api_key log_level models_max auto_start
+    models_dir=$(_migrate_get models_dir)
+    external_url=$(_migrate_get external_url)
+    hf_token=$(_migrate_get hf_token)
+    api_key=$(_migrate_get api_key)
+    log_level=$(_migrate_get log_level)
+    models_max=$(_migrate_get models_max)
+    auto_start=$(_migrate_get auto_start)
+
+    local listen_addr data_dir
+    case "$direction" in
+        to-host)
+            # The container's listen_addr is always :3000 internally. We
+            # want the *host-side* port (i.e. what the user types in their
+            # browser), pulled from the container's port mapping if we
+            # can; fall back to 3000.
+            local p=""
+            if [[ -n "${CONTAINER_CMD:-}" ]]; then
+                p=$($CONTAINER_CMD inspect llama-toolchest 2>/dev/null \
+                    | grep -A 5 '"3000/tcp"' | grep -m1 HostPort \
+                    | sed 's/.*"\([0-9]*\)".*/\1/')
+            fi
+            listen_addr=":${p:-3000}"
+            data_dir="$(host_data_dir)"
+            ;;
+        to-container)
+            # Inside the container, listen_addr is always :3000. The
+            # host-side port is set in .env (LLAMA_TOOLCHEST_PORT) and
+            # mapped via compose.
+            listen_addr=":3000"
+            data_dir="/data"
+            # Translate the host listen_addr to the .env port, so the
+            # caller's compose run maps the right host port. Strip the
+            # leading ':'.
+            local host_port; host_port=$(_migrate_get listen_addr)
+            host_port="${host_port#:}"
+            [[ -n "$host_port" ]] && LLAMA_TOOLCHEST_PORT="$host_port"
+            ;;
+        *)
+            err "Unknown direction: $direction"
+            return 1
+            ;;
+    esac
+
+    {
+        echo "# llama-toolchest configuration (migrated $direction on $(date -u +%FT%TZ))"
+        echo ""
+        echo "listen_addr: \"$listen_addr\""
+        echo "data_dir: \"$data_dir\""
+        [[ -n "$models_dir" ]] && echo "models_dir: \"$models_dir\""
+        echo "llama_port: ${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}"
+        echo "external_url: \"${external_url:-}\""
+        echo "hf_token: \"${hf_token:-}\""
+        echo "api_key: \"${api_key:-}\""
+        echo "log_level: \"${log_level:-info}\""
+        echo "models_max: ${models_max:-1}"
+        echo "auto_start: ${auto_start:-true}"
+    } > "$dst"
+
+    unset -f _migrate_get
+}
+
+# ─── Forward: container → host ───────────────────────────────────────────────
+
+migrate_to_host() {
+    log "Migrating: container → host"
+    echo ""
+
+    if [[ -z "${CONTAINER_CMD:-}" ]]; then
+        err "No container runtime detected — nothing to migrate from."
+        return 1
+    fi
+    migrate_check_no_host_install || return 1
+
+    if ! $CONTAINER_CMD inspect llama-toolchest >/dev/null 2>&1 \
+       && ! $CONTAINER_CMD volume inspect llama-toolchest-data >/dev/null 2>&1; then
+        err "No 'llama-toolchest' container or 'llama-toolchest-data' volume found."
+        return 1
+    fi
+
+    local staging="${HOME}/llt-migrate-$(date +%s)"
+    log "Snapshotting registry → $staging"
+    migrate_snapshot_from_container "$staging" || return 1
+
+    if $CONTAINER_CMD inspect llama-toolchest >/dev/null 2>&1; then
+        log "Stopping and removing container..."
+        container_down 2>/dev/null || true
+        $CONTAINER_CMD rm -f llama-toolchest >/dev/null 2>&1 || true
+    fi
+
+    log "Running host install (from-package)..."
+    HOST_INSTALL_MODE="package"
+    MIGRATE_SKIP_START=1 host_install || { err "Host install failed."; return 1; }
+
+    log "Translating config..."
+    migrate_write_translated_config \
+        "$staging/llama-toolchest.yaml" \
+        "$(host_config_path)" \
+        "to-host"
+
+    local cfg_dir; cfg_dir="$(host_data_dir)/config"
+    mkdir -p "$cfg_dir"
+    for f in models.json preset.ini benchmarks.json; do
+        [[ -f "$staging/$f" ]] && cp "$staging/$f" "$cfg_dir/$f"
+    done
+    echo "[]" > "$cfg_dir/builds.json"
+    ok "Registry restored. builds.json wiped — rebuild llama.cpp from the UI."
+
+    log "Starting service..."
+    service_enable
+
+    local port; port=$(grep '^listen_addr:' "$(host_config_path)" | sed 's/.*: *"//; s/".*//; s/^://')
+    echo ""
+    ok "Migration complete."
+    echo ""
+    echo "  Web UI:        http://localhost:${port:-3000}"
+    echo "  Snapshot kept: $staging"
+    echo "  Volume kept:   llama-toolchest-data"
+    echo "                 (remove with: $CONTAINER_CMD volume rm llama-toolchest-data"
+    echo "                  once you've confirmed the host install works)"
+    echo ""
+    echo "  NEXT STEPS:"
+    echo "    1. Open the Builds page and run a fresh build. Container-built"
+    echo "       binaries don't run natively, so builds.json was wiped."
+    echo "    2. Set the new build as active, then restart the service."
+    echo "    3. Optionally: sudo loginctl enable-linger \$USER  (survives logout)"
+    echo ""
+}
+
+# ─── Reverse: host → container ───────────────────────────────────────────────
+
+migrate_to_container() {
+    log "Migrating: host → container"
+    echo ""
+
+    if [[ -z "${CONTAINER_CMD:-}" ]]; then
+        err "No container runtime detected. Install Docker or Podman first."
+        return 1
+    fi
+    migrate_check_no_container || return 1
+
+    if ! dpkg -s llama-toolchest >/dev/null 2>&1 \
+       && ! rpm -q llama-toolchest >/dev/null 2>&1 \
+       && ! [[ -f "$(host_config_path)" ]]; then
+        err "No host install detected."
+        return 1
+    fi
+
+    local staging="${HOME}/llt-migrate-$(date +%s)"
+    log "Snapshotting registry → $staging"
+    migrate_snapshot_from_host "$staging" || return 1
+
+    if service_is_active 2>/dev/null; then
+        log "Stopping host service..."
+        service_disable
+    fi
+    # Note: the host package itself stays installed. User can run
+    # './setup.sh uninstall --host' once the container is healthy.
+
+    # The translated config sets LLAMA_TOOLCHEST_PORT (read from the host's
+    # listen_addr) before we write .env, so compose maps the right port.
+    local tmp_cfg; tmp_cfg=$(mktemp)
+    migrate_write_translated_config \
+        "$staging/llama-toolchest.yaml" \
+        "$tmp_cfg" \
+        "to-container"
+
+    write_env_file
+    log "Building and starting container..."
+    container_install || { err "Container install failed."; rm -f "$tmp_cfg"; return 1; }
+
+    # Wait for the container to be running before we rewrite /data/config —
+    # the entrypoint creates /data on first start.
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        if $CONTAINER_CMD inspect -f '{{.State.Running}}' llama-toolchest 2>/dev/null \
+            | grep -q true; then break; fi
+        sleep 1
+    done
+
+    # Stop, repopulate /data/config from the staging dir + translated yaml,
+    # then restart. We run an alpine sidecar against the volume rather than
+    # `docker cp`-ing into the running container so we don't race the entry
+    # point's own writes.
+    log "Restoring registry into container volume..."
+    container_down
+    $CONTAINER_CMD run --rm \
+        -v llama-toolchest-data:/data \
+        -v "$staging:/snap:ro" \
+        -v "$tmp_cfg:/snap-cfg:ro" \
+        alpine sh -c '
+            mkdir -p /data/config
+            for f in models.json preset.ini benchmarks.json; do
+                [ -f "/snap/$f" ] && cp "/snap/$f" "/data/config/$f"
+            done
+            cp /snap-cfg /data/config/llama-toolchest.yaml
+            echo "[]" > /data/config/builds.json
+        ' || { err "Failed to populate volume."; rm -f "$tmp_cfg"; return 1; }
+    rm -f "$tmp_cfg"
+
+    container_up
+    ok "Registry restored. builds.json wiped — rebuild llama.cpp from the UI."
+
+    echo ""
+    ok "Migration complete."
+    echo ""
+    echo "  Web UI:        http://localhost:${LLAMA_TOOLCHEST_PORT:-3000}"
+    echo "  Snapshot kept: $staging"
+    echo ""
+    echo "  NEXT STEPS:"
+    echo "    1. Open the Builds page and run a fresh build (host binaries"
+    echo "       don't run inside the container; builds.json was wiped)."
+    echo "    2. Set it active, then restart the inference server."
+    echo "    3. When you're confident, remove the host package:"
+    echo "       ./setup.sh uninstall --host"
+    echo ""
+}

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,7 @@ COMPOSE_VERSION=""
 
 INSTALL_MODE="${INSTALL_MODE:-container}"  # host or container; default container preserves existing behavior
 HOST_INSTALL_MODE="${HOST_INSTALL_MODE:-package}"  # for --host: "package" (download released .deb/.rpm) or "source" (go build locally)
+HOST_SDK_BACKENDS=()    # backends to install host SDKs for (--cuda/--rocm/--vulkan); empty means autodetect+prompt
 
 DISTRO_ID=""            # debian, ubuntu, fedora, arch, cachyos, opensuse-leap, etc.
 DISTRO_NAME=""          # Pretty name from os-release
@@ -1260,6 +1261,17 @@ Install modes:
                   via `go build` instead of installing a release package.
                   Useful for testing uncommitted changes.
 
+Backend selection (host mode, additive — stack flags to install multiple
+SDKs in a single run; each implies --host):
+  --cuda          Install the CUDA toolkit
+  --rocm          Install the ROCm SDK
+  --vulkan        Install the Vulkan SDK (loader headers, glslc, vulkaninfo)
+                  Vulkan-only is fine; combined with --cuda or --rocm gives
+                  you a portable fallback alongside the vendor backend.
+
+If no backend flag and no GPU= env is set, setup.sh auto-detects the
+primary GPU and asks whether to add Vulkan as a secondary SDK.
+
 Pin a specific released version with `LT_VERSION=1.0.0 ./setup.sh
 install --host` to avoid hitting the GH API for the latest tag.
 
@@ -1294,7 +1306,9 @@ Host-mode lifecycle is managed via systemd directly:
   sudo systemctl start|stop|status llama-toolchest      (system install, when run as root)
 
 Environment variables:
-  GPU=cuda|rocm|vulkan|cpu      Override GPU auto-detection
+  GPU=cuda|rocm|vulkan|cpu      Override GPU auto-detection (single
+                                backend; for multi-SDK host installs
+                                use --cuda/--rocm/--vulkan flags instead)
   RUNTIME=docker|podman         Override container runtime auto-detection
   INSTALL_MODE=host|container   Same as --host / --container
 
@@ -1304,6 +1318,8 @@ You can edit .env directly instead of using the interactive setup.
 Examples:
   ./setup.sh install                    # detect, install prereqs, build & run (container)
   ./setup.sh install --host             # install latest released package on the host
+  ./setup.sh install --rocm --vulkan    # host install, install both ROCm and Vulkan SDKs
+  ./setup.sh install --vulkan           # host install, Vulkan SDK only (cross-vendor)
   ./setup.sh install --from-source      # host install, build from local source
   ./setup.sh status --host              # show host install status
   ./setup.sh uninstall --host           # remove host install
@@ -1327,6 +1343,13 @@ main() {
             --container)    INSTALL_MODE="container" ;;
             --from-source)  INSTALL_MODE="host"; HOST_INSTALL_MODE="source" ;;
             --from-package) INSTALL_MODE="host"; HOST_INSTALL_MODE="package" ;;
+            # Backend flags are additive and host-mode-only (vulkan can't run
+            # in containers without driver passthrough we don't manage; for
+            # consistency cuda/rocm flags also imply --host). Stack them:
+            # `./setup.sh install --rocm --vulkan` installs both SDKs.
+            --cuda)         INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("cuda") ;;
+            --rocm)         INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("rocm") ;;
+            --vulkan)       INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("vulkan") ;;
             -h|--help)      usage; exit 0 ;;
             *)
                 err "Unknown flag: $1"
@@ -1367,6 +1390,32 @@ main() {
         # package manager + extension to use, and host_install_gpu_sdk
         # knows which package names to install.
         detect_distro
+
+        # Resolve which backend SDKs to install on the host. Precedence:
+        #   1. Explicit --cuda/--rocm/--vulkan flags (already in HOST_SDK_BACKENDS)
+        #   2. GPU= env override (single backend, back-compat)
+        #   3. Auto-detected primary, plus an interactive prompt to also
+        #      install the Vulkan SDK (since AMD/NVIDIA users frequently
+        #      want it as a portable fallback).
+        # The first non-vulkan entry wins as GPU_VENDOR for systemd unit
+        # overrides; vulkan-only is fine, just no overrides needed.
+        if [[ "$command" == "install" && ${#HOST_SDK_BACKENDS[@]} -eq 0 ]]; then
+            if [[ -n "${GPU:-}" ]]; then
+                HOST_SDK_BACKENDS=("$GPU_VENDOR")
+            else
+                HOST_SDK_BACKENDS=("$GPU_VENDOR")
+                if [[ "$GPU_VENDOR" == "cuda" || "$GPU_VENDOR" == "rocm" ]]; then
+                    if prompt_confirm "Also install the Vulkan SDK on the host? (provides a portable backend in addition to $GPU_VENDOR)"; then
+                        HOST_SDK_BACKENDS+=("vulkan")
+                    fi
+                fi
+            fi
+        fi
+        # Pick a primary for unit overrides: first non-vulkan backend.
+        for _b in "${HOST_SDK_BACKENDS[@]:-}"; do
+            if [[ "$_b" != "vulkan" ]]; then GPU_VENDOR="$_b"; break; fi
+        done
+        unset _b
 
         case "$command" in
             install)   host_install ;;

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,7 @@ COMPOSE_VERSION=""
 INSTALL_MODE="${INSTALL_MODE:-container}"  # host or container; default container preserves existing behavior
 HOST_INSTALL_MODE="${HOST_INSTALL_MODE:-package}"  # for --host: "package" (download released .deb/.rpm) or "source" (go build locally)
 HOST_SDK_BACKENDS=()    # backends to install host SDKs for (--cuda/--rocm/--vulkan); empty means autodetect+prompt
+MIGRATE_DIRECTION=""    # "to-host" or "to-container" when command=migrate
 
 DISTRO_ID=""            # debian, ubuntu, fedora, arch, cachyos, opensuse-leap, etc.
 DISTRO_NAME=""          # Pretty name from os-release
@@ -1238,6 +1239,8 @@ prompt_confirm() {
 source "${SCRIPT_DIR}/scripts/lib/service.sh"
 # shellcheck source=scripts/lib/host.sh
 source "${SCRIPT_DIR}/scripts/lib/host.sh"
+# shellcheck source=scripts/lib/migrate.sh
+source "${SCRIPT_DIR}/scripts/lib/migrate.sh"
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
@@ -1278,6 +1281,13 @@ install --host` to avoid hitting the GH API for the latest tag.
 Lifecycle:
   install     Detect, install prerequisites, build, and start
   uninstall   Stop and remove (container or host install)
+  migrate     Move state between container and host installs. Takes
+              one of --to-host / --to-container. Snapshots the
+              registry, brings up the destination, restores the
+              registry. Refuses if the destination side already
+              exists. builds.json is wiped — llama.cpp must be
+              rebuilt on the new side (binaries don't cross the
+              container/host boundary).
   quick       Container only: pull the latest released package and
               reinstall it inside the existing image. Reuses the GPU
               SDK / base-OS layers — only the package-install layer
@@ -1321,6 +1331,8 @@ Examples:
   ./setup.sh install --rocm --vulkan    # host install, install both ROCm and Vulkan SDKs
   ./setup.sh install --vulkan           # host install, Vulkan SDK only (cross-vendor)
   ./setup.sh install --from-source      # host install, build from local source
+  ./setup.sh migrate --to-host          # snapshot container state, install on host
+  ./setup.sh migrate --to-container     # opposite direction
   ./setup.sh status --host              # show host install status
   ./setup.sh uninstall --host           # remove host install
   ./setup.sh status                     # container dry run
@@ -1350,6 +1362,15 @@ main() {
             --cuda)         INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("cuda") ;;
             --rocm)         INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("rocm") ;;
             --vulkan)       INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("vulkan") ;;
+            # Direction flags for the `migrate` command. Mutually exclusive
+            # — passing both is an error. Each implies its target mode for
+            # the purpose of post-flag dispatch.
+            --to-host)
+                [[ -n "$MIGRATE_DIRECTION" ]] && { err "--to-host and --to-container are mutually exclusive"; exit 1; }
+                MIGRATE_DIRECTION="to-host" ;;
+            --to-container)
+                [[ -n "$MIGRATE_DIRECTION" ]] && { err "--to-host and --to-container are mutually exclusive"; exit 1; }
+                MIGRATE_DIRECTION="to-container" ;;
             -h|--help)      usage; exit 0 ;;
             *)
                 err "Unknown flag: $1"
@@ -1361,9 +1382,15 @@ main() {
         shift
     done
 
+    # ── Validate flag/command combinations ──
+    if [[ -n "$MIGRATE_DIRECTION" && "$command" != "migrate" ]]; then
+        err "--to-host / --to-container are only valid with the 'migrate' command"
+        exit 1
+    fi
+
     # ── Validate command ──
     case "$command" in
-        install|uninstall|up|down|rebuild|quick|logs|detect|status|enable|disable) ;;
+        install|uninstall|up|down|rebuild|quick|logs|detect|status|enable|disable|migrate) ;;
         -h|--help|help)
             usage
             exit 0
@@ -1375,6 +1402,48 @@ main() {
             exit 1
             ;;
     esac
+
+    # ── migrate: hybrid command, needs both container and host context ──
+    if [[ "$command" == "migrate" ]]; then
+        if [[ -z "$MIGRATE_DIRECTION" ]]; then
+            err "migrate requires --to-host or --to-container"
+            echo ""
+            usage
+            exit 1
+        fi
+        detect_distro
+        detect_container_runtime
+        if [[ -n "${GPU:-}" ]]; then
+            GPU_VENDOR="$GPU"
+            GPU_INFO="(manually set: $GPU)"
+        else
+            detect_gpu
+        fi
+        case "$MIGRATE_DIRECTION" in
+            to-host)
+                # Resolve SDK backends the same way `install --host` does:
+                # explicit flags win; otherwise auto-detect + prompt for vulkan.
+                if [[ ${#HOST_SDK_BACKENDS[@]} -eq 0 ]]; then
+                    HOST_SDK_BACKENDS=("$GPU_VENDOR")
+                    if [[ -z "${GPU:-}" ]] && [[ "$GPU_VENDOR" == "cuda" || "$GPU_VENDOR" == "rocm" ]]; then
+                        if prompt_confirm "Also install the Vulkan SDK on the host?"; then
+                            HOST_SDK_BACKENDS+=("vulkan")
+                        fi
+                    fi
+                fi
+                for _b in "${HOST_SDK_BACKENDS[@]:-}"; do
+                    if [[ "$_b" != "vulkan" ]]; then GPU_VENDOR="$_b"; break; fi
+                done
+                unset _b
+                migrate_to_host
+                ;;
+            to-container)
+                load_env_ports
+                migrate_to_container
+                ;;
+        esac
+        exit 0
+    fi
 
     # ── Host mode: short circuit before any container detection ──
     if [[ "$INSTALL_MODE" == "host" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -330,6 +330,100 @@ selinux_device_bool_set() {
     need_cmd getsebool && getsebool container_use_devices 2>/dev/null | grep -q "on"
 }
 
+# Container-mode dependency report. Verifies the prereqs needed to run
+# `setup.sh install` in container mode and prints remediation commands
+# for anything missing. Returns 0 if everything's present, 1 otherwise.
+container_deps() {
+    local rc=0
+    local inst_cmd
+    case "$DISTRO_FAMILY" in
+        debian) inst_cmd="sudo apt-get install -y" ;;
+        fedora) inst_cmd="sudo dnf install -y" ;;
+        arch)   inst_cmd="sudo pacman -S --needed" ;;
+        suse)   inst_cmd="sudo zypper install -y" ;;
+        *)      inst_cmd="<distro ${DISTRO_FAMILY:-unknown}>" ;;
+    esac
+
+    echo "Container install dependencies (distro: ${DISTRO_FAMILY:-unknown}, GPU: ${GPU_VENDOR:-unknown}):"
+    echo ""
+    echo "  Container runtime:"
+    if [[ -n "$CONTAINER_CMD" ]]; then
+        printf "    %-25s %s\n" "$CONTAINER_CMD" "OK ($CONTAINER_VERSION)"
+    else
+        printf "    %-25s %s\n" "docker or podman" "not installed"
+        case "$DISTRO_FAMILY" in
+            debian) echo "            $inst_cmd docker.io  (or follow https://docs.docker.com/engine/install/)" ;;
+            fedora) echo "            $inst_cmd podman      (or docker-ce from Docker's repo)" ;;
+            arch)   echo "            $inst_cmd docker      (or podman)" ;;
+            *)      echo "            install Docker or Podman from your distro" ;;
+        esac
+        rc=1
+    fi
+
+    if [[ -n "$COMPOSE_CMD" ]]; then
+        printf "    %-25s %s\n" "compose" "OK ($COMPOSE_VERSION)"
+    else
+        printf "    %-25s %s\n" "compose" "not installed"
+        case "$CONTAINER_CMD" in
+            docker) echo "            $inst_cmd docker-compose-plugin" ;;
+            podman) echo "            $inst_cmd podman-compose" ;;
+            *)      echo "            install docker-compose-plugin or podman-compose" ;;
+        esac
+        rc=1
+    fi
+    echo ""
+
+    # GPU-specific integration. Only flag what's relevant for this host.
+    if [[ "$GPU_VENDOR" == "cuda" ]]; then
+        echo "  NVIDIA GPU integration:"
+        if has_nvidia_toolkit; then
+            printf "    %-25s %s\n" "NVIDIA Container Toolkit" "OK"
+        else
+            printf "    %-25s %s\n" "NVIDIA Container Toolkit" "not installed"
+            echo "            ./setup.sh install   # this script auto-installs the toolkit"
+            rc=1
+        fi
+        if [[ "$CONTAINER_CMD" == "docker" ]]; then
+            if has_nvidia_toolkit && docker_has_nvidia_runtime; then
+                printf "    %-25s %s\n" "Docker NVIDIA runtime" "OK"
+            else
+                printf "    %-25s %s\n" "Docker NVIDIA runtime" "not configured"
+                echo "            sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker"
+                rc=1
+            fi
+        fi
+        if [[ "$CONTAINER_CMD" == "podman" ]]; then
+            if has_cdi_spec; then
+                printf "    %-25s %s\n" "Podman CDI spec" "OK"
+            else
+                printf "    %-25s %s\n" "Podman CDI spec" "missing"
+                echo "            sudo nvidia-ctk cdi generate --output=$CDI_SYSTEM_DIR/nvidia.yaml"
+                rc=1
+            fi
+        fi
+        echo ""
+    fi
+
+    if [[ "$GPU_VENDOR" == "rocm" && "$DISTRO_FAMILY" == "fedora" ]] && selinux_enforcing; then
+        echo "  SELinux (rocm on Fedora/RHEL):"
+        if selinux_device_bool_set; then
+            printf "    %-25s %s\n" "container_use_devices" "OK"
+        else
+            printf "    %-25s %s\n" "container_use_devices" "off"
+            echo "            sudo setsebool -P container_use_devices on"
+            rc=1
+        fi
+        echo ""
+    fi
+
+    if [[ $rc -eq 0 ]]; then
+        ok "All container dependencies satisfied."
+    else
+        warn "One or more dependencies are missing — see commands above."
+    fi
+    return $rc
+}
+
 check_prerequisites() {
     PREREQS=()
     ACTIONS=()
@@ -1307,7 +1401,14 @@ Auto-start (container only):
 
 Info:
   status      Show detected environment and planned actions, then exit
-              (works for both modes)
+              (works for both modes; --host adds backend SDK report)
+  deps        Verify all packages needed to build and run, with copy-
+              paste install commands for anything missing. --host
+              checks the host package, llama.cpp build toolchain
+              (cmake/ninja/git/gcc), and per-backend GPU SDKs (cuda/
+              rocm/vulkan). Without --host, checks container runtime,
+              compose, and GPU integration (NVIDIA toolkit / SELinux).
+              Exits non-zero if anything is missing.
   detect      Print detected GPU backend (cuda/rocm/cpu/vulkan/metal) and exit
   help        Show this help message
 
@@ -1390,7 +1491,7 @@ main() {
 
     # ── Validate command ──
     case "$command" in
-        install|uninstall|up|down|rebuild|quick|logs|detect|status|enable|disable|migrate) ;;
+        install|uninstall|up|down|rebuild|quick|logs|detect|status|enable|disable|migrate|deps) ;;
         -h|--help|help)
             usage
             exit 0
@@ -1490,6 +1591,7 @@ main() {
             install)   host_install ;;
             uninstall) host_uninstall ;;
             status)    host_status ;;
+            deps)      host_deps ;;
             detect)    echo "$GPU_VENDOR" ;;
             up|down|logs|enable|disable|rebuild|quick)
                 err "'$command' is not supported in --host mode."
@@ -1561,6 +1663,10 @@ main() {
             echo "  Web UI:     http://localhost:${LLAMA_TOOLCHEST_PORT}"
             echo ""
             exit 0
+            ;;
+        deps)
+            container_deps
+            exit $?
             ;;
     esac
 


### PR DESCRIPTION
Title: Host-install improvements: multi-backend SDKs, migrate, deps, and bugfixes
                                                                                                                                                                                            
  Body:
                                                                                                                                                                                            
  ## Summary                                                      

  Six commits packaged together — all touching the host-install path that                                                                                                                   
  landed in the previous release. Three features and three fixes.
                                                                                                                                                                                            
  ### Features                                                    
                                                                                                                                                                                            
  - **`feat(host): support multi-backend SDK installs (--cuda/--rocm/--vulkan)`**                                                                                                           
    Stack-able backend flags so a host install can install ROCm + Vulkan
    (or CUDA + Vulkan) in one run. Without flags, auto-detect the primary                                                                                                                   
    GPU and prompt about adding Vulkan as a portable fallback. Adds                                                                                                                         
    `vulkan-tools` to the Vulkan SDK list so the post-install backend                                                                                                                       
    probe can find `vulkaninfo`.                                                                                                                                                            
                                                                                                                                                                                            
  - **`feat: add migrate command for switching between container and host installs`**                                                                                                       
    `./setup.sh migrate --to-host` snapshots the container's registry,                                                                                                                      
    stops the container, runs `host_install`, and restores the registry                                                                                                                     
    on the host side (with config translation). Reverse direction does                                                                                                                      
    the opposite via an alpine sidecar against the volume. Refuses if the                                                                                                                   
    destination is already populated. `builds.json` is wiped — the binary                                                                                                                   
    doesn't cross the container/host boundary.                                                                                                                                              
                                                                                                                                                                                            
  - **`feat: add deps command and SDK section in status --host`**                                                                                                                           
    `./setup.sh deps [--host]` verifies all packages needed to build
    and run, with copy-paste install commands for anything missing. In                                                                                                                      
    host mode covers the package, build toolchain (cmake/ninja/git/gcc),                                                                                                                    
    and per-backend GPU SDKs (cuda/rocm/vulkan), filtering by which                                                                                                                         
    hardware is actually present. `status --host` gains the same SDK                                                                                                                        
    report.                                                                                                                                                                                 
                                                                                                                                                                                            
  ### Fixes                                                                                                                                                                                 
                                                                  
  - **`fix(host): use glslc package on Debian instead of glslang-tools`**                                                                                                                   
    CMake's `find_package(Vulkan)` looks for `glslc` (Google's shaderc
    frontend), not `glslangValidator` (which is what glslang-tools ships).                                                                                                                  
    llama.cpp's Vulkan build was failing on Debian with `Could NOT find                                                                                                                     
    Vulkan (missing: glslc)`.                                                                                                                                                               
                                                                                                                                                                                            
    Upstream llama.cpp removed the legacy mode-agnostic `--draft-max` /                                                                                                                     
    `--draft-min` / `--spec-ngram-size-n/m` flags and replaced them with                                                                                                                    
    mode-prefixed variants. Translate `DraftMax` / `DraftMin` /                                                                                                                             
    `DraftPMin` / `NgramSizeN` / `NgramSizeM` at INI/CLI emission time                                                                                                                      
    based on `cfg.SpecType` (`spec-draft-*`, `spec-ngram-mod-*`,                                                                                                                            
    `spec-ngram-{simple,map-k,map-k4v}-*`).                                                                                                                                                 
                                                                                                                                                                                            
  - **`fix(migrate): translate mmproj_path/draft_model_path across the boundary`**                                                                                                          
    The post-migration scanner refreshes `.models[*].file_path` but                                                                                                                         
    doesn't touch the per-config `.configs[*].mmproj_path` /                                                                                                                                
    `draft_model_path`. After a container-era migration, vision models                                                                                                                      
    failed at load with `failed to load multimodal model,                                                                                                                                   
    '/data/models/.../mmproj-F16.gguf'`. Add a jq-based path rewrite                                                                                                                        
    that runs after registry restore in both directions.                                                                                                                                    
                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                              
                                                                                                                                                                                            
  - [x] `bash -n` clean on `setup.sh`, `host.sh`, `migrate.sh`                                                                                                                              
  - [x] `go build` clean (speculative-decoding refactor)          
  - [x] `./setup.sh deps --host` shows correct per-backend status,                                                                                                                          
        filters out non-applicable backends (no cuda on AMD-only hosts),                                                                                                                    
        emits exit-1 + install command for any missing                                                                                                                                      
  - [x] `./setup.sh deps` (container) shows runtime + compose status                                                                                                                        
  - [x] `./setup.sh migrate --to-host` and `--to-container` correctly                                                                                                                       
        refuse when destination side is populated                                                                                                                                           
  - [x] `--to-host`/`--to-container` outside `migrate` rejected                                                                                                                             
  - [x] Both flags together rejected                                                                                                                                                        
  - [x] Migration on this developer machine completed end-to-end with                                                                                                                       
        registry preserved (after applying the path-translate fix)                                                                                                                          
  - [x] After patching `mmproj_path` translations, Qwen3.6-27B with                                                                                                                         
        vision loads against the host's `/home/tim/llama/...mmproj-F16.gguf`                                                                                                                
                                                                                                                                                                                            
  Tested on Debian trixie, AMD Radeon AI PRO R9700 (gfx1201), ROCm 7.2.3.                                                                                                                   
                                                                                     