### PR TITLE
Batch benchmark jobs

### DIFF
--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -96,9 +96,14 @@ func filterRunsByJob(runs []benchmark.BenchmarkRun, jobID string) []benchmark.Be
 
 // renderBenchmarkList emits the grouped, searchable benchmarks table.
 // Groups by ModelName; each group is collapsed by default. The wrapping
-// JS in benchmarks.html drives toggle/filter using data-model and
-// data-search attributes — same pattern as the models page.
+// JS in benchmarks.html drives toggle/filter/compare/export/delete using
+// data-model and data-search attributes plus the .bench-runs-container
+// scope so the same renderer can serve multiple list contexts (today
+// just the adhoc job's expanded view; tomorrow per-job filtered views).
 func (s *Server) renderBenchmarkList(w http.ResponseWriter, runs []benchmark.BenchmarkRun) {
+	w.Write([]byte(`<div class="bench-runs-container">`))
+	defer w.Write([]byte(`</div>`))
+
 	if len(runs) == 0 {
 		w.Write([]byte("<p>No benchmarks yet. Run one above to get started.</p>"))
 		return
@@ -126,9 +131,12 @@ func (s *Server) renderBenchmarkList(w http.ResponseWriter, runs []benchmark.Ben
 	sort.Slice(names, func(i, j int) bool { return strings.ToLower(names[i]) < strings.ToLower(names[j]) })
 
 	w.Write([]byte(`<div class="model-list-controls">
-		<input type="search" class="model-filter" placeholder="Filter by model, quant, build, preset…" oninput="filterBenchmarks(this.value)" autocomplete="off">
-		<button type="button" class="outline secondary" onclick="collapseAllBenchGroups()">Collapse All</button>
-		<button type="button" class="outline secondary" onclick="expandAllBenchGroups()">Expand All</button>
+		<input type="search" class="model-filter" placeholder="Filter by model, quant, build, preset…" oninput="filterBenchmarks(this, this.value)" autocomplete="off">
+		<button type="button" class="outline secondary" onclick="collapseAllBenchGroups(this)">Collapse All</button>
+		<button type="button" class="outline secondary" onclick="expandAllBenchGroups(this)">Expand All</button>
+		<button type="button" class="outline secondary" onclick="compareSelectedRuns(this)">Compare</button>
+		<button type="button" class="outline secondary" onclick="exportSelectedRuns(this)">Export CSV</button>
+		<button type="button" class="outline secondary" onclick="deleteSelectedRuns(this)">Delete Selected</button>
 	</div>`))
 
 	w.Write([]byte(`<table role="grid">

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -98,6 +98,9 @@ func (s *Server) renderBenchmarkList(w http.ResponseWriter, runs []benchmark.Ben
 			if run.LlamaBench != nil {
 				benchTag = ` <mark style="padding:0 0.3rem;font-size:0.75rem;">bench</mark>`
 			}
+			if len(run.LlamaBenchy) > 0 {
+				benchTag += ` <mark style="padding:0 0.3rem;font-size:0.75rem;background:var(--pico-primary-background);color:var(--pico-primary-inverse);">benchy</mark>`
+			}
 			runningTitle := ""
 			if run.Status == "running" {
 				runningTitle = `title="Running — select to delete anyway"`
@@ -260,6 +263,7 @@ func (s *Server) handleStartBenchmark(w http.ResponseWriter, r *http.Request) {
 		RouterURL:  fmt.Sprintf("http://localhost:%d", s.cfg.LlamaPort),
 		RouterName: routerName,
 		BinaryDir:  activeBuild.BinaryPath,
+		HFRepoID:   model.ModelID,
 	}
 	// BinaryDir should be the directory, not the binary itself
 	if strings.HasSuffix(runCfg.BinaryDir, "/llama-server") {

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -244,6 +244,16 @@ func (s *Server) handleStartBenchmark(w http.ResponseWriter, r *http.Request) {
 		BuildID:      activeBuild.ID,
 		BuildRef:     activeBuild.GitRef,
 		BuildProfile: activeBuild.Profile,
+		Build: benchmark.BuildSnapshot{
+			ID:         activeBuild.ID,
+			Tag:        activeBuild.Tag,
+			Profile:    activeBuild.Profile,
+			Vendor:     activeBuild.Profile,
+			GitSHA:     activeBuild.GitSHA,
+			GitRef:     activeBuild.GitRef,
+			CMakeFlags: activeBuild.CMakeFlags,
+			BinaryPath: activeBuild.BinaryPath,
+		},
 
 		GPUs: benchmark.GPUSnapshotsFromMetrics(metrics),
 

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"context"
+	"errors"
 	"fmt"
 	"html"
 	"log/slog"
@@ -229,7 +229,10 @@ func (s *Server) handleGetBenchmark(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, run)
 }
 
-// handleStartBenchmark starts a new benchmark run.
+// handleStartBenchmark is the Quick Benchmark entry point: it builds a
+// 1-cell job from a (model, preset) pair and submits it to the JobQueue,
+// using the currently-active build. Equivalent to the new-job form with
+// {ModelIDs:[modelID], BuildIDs:[active], Presets:[preset]}.
 func (s *Server) handleStartBenchmark(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 	modelID := r.FormValue("model_id")
@@ -245,126 +248,58 @@ func (s *Server) handleStartBenchmark(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	cfg, err := s.registry.GetConfig(modelID)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
 
 	if !s.process.IsRunning() {
 		http.Error(w, "router is not running — start the server first", http.StatusBadRequest)
 		return
 	}
 
-	preset := benchmark.GetPreset(presetName)
-	metrics := s.monitor.Current()
-
-	// Find active build info. Explicit selection wins; otherwise fall back
-	// to the successful build with the newest GitRef.
-	var activeBuild builder.BuildResult
-	if s.cfg.ActiveBuild != "" {
-		for _, b := range s.builder.List() {
-			if b.ID == s.cfg.ActiveBuild && b.Status == builder.BuildStatusSuccess {
-				activeBuild = b
-				break
-			}
-		}
-	}
-	if activeBuild.ID == "" {
+	// Resolve active build the same way startRouter does.
+	buildID := s.cfg.ActiveBuild
+	if buildID == "" {
 		if b := s.builder.LatestSuccessfulBuild(); b != nil {
-			activeBuild = *b
+			buildID = b.ID
 		}
 	}
-
-	// Short model name for display
-	modelName := model.ModelID
-	if idx := strings.LastIndex(modelName, "/"); idx >= 0 {
-		modelName = modelName[idx+1:]
-	}
-	modelName = strings.TrimSuffix(modelName, "-GGUF")
-	modelName = strings.TrimSuffix(modelName, "-gguf")
-
-	run := benchmark.BenchmarkRun{
-		ID:        fmt.Sprintf("bench-%d", time.Now().UnixMilli()),
-		CreatedAt: time.Now(),
-		Status:    benchmark.StatusRunning,
-
-		ModelID:   modelID,
-		ModelName: modelName,
-		Quant:     model.Quant,
-		SizeGB:    models.BytesToGB(model.SizeBytes),
-
-		Config: benchmark.ConfigSnapshot{
-			GPULayers:      cfg.GPULayers,
-			ContextSize:    cfg.ContextSize,
-			GPUAssign:      cfg.GPUAssign,
-			TensorSplit:    cfg.TensorSplit,
-			FlashAttention: cfg.FlashAttention,
-			KVCacheQuant:   cfg.KVCacheQuant,
-			DirectIO:       cfg.DirectIO,
-			Threads:        cfg.Threads,
-			SpecType:       cfg.SpecType,
-		},
-
-		BuildID:      activeBuild.ID,
-		BuildRef:     activeBuild.GitRef,
-		BuildProfile: activeBuild.Profile,
-		Build: benchmark.BuildSnapshot{
-			ID:         activeBuild.ID,
-			Tag:        activeBuild.Tag,
-			Profile:    activeBuild.Profile,
-			Vendor:     activeBuild.Profile,
-			GitSHA:     activeBuild.GitSHA,
-			GitRef:     activeBuild.GitRef,
-			CMakeFlags: activeBuild.CMakeFlags,
-			BinaryPath: activeBuild.BinaryPath,
-		},
-
-		GPUs: benchmark.GPUSnapshotsFromMetrics(metrics),
-
-		Preset:       preset.Name,
-		PromptTokens: preset.PromptTokens,
-		GenTokens:    preset.GenTokens,
-	}
-
-	s.bench.Save(run)
-
-	// Build runner config
-	routerName := s.registry.RouterName(modelID)
-	runCfg := benchmark.RunConfig{
-		Run:        run,
-		Preset:     preset,
-		RouterURL:  fmt.Sprintf("http://localhost:%d", s.cfg.LlamaPort),
-		RouterName: routerName,
-		HFRepoID:   model.ModelID,
-	}
-
-	// Start benchmark in background
-	progressCh := make(chan benchmark.ProgressUpdate, 16)
-	s.benchProgressMu.Lock()
-	s.benchProgress[run.ID] = progressCh
-	s.benchProgressMu.Unlock()
-
-	runner := benchmark.NewRunner(s.bench)
-	go func() {
-		runner.Run(context.Background(), runCfg, progressCh)
-		// Clean up progress channel after completion
-		s.benchProgressMu.Lock()
-		delete(s.benchProgress, run.ID)
-		s.benchProgressMu.Unlock()
-	}()
-
-	if isHTMX(r) {
-		respondHTML(w)
-		// Return just the initial text content. The HX-Trigger-After-Swap
-		// header tells the page JS to start polling.
-		w.Header().Set("HX-Trigger-After-Swap", fmt.Sprintf(
-			`{"benchmarkStarted":{"id":%q}}`, run.ID))
-		fmt.Fprint(w, "&#x23F3; Benchmark starting...")
+	if buildID == "" {
+		http.Error(w, "no compiled build available — build llama.cpp first", http.StatusBadRequest)
 		return
 	}
 
-	respondJSON(w, run)
+	preset := benchmark.GetPreset(presetName)
+
+	jobName := fmt.Sprintf("Quick: %s / %s", shortenModelName(model.ModelID), preset.Name)
+	job := benchmark.BenchmarkJob{
+		ID:        newJobID(),
+		Name:      jobName,
+		Kind:      benchmark.JobKindBatch,
+		Status:    benchmark.JobStatusPending,
+		CreatedAt: time.Now(),
+		ModelIDs:  []string{modelID},
+		BuildIDs:  []string{buildID},
+		Presets:   []string{preset.Name},
+		Cells:     benchmark.ExpandCells([]string{modelID}, []string{buildID}, []string{preset.Name}),
+	}
+
+	if err := s.jobs.Submit(job); err != nil {
+		if errors.Is(err, benchmark.ErrJobAlreadyRunning) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if isHTMX(r) {
+		respondHTML(w)
+		// Tell the jobs list to refresh so the user sees the new job
+		// appear; the response body itself is just a brief confirmation.
+		w.Header().Set("HX-Trigger", "jobChanged")
+		fmt.Fprintf(w, `<small style="color:var(--pico-muted-color);">Started: %s</small>`, html.EscapeString(jobName))
+		return
+	}
+
+	respondJSON(w, job)
 }
 
 // handleDeleteBenchmark removes a benchmark run.
@@ -473,31 +408,6 @@ func (s *Server) handleExportBenchmarks(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-// handleBenchmarkProgress returns the current state of a running benchmark.
-// Called by HTMX polling from the progress partial.
-func (s *Server) handleBenchmarkProgress(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-
-	run, err := s.bench.Get(id)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
-
-	if isHTMX(r) {
-		respondHTML(w)
-		s.renderPartial(w, "benchmark_progress", struct {
-			ID     string
-			Status string
-			Detail string
-			Error  string
-		}{ID: run.ID, Status: run.Status, Detail: run.ProgressDetail, Error: run.Error})
-		return
-	}
-
-	respondJSON(w, run)
-}
-
 // handleCompareBenchmarks returns comparison data for selected runs.
 func (s *Server) handleCompareBenchmarks(w http.ResponseWriter, r *http.Request) {
 	idsParam := r.URL.Query().Get("ids")
@@ -560,31 +470,15 @@ func (s *Server) handleBenchmarkForm(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// If a benchmark is currently running, surface its ID so the page
-	// can reattach the progress UI when the user navigates back to
-	// this tab. The runner uses the most-recent run, so pick the
-	// newest by CreatedAt.
-	var activeID string
-	var activeAt time.Time
-	for _, run := range s.bench.List() {
-		if run.Status == benchmark.StatusRunning && run.CreatedAt.After(activeAt) {
-			activeID = run.ID
-			activeAt = run.CreatedAt
-		}
-	}
-
-	data := struct {
-		Models   []*models.Model
-		Presets  []benchmark.Preset
-		Running  bool
-		ActiveID string
+	s.renderPartial(w, "benchmark_form", struct {
+		Models  []*models.Model
+		Presets []benchmark.Preset
+		Running bool
 	}{
-		Models:   enabledModels,
-		Presets:  benchmark.Presets(),
-		Running:  s.process.IsRunning(),
-		ActiveID: activeID,
-	}
-	s.renderPartial(w, "benchmark_form", data)
+		Models:  enabledModels,
+		Presets: benchmark.Presets(),
+		Running: s.process.IsRunning(),
+	})
 }
 
 // captureTimings is called by the proxy to record passive timing data.

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -41,9 +41,39 @@ func builderResolver(b *builder.Builder) benchmark.BuildResolver {
 	}
 }
 
-// handleListBenchmarks returns all benchmark runs.
+// handleListBenchmarks returns benchmark runs, optionally filtered:
+//   - ?job=<id>          returns only runs belonging to that job
+//   - ?scope=adhoc       returns only runs in the synthetic adhoc job
+//   - ?scope=batch       returns only runs belonging to a real batch job
 func (s *Server) handleListBenchmarks(w http.ResponseWriter, r *http.Request) {
 	runs := s.bench.List()
+
+	if jobID := r.URL.Query().Get("job"); jobID != "" {
+		runs = filterRunsByJob(runs, jobID)
+	}
+	if scope := r.URL.Query().Get("scope"); scope != "" {
+		switch scope {
+		case "adhoc":
+			runs = filterRunsByJob(runs, benchmark.AdhocJobID)
+		case "batch":
+			batchJobIDs := map[string]bool{}
+			for _, j := range s.bench.ListJobs() {
+				if j.ID != benchmark.AdhocJobID {
+					batchJobIDs[j.ID] = true
+				}
+			}
+			filtered := runs[:0]
+			for _, run := range runs {
+				if batchJobIDs[run.JobID] {
+					filtered = append(filtered, run)
+				}
+			}
+			runs = filtered
+		default:
+			http.Error(w, "scope must be 'adhoc' or 'batch'", http.StatusBadRequest)
+			return
+		}
+	}
 
 	if isHTMX(r) {
 		respondHTML(w)
@@ -52,6 +82,16 @@ func (s *Server) handleListBenchmarks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respondJSON(w, runs)
+}
+
+func filterRunsByJob(runs []benchmark.BenchmarkRun, jobID string) []benchmark.BenchmarkRun {
+	out := runs[:0]
+	for _, r := range runs {
+		if r.JobID == jobID {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // renderBenchmarkList emits the grouped, searchable benchmarks table.

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -16,6 +16,31 @@ import (
 	"github.com/tmlabonte/llamactl/internal/models"
 )
 
+// builderResolver adapts the builder's List() into a benchmark.BuildResolver
+// closure so the benchmark package can backfill Build snapshots without
+// importing builder. Returns the zero value when the build is no longer
+// known, which the migration treats as "fall back to the legacy flat
+// fields."
+func builderResolver(b *builder.Builder) benchmark.BuildResolver {
+	return func(buildID string) benchmark.BuildSnapshot {
+		for _, br := range b.List() {
+			if br.ID == buildID {
+				return benchmark.BuildSnapshot{
+					ID:         br.ID,
+					Tag:        br.Tag,
+					Profile:    br.Profile,
+					Vendor:     br.Profile,
+					GitSHA:     br.GitSHA,
+					GitRef:     br.GitRef,
+					CMakeFlags: br.CMakeFlags,
+					BinaryPath: br.BinaryPath,
+				}
+			}
+		}
+		return benchmark.BuildSnapshot{}
+	}
+}
+
 // handleListBenchmarks returns all benchmark runs.
 func (s *Server) handleListBenchmarks(w http.ResponseWriter, r *http.Request) {
 	runs := s.bench.List()

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -259,15 +259,9 @@ func (s *Server) handleStartBenchmark(w http.ResponseWriter, r *http.Request) {
 	runCfg := benchmark.RunConfig{
 		Run:        run,
 		Preset:     preset,
-		ModelPath:  model.FilePath,
 		RouterURL:  fmt.Sprintf("http://localhost:%d", s.cfg.LlamaPort),
 		RouterName: routerName,
-		BinaryDir:  activeBuild.BinaryPath,
 		HFRepoID:   model.ModelID,
-	}
-	// BinaryDir should be the directory, not the binary itself
-	if strings.HasSuffix(runCfg.BinaryDir, "/llama-server") {
-		runCfg.BinaryDir = runCfg.BinaryDir[:len(runCfg.BinaryDir)-len("/llama-server")]
 	}
 
 	// Start benchmark in background

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -135,7 +135,8 @@ func (s *Server) renderBenchmarkList(w http.ResponseWriter, runs []benchmark.Ben
 		<button type="button" class="outline secondary" onclick="collapseAllBenchGroups(this)">Collapse All</button>
 		<button type="button" class="outline secondary" onclick="expandAllBenchGroups(this)">Expand All</button>
 		<button type="button" class="outline secondary" onclick="compareSelectedRuns(this)">Compare</button>
-		<button type="button" class="outline secondary" onclick="exportSelectedRuns(this)">Export CSV</button>
+		<button type="button" class="outline secondary" onclick="exportSelectedRuns(this, 'csv')">Export CSV</button>
+		<button type="button" class="outline secondary" onclick="exportSelectedRuns(this, 'json')">Export JSON</button>
 		<button type="button" class="outline secondary" onclick="deleteSelectedRuns(this)">Delete Selected</button>
 	</div>`))
 
@@ -341,78 +342,58 @@ func (s *Server) handleBatchDeleteBenchmarks(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleExportBenchmarks exports selected benchmark runs as CSV.
+// handleExportBenchmarks exports an arbitrary selection of runs in
+// either CSV (cells or summary scope) or JSON. Routes through the
+// shared exporter so the column schema matches /api/benchmark-jobs/{id}/export.
 func (s *Server) handleExportBenchmarks(w http.ResponseWriter, r *http.Request) {
 	idsParam := r.URL.Query().Get("ids")
 	if idsParam == "" {
 		http.Error(w, "ids parameter required", http.StatusBadRequest)
 		return
 	}
+	format, err := parseExportFormat(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	scope, err := parseExportScope(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	var runs []benchmark.BenchmarkRun
+	jobIDs := map[string]struct{}{}
 	for _, id := range strings.Split(idsParam, ",") {
 		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
 		if run, err := s.bench.Get(id); err == nil {
 			runs = append(runs, *run)
+			if run.JobID != "" {
+				jobIDs[run.JobID] = struct{}{}
+			}
 		}
 	}
 
-	w.Header().Set("Content-Type", "text/csv")
-	w.Header().Set("Content-Disposition", "attachment; filename=benchmarks.csv")
-
-	// Header — one row per test point, with run metadata repeated
-	fmt.Fprintln(w, "Model,Quant,Size (GB),Preset,Row Type,Prompt Tokens,Gen Tokens,Rep,PP t/s,TG t/s,TTFT (ms),Total (ms),GPU Layers,Context,GPU Assign,Tensor Split,Flash Attn,KV Quant,Direct IO,Threads,Spec Type,Build,Build Ref,GPUs,Date")
-
-	for _, run := range runs {
-		gpuNames := ""
-		for i, g := range run.GPUs {
-			if i > 0 {
-				gpuNames += "; "
-			}
-			gpuNames += g.Name
+	jobs := make([]*benchmark.BenchmarkJob, 0, len(jobIDs))
+	for jid := range jobIDs {
+		if j, err := s.bench.GetJob(jid); err == nil {
+			jobs = append(jobs, j)
 		}
+	}
+	jobLU := newJobLookup(jobs)
 
-		common := fmt.Sprintf("%s,%s,%.1f,%s",
-			run.ModelName, run.Quant, run.SizeGB, run.Preset)
-		config := fmt.Sprintf("%d,%d,%s,%s,%t,%s,%t,%d,%s,%s,%s,\"%s\",%s",
-			run.Config.GPULayers,
-			run.Config.ContextSize,
-			run.Config.GPUAssign,
-			run.Config.TensorSplit,
-			run.Config.FlashAttention,
-			run.Config.KVCacheQuant,
-			run.Config.DirectIO,
-			run.Config.Threads,
-			run.Config.SpecType,
-			run.BuildID,
-			run.BuildRef,
-			gpuNames,
-			run.CreatedAt.Format("2006-01-02 15:04"))
-
-		// Individual test results
-		for _, r := range run.Results {
-			fmt.Fprintf(w, "%s,api,%d,%d,%d,%.0f,%.1f,%.0f,%.0f,%s\n",
-				common, r.PromptTokens, r.GenTokens, r.Repetition,
-				r.PromptTokPerSec, r.GenTokPerSec, r.TTFTMs, r.TotalMs,
-				config)
-		}
-
-		// Summary row
-		if run.Summary != nil {
-			fmt.Fprintf(w, "%s,api-avg,,,,%.0f,%.1f,%.0f,,%s\n",
-				common,
-				run.Summary.AvgPromptTokPerSec, run.Summary.AvgGenTokPerSec, run.Summary.AvgTTFTMs,
-				config)
-		}
-
-		// llama-bench results
-		if run.LlamaBench != nil {
-			fmt.Fprintf(w, "%s,llama-bench,%d,%d,%d,%.0f,%.1f,,,%s\n",
-				common,
-				run.LlamaBench.PromptTokens, run.LlamaBench.GenTokens, run.LlamaBench.Repetitions,
-				run.LlamaBench.PromptTokPerSec, run.LlamaBench.GenTokPerSec,
-				config)
-		}
+	switch format {
+	case exportFormatJSON:
+		_ = writeJSONExport(w, "benchmarks.json", ExportEnvelope{
+			Version: exportEnvelopeVersion,
+			Jobs:    jobs,
+			Runs:    runs,
+		})
+	default:
+		_ = writeCSVExport(w, fmt.Sprintf("benchmarks-%s.csv", scope), runs, jobLU, scope)
 	}
 }
 

--- a/internal/api/bench_about.go
+++ b/internal/api/bench_about.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/tmlabonte/llamactl/internal/benchmark"
+)
+
+// AboutBenchmarks is the JSON shape for /api/benchmarks/about. The HTMX
+// branch renders the same data through templates/partials/bench_about.html.
+type AboutBenchmarks struct {
+	InternalPrompt struct {
+		Text             string `json:"text"`
+		RepetitionPrefix string `json:"repetition_prefix"`
+		CharsPerToken    int    `json:"chars_per_token"`
+	} `json:"internal_prompt"`
+	Presets        []benchmark.Preset `json:"presets"`
+	BenchyCommands []BenchyCommandExample `json:"benchy_commands,omitempty"`
+}
+
+// BenchyCommandExample is the exact uvx invocation we'd run for one of
+// the benchy-* presets. Placeholder values mark the per-cell variables
+// (router URL, served model name, HuggingFace tokenizer id) so the
+// modal can show the shape of the command without committing to a
+// specific model.
+type BenchyCommandExample struct {
+	PresetName string `json:"preset_name"`
+	Command    string `json:"command"`
+}
+
+// handleBenchmarksAbout returns the disclosure data the "About benchmarks"
+// modal needs: the internal prompt prose, per-rep prefix template, the
+// live preset table, and an example uvx llama-benchy command per benchy
+// preset. HTMX requests get the rendered partial; JSON callers get the
+// raw struct.
+func (s *Server) handleBenchmarksAbout(w http.ResponseWriter, r *http.Request) {
+	about := AboutBenchmarks{
+		Presets: benchmark.Presets(),
+	}
+	about.InternalPrompt.Text = benchmark.BenchPromptText
+	about.InternalPrompt.RepetitionPrefix = benchmark.BenchPromptPrefixTemplate
+	about.InternalPrompt.CharsPerToken = benchmark.BenchPromptCharsPerToken
+
+	for _, p := range about.Presets {
+		if p.EffectiveSource() != benchmark.PresetSourceBenchy {
+			continue
+		}
+		conc := p.Concurrency
+		if len(conc) == 0 {
+			conc = []int{1}
+		}
+		cmd := benchmark.FormatBenchyCommand(benchmark.BenchyConfig{
+			BaseURL:         "http://127.0.0.1:{routerPort}/v1",
+			APIKey:          "EMPTY",
+			ServedModelName: "{router-served-model-name}",
+			Tokenizer:       "{hf-repo-id}",
+			PromptSizes:     p.PromptTokens,
+			GenSizes:        []int{p.GenTokens},
+			Runs:            p.Repetitions,
+			Concurrency:     conc,
+			SaveResultPath:  "{tmpfile.json}",
+		})
+		about.BenchyCommands = append(about.BenchyCommands, BenchyCommandExample{
+			PresetName: p.Name,
+			Command:    cmd,
+		})
+	}
+
+	if isHTMX(r) {
+		respondHTML(w)
+		s.renderPartial(w, "bench_about", about)
+		return
+	}
+	respondJSON(w, about)
+}

--- a/internal/api/bench_export.go
+++ b/internal/api/bench_export.go
@@ -1,0 +1,251 @@
+package api
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/tmlabonte/llamactl/internal/benchmark"
+)
+
+// ExportEnvelope is the on-disk JSON shape for both per-job and
+// per-selection exports. Always includes a `version` so we can grow
+// the shape without breaking re-importers.
+//
+//   - Per-job exports: Jobs has one entry (the requested job), Runs
+//     contains every run belonging to it.
+//   - Per-selection exports: Jobs is the unique set of jobs the runs
+//     belong to (lookup by id), Runs is the user's exact selection.
+type ExportEnvelope struct {
+	Version int                       `json:"version"`
+	Jobs    []*benchmark.BenchmarkJob `json:"jobs,omitempty"`
+	Runs    []benchmark.BenchmarkRun  `json:"runs"`
+}
+
+const exportEnvelopeVersion = 1
+
+const (
+	exportFormatCSV  = "csv"
+	exportFormatJSON = "json"
+	exportScopeCells = "cells"
+	exportScopeSum   = "summary"
+)
+
+// jobByID looks up a job pointer in a slice without scanning twice.
+type jobLookup map[string]*benchmark.BenchmarkJob
+
+func newJobLookup(jobs []*benchmark.BenchmarkJob) jobLookup {
+	m := make(jobLookup, len(jobs))
+	for _, j := range jobs {
+		m[j.ID] = j
+	}
+	return m
+}
+
+// writeJSONExport serializes the envelope with stable indentation.
+func writeJSONExport(w http.ResponseWriter, filename string, env ExportEnvelope) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, filename))
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(env)
+}
+
+// writeCSVExport writes either per-cell rows (one per result) or per-cell
+// summary rows (one per run), with full job/build/preset/source context
+// per the column schema in plan/batch-benchmarks.md.
+func writeCSVExport(w http.ResponseWriter, filename string, runs []benchmark.BenchmarkRun, jobs jobLookup, scope string) error {
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, filename))
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+
+	switch scope {
+	case exportScopeSum:
+		return writeCSVSummary(cw, runs, jobs)
+	case exportScopeCells, "":
+		return writeCSVCells(cw, runs, jobs)
+	default:
+		return fmt.Errorf("unknown scope %q (want cells or summary)", scope)
+	}
+}
+
+func writeCSVCells(cw *csv.Writer, runs []benchmark.BenchmarkRun, jobs jobLookup) error {
+	header := []string{
+		"job_id", "job_name", "run_id", "created_at",
+		"model_id", "model_name", "quant",
+		"build_id", "build_profile", "git_ref",
+		"preset", "source",
+		"prompt_tokens", "gen_tokens", "depth", "concurrency", "repetition",
+		"pp_throughput", "pp_throughput_std",
+		"tg_throughput", "tg_throughput_std",
+		"peak_throughput", "peak_throughput_std",
+		"ttft_ms", "ttfr_ms", "e2e_ttft_ms", "total_ms",
+	}
+	if err := cw.Write(header); err != nil {
+		return err
+	}
+
+	for _, run := range runs {
+		jobName := ""
+		if j := jobs[run.JobID]; j != nil {
+			jobName = j.Name
+		}
+		build := run.EffectiveBuild()
+		base := []string{
+			run.JobID, jobName, run.ID, run.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			run.ModelID, run.ModelName, run.Quant,
+			build.ID, build.Profile, build.GitRef,
+			run.Preset,
+		}
+
+		if len(run.Results) > 0 {
+			for _, r := range run.Results {
+				row := append([]string(nil), base...)
+				row = append(row,
+					"internal",
+					itoa(r.PromptTokens), itoa(r.GenTokens), "", "1", itoa(r.Repetition),
+					ftoa(r.PromptTokPerSec), "",
+					ftoa(r.GenTokPerSec), "",
+					"", "",
+					ftoa(r.TTFTMs), "", "", ftoa(r.TotalMs),
+				)
+				if err := cw.Write(row); err != nil {
+					return err
+				}
+			}
+		}
+
+		for _, b := range run.LlamaBenchy {
+			row := append([]string(nil), base...)
+			row = append(row,
+				"benchy",
+				itoa(b.PromptSize), itoa(b.ResponseSize), itoa(b.ContextSize), itoa(b.Concurrency), "",
+				metricMean(b.PPThroughput), metricStd(b.PPThroughput),
+				metricMean(b.TGThroughput), metricStd(b.TGThroughput),
+				metricMean(b.PeakThroughput), metricStd(b.PeakThroughput),
+				"", metricMean(b.TTFR), metricMean(b.E2ETTFT), "",
+			)
+			if err := cw.Write(row); err != nil {
+				return err
+			}
+		}
+
+		// If a run has neither internal results nor benchy results
+		// (e.g. failed before producing any), emit a single
+		// header-only row so the run still shows up in the export.
+		if len(run.Results) == 0 && len(run.LlamaBenchy) == 0 {
+			row := append([]string(nil), base...)
+			source := "internal"
+			if run.BenchyCommand != "" {
+				source = "benchy"
+			}
+			row = append(row, source, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "")
+			if err := cw.Write(row); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeCSVSummary(cw *csv.Writer, runs []benchmark.BenchmarkRun, jobs jobLookup) error {
+	header := []string{
+		"job_id", "job_name", "run_id", "created_at",
+		"model_id", "model_name", "quant",
+		"build_id", "build_profile", "git_ref",
+		"preset", "source", "status",
+		"avg_pp_throughput", "avg_tg_throughput", "avg_ttft_ms",
+		"min_tg_throughput", "max_tg_throughput",
+		"result_count", "duration_ms",
+	}
+	if err := cw.Write(header); err != nil {
+		return err
+	}
+	for _, run := range runs {
+		jobName := ""
+		if j := jobs[run.JobID]; j != nil {
+			jobName = j.Name
+		}
+		build := run.EffectiveBuild()
+		source := "internal"
+		if len(run.LlamaBenchy) > 0 || run.BenchyCommand != "" {
+			source = "benchy"
+		}
+		count := len(run.Results) + len(run.LlamaBenchy)
+
+		var avgPP, avgTG, avgTTFT, minTG, maxTG string
+		if run.Summary != nil {
+			avgPP = ftoa(run.Summary.AvgPromptTokPerSec)
+			avgTG = ftoa(run.Summary.AvgGenTokPerSec)
+			avgTTFT = ftoa(run.Summary.AvgTTFTMs)
+			minTG = ftoa(run.Summary.MinGenTokPerSec)
+			maxTG = ftoa(run.Summary.MaxGenTokPerSec)
+		}
+
+		row := []string{
+			run.JobID, jobName, run.ID, run.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			run.ModelID, run.ModelName, run.Quant,
+			build.ID, build.Profile, build.GitRef,
+			run.Preset, source, run.Status,
+			avgPP, avgTG, avgTTFT,
+			minTG, maxTG,
+			itoa(count), strconv.FormatInt(run.DurationMs, 10),
+		}
+		if err := cw.Write(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+func ftoa(f float64) string {
+	if f == 0 {
+		return "0"
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+func metricMean(m *benchmark.LlamaBenchyMetric) string {
+	if m == nil {
+		return ""
+	}
+	return ftoa(m.Mean)
+}
+func metricStd(m *benchmark.LlamaBenchyMetric) string {
+	if m == nil {
+		return ""
+	}
+	return ftoa(m.Std)
+}
+
+// parseExportFormat normalizes the format query param. Defaults to csv
+// because the typical browser flow downloads a spreadsheet-friendly file.
+func parseExportFormat(r *http.Request) (string, error) {
+	v := strings.ToLower(r.URL.Query().Get("format"))
+	switch v {
+	case "":
+		return exportFormatCSV, nil
+	case exportFormatCSV, exportFormatJSON:
+		return v, nil
+	default:
+		return "", fmt.Errorf("format must be %q or %q", exportFormatCSV, exportFormatJSON)
+	}
+}
+
+func parseExportScope(r *http.Request) (string, error) {
+	v := strings.ToLower(r.URL.Query().Get("scope"))
+	switch v {
+	case "":
+		return exportScopeCells, nil
+	case exportScopeCells, exportScopeSum:
+		return v, nil
+	default:
+		return "", fmt.Errorf("scope must be %q or %q", exportScopeCells, exportScopeSum)
+	}
+}

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -155,8 +155,10 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 // parent list row without re-rendering the entire list.
 func (s *Server) renderJobDetail(w http.ResponseWriter, job *benchmark.BenchmarkJob) {
 	type cellRow struct {
+		Idx       int
 		Cell      benchmark.JobCell
 		ModelName string
+		Quant     string
 		BuildLbl  string
 		TGTPS     string // formatted, "—" when no summary
 		PPTPS     string
@@ -164,18 +166,26 @@ func (s *Server) renderJobDetail(w http.ResponseWriter, job *benchmark.Benchmark
 	}
 	rows := make([]cellRow, 0, len(job.Cells))
 	var done, failed int
-	for _, c := range job.Cells {
+	for i, c := range job.Cells {
 		switch c.Status {
 		case benchmark.CellStatusCompleted:
 			done++
 		case benchmark.CellStatusFailed:
 			failed++
 		}
-		row := cellRow{Cell: c, ModelName: shortenModelName(c.ModelID), BuildLbl: c.BuildID, TGTPS: "—", PPTPS: "—"}
+		row := cellRow{Idx: i, Cell: c, ModelName: shortenModelName(c.ModelID), BuildLbl: c.BuildID, TGTPS: "—", PPTPS: "—"}
+		// Pull Quant from the registry first so pending cells (no run
+		// yet) still show it; the run's value wins once it exists.
+		if m, err := s.registry.Get(c.ModelID); err == nil {
+			row.Quant = m.Quant
+		}
 		if c.BenchmarkRunID != "" {
 			if run, err := s.bench.Get(c.BenchmarkRunID); err == nil {
 				if run.ModelName != "" {
 					row.ModelName = run.ModelName
+				}
+				if run.Quant != "" {
+					row.Quant = run.Quant
 				}
 				if run.BuildID != "" {
 					row.BuildLbl = run.BuildID

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -150,7 +150,9 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 
 // renderJobDetail enriches a job's cells with their linked run summary
 // before rendering, so the matrix view can show TG t/s without a second
-// round-trip per cell.
+// round-trip per cell. Also tallies done/failed/total so the OOB
+// summary update fragments at the top of the partial can patch the
+// parent list row without re-rendering the entire list.
 func (s *Server) renderJobDetail(w http.ResponseWriter, job *benchmark.BenchmarkJob) {
 	type cellRow struct {
 		Cell      benchmark.JobCell
@@ -161,7 +163,14 @@ func (s *Server) renderJobDetail(w http.ResponseWriter, job *benchmark.Benchmark
 		ErrorShort string
 	}
 	rows := make([]cellRow, 0, len(job.Cells))
+	var done, failed int
 	for _, c := range job.Cells {
+		switch c.Status {
+		case benchmark.CellStatusCompleted:
+			done++
+		case benchmark.CellStatusFailed:
+			failed++
+		}
 		row := cellRow{Cell: c, ModelName: shortenModelName(c.ModelID), BuildLbl: c.BuildID, TGTPS: "—", PPTPS: "—"}
 		if c.BenchmarkRunID != "" {
 			if run, err := s.bench.Get(c.BenchmarkRunID); err == nil {
@@ -186,9 +195,12 @@ func (s *Server) renderJobDetail(w http.ResponseWriter, job *benchmark.Benchmark
 		rows = append(rows, row)
 	}
 	s.renderPartial(w, "job_detail", struct {
-		Job  *benchmark.BenchmarkJob
-		Rows []cellRow
-	}{Job: job, Rows: rows})
+		Job    *benchmark.BenchmarkJob
+		Rows   []cellRow
+		Done   int
+		Failed int
+		Total  int
+	}{Job: job, Rows: rows, Done: done, Failed: failed, Total: len(job.Cells)})
 }
 
 // handleJobForm renders the new-job modal contents (multi-select models,

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -12,11 +12,63 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/tmlabonte/llamactl/internal/benchmark"
+	"github.com/tmlabonte/llamactl/internal/models"
 )
 
-// handleListJobs returns all benchmark jobs as JSON.
+// handleListJobs returns all benchmark jobs.
 func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
-	respondJSON(w, s.bench.ListJobs())
+	jobs := s.bench.ListJobs()
+	if isHTMX(r) {
+		respondHTML(w)
+		s.renderJobList(w, jobs)
+		return
+	}
+	respondJSON(w, jobs)
+}
+
+// renderJobList renders the collapsible jobs list partial. Each job row
+// shows status + cell-progress; expanding fetches the detail partial via
+// HTMX so the matrix view doesn't render on every list refresh.
+func (s *Server) renderJobList(w http.ResponseWriter, jobs []benchmark.BenchmarkJob) {
+	enriched := make([]jobListEntry, 0, len(jobs))
+	for _, j := range jobs {
+		j := j
+		var done, failed, total int
+		for _, c := range j.Cells {
+			total++
+			switch c.Status {
+			case benchmark.CellStatusCompleted:
+				done++
+			case benchmark.CellStatusFailed:
+				failed++
+			}
+		}
+		enriched = append(enriched, jobListEntry{
+			Job:       &j,
+			Done:      done,
+			Failed:    failed,
+			Total:     total,
+			AdhocRuns: 0,
+		})
+	}
+	if len(enriched) > 0 {
+		// The synthetic adhoc job carries no Cells, so its progress
+		// column should show the total run count instead.
+		for i := range enriched {
+			if enriched[i].Job.ID == benchmark.AdhocJobID {
+				enriched[i].AdhocRuns = len(s.bench.RunsForJob(benchmark.AdhocJobID))
+			}
+		}
+	}
+	s.renderPartial(w, "job_list", enriched)
+}
+
+type jobListEntry struct {
+	Job       *benchmark.BenchmarkJob
+	Done      int
+	Failed    int
+	Total     int
+	AdhocRuns int
 }
 
 // jobCreateRequest is the JSON body POST /api/benchmark-jobs accepts.
@@ -75,12 +127,101 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 
 // handleGetJob returns one job (with its cells).
 func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
-	job, err := s.bench.GetJob(chi.URLParam(r, "id"))
+	id := chi.URLParam(r, "id")
+	job, err := s.bench.GetJob(id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
+	if isHTMX(r) {
+		respondHTML(w)
+		// The synthetic adhoc job has no cell matrix — render the
+		// existing flat run list instead so legacy + quick-bench runs
+		// stay visible.
+		if job.ID == benchmark.AdhocJobID {
+			s.renderBenchmarkList(w, s.bench.RunsForJob(benchmark.AdhocJobID))
+			return
+		}
+		s.renderJobDetail(w, job)
+		return
+	}
 	respondJSON(w, job)
+}
+
+// renderJobDetail enriches a job's cells with their linked run summary
+// before rendering, so the matrix view can show TG t/s without a second
+// round-trip per cell.
+func (s *Server) renderJobDetail(w http.ResponseWriter, job *benchmark.BenchmarkJob) {
+	type cellRow struct {
+		Cell      benchmark.JobCell
+		ModelName string
+		BuildLbl  string
+		TGTPS     string // formatted, "—" when no summary
+		PPTPS     string
+		ErrorShort string
+	}
+	rows := make([]cellRow, 0, len(job.Cells))
+	for _, c := range job.Cells {
+		row := cellRow{Cell: c, ModelName: shortenModelName(c.ModelID), BuildLbl: c.BuildID, TGTPS: "—", PPTPS: "—"}
+		if c.BenchmarkRunID != "" {
+			if run, err := s.bench.Get(c.BenchmarkRunID); err == nil {
+				if run.ModelName != "" {
+					row.ModelName = run.ModelName
+				}
+				if run.BuildID != "" {
+					row.BuildLbl = run.BuildID
+				}
+				if run.Summary != nil {
+					row.TGTPS = fmt.Sprintf("%.1f", run.Summary.AvgGenTokPerSec)
+					row.PPTPS = fmt.Sprintf("%.0f", run.Summary.AvgPromptTokPerSec)
+				}
+			}
+		}
+		if c.Error != "" {
+			row.ErrorShort = c.Error
+			if len(row.ErrorShort) > 80 {
+				row.ErrorShort = row.ErrorShort[:80] + "…"
+			}
+		}
+		rows = append(rows, row)
+	}
+	s.renderPartial(w, "job_detail", struct {
+		Job  *benchmark.BenchmarkJob
+		Rows []cellRow
+	}{Job: job, Rows: rows})
+}
+
+// handleJobForm renders the new-job modal contents (multi-select models,
+// builds, presets, optional overrides, live cell-count preview).
+func (s *Server) handleJobForm(w http.ResponseWriter, r *http.Request) {
+	respondHTML(w)
+	var enabled []*models.Model
+	for _, m := range s.registry.List() {
+		if cfg, err := s.registry.GetConfig(m.ID); err == nil && cfg.Enabled {
+			enabled = append(enabled, m)
+		}
+	}
+	type buildOpt struct {
+		ID, Profile, GitRef, Tag string
+	}
+	var builds []buildOpt
+	for _, b := range s.builder.List() {
+		if b.Status != "success" {
+			continue
+		}
+		builds = append(builds, buildOpt{ID: b.ID, Profile: b.Profile, GitRef: b.GitRef, Tag: b.Tag})
+	}
+	s.renderPartial(w, "job_form", struct {
+		Models  []*models.Model
+		Builds  []buildOpt
+		Presets []benchmark.Preset
+		Running bool
+	}{
+		Models:  enabled,
+		Builds:  builds,
+		Presets: benchmark.Presets(),
+		Running: s.process.IsRunning(),
+	})
 }
 
 // handleDeleteJob removes a job. The runs query param controls what

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -233,16 +233,19 @@ func (s *Server) handleJobForm(w http.ResponseWriter, r *http.Request) {
 		}
 		builds = append(builds, buildOpt{ID: b.ID, Profile: b.Profile, GitRef: b.GitRef, Tag: b.Tag})
 	}
+	numGPUs := len(s.monitor.Current().GPU)
 	s.renderPartial(w, "job_form", struct {
-		Models  []*models.Model
-		Builds  []buildOpt
-		Presets []benchmark.Preset
-		Running bool
+		Models     []*models.Model
+		Builds     []buildOpt
+		Presets    []benchmark.Preset
+		GPUOptions []models.GPUOption
+		Running    bool
 	}{
-		Models:  enabled,
-		Builds:  builds,
-		Presets: benchmark.Presets(),
-		Running: s.process.IsRunning(),
+		Models:     enabled,
+		Builds:     builds,
+		Presets:    benchmark.Presets(),
+		GPUOptions: models.GPUAssignOptions(numGPUs),
+		Running:    s.process.IsRunning(),
 	})
 }
 

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -356,8 +356,9 @@ func (s *Server) handleJobProgress(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleExportJob is a minimal JSON-only export stub. Step 9 replaces
-// it with full CSV (per-cell rows + summary) and self-contained JSON.
+// handleExportJob serves a per-job export. Both formats accept the
+// same scope param (?scope=cells|summary) since CSV honours it and
+// JSON is always full-fidelity.
 func (s *Server) handleExportJob(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	job, err := s.bench.GetJob(id)
@@ -365,23 +366,29 @@ func (s *Server) handleExportJob(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	format := r.URL.Query().Get("format")
-	if format == "" {
-		format = "json"
-	}
-	if format != "json" {
-		http.Error(w, "only format=json is wired up; CSV ships with step 9", http.StatusNotImplemented)
+	format, err := parseExportFormat(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	payload := struct {
-		Job  *benchmark.BenchmarkJob   `json:"job"`
-		Runs []benchmark.BenchmarkRun  `json:"runs"`
-	}{
-		Job:  job,
-		Runs: s.bench.RunsForJob(id),
+	scope, err := parseExportScope(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="job-%s.json"`, id))
-	respondJSON(w, payload)
+	runs := s.bench.RunsForJob(id)
+	jobs := newJobLookup([]*benchmark.BenchmarkJob{job})
+
+	switch format {
+	case exportFormatJSON:
+		_ = writeJSONExport(w, fmt.Sprintf("job-%s.json", id), ExportEnvelope{
+			Version: exportEnvelopeVersion,
+			Jobs:    []*benchmark.BenchmarkJob{job},
+			Runs:    runs,
+		})
+	default: // csv
+		_ = writeCSVExport(w, fmt.Sprintf("job-%s-%s.csv", id, scope), runs, jobs, scope)
+	}
 }
 
 func jobInTerminalState(status string) bool {

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tmlabonte/llamactl/internal/benchmark"
+)
+
+// handleListJobs returns all benchmark jobs as JSON.
+func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, s.bench.ListJobs())
+}
+
+// jobCreateRequest is the JSON body POST /api/benchmark-jobs accepts.
+type jobCreateRequest struct {
+	Name        string                       `json:"name"`
+	Description string                       `json:"description,omitempty"`
+	ModelIDs    []string                     `json:"model_ids"`
+	BuildIDs    []string                     `json:"build_ids"`
+	Presets     []string                     `json:"presets"`
+	Overrides   *benchmark.ConfigOverrides   `json:"overrides,omitempty"`
+}
+
+// handleCreateJob expands the matrix and submits the job to the queue.
+// Returns 409 when another job is already running.
+func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
+	var req jobCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	if len(req.ModelIDs) == 0 || len(req.BuildIDs) == 0 || len(req.Presets) == 0 {
+		http.Error(w, "model_ids, build_ids, and presets are all required", http.StatusBadRequest)
+		return
+	}
+
+	job := benchmark.BenchmarkJob{
+		ID:          newJobID(),
+		Name:        req.Name,
+		Description: req.Description,
+		Kind:        benchmark.JobKindBatch,
+		Status:      benchmark.JobStatusPending,
+		CreatedAt:   time.Now(),
+		ModelIDs:    req.ModelIDs,
+		BuildIDs:    req.BuildIDs,
+		Presets:     req.Presets,
+		Overrides:   req.Overrides,
+		Cells:       benchmark.ExpandCells(req.ModelIDs, req.BuildIDs, req.Presets),
+	}
+
+	if err := s.jobs.Submit(job); err != nil {
+		if errors.Is(err, benchmark.ErrJobAlreadyRunning) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	respondJSON(w, job)
+}
+
+// handleGetJob returns one job (with its cells).
+func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
+	job, err := s.bench.GetJob(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	respondJSON(w, job)
+}
+
+// handleDeleteJob removes a job. The runs query param controls what
+// happens to its runs:
+//   - cascade (default): runs deleted with the job
+//   - orphan: runs reassigned to the synthetic adhoc job
+func (s *Server) handleDeleteJob(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	disposition := benchmark.DeleteCascade
+	if v := r.URL.Query().Get("runs"); v != "" {
+		switch v {
+		case "cascade":
+			disposition = benchmark.DeleteCascade
+		case "orphan":
+			disposition = benchmark.DeleteOrphan
+		default:
+			http.Error(w, "runs must be 'cascade' or 'orphan'", http.StatusBadRequest)
+			return
+		}
+	}
+	if err := s.bench.DeleteJob(id, disposition); err != nil {
+		// Refusing to delete the synthetic adhoc job is a 400 (the
+		// caller passed something they shouldn't); not-found is a 404.
+		if strings.Contains(err.Error(), "synthetic") {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleCancelJob signals the queue to cancel the running job.
+func (s *Server) handleCancelJob(w http.ResponseWriter, r *http.Request) {
+	if err := s.jobs.Cancel(chi.URLParam(r, "id")); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleRetryFailedCells re-queues only failed cells of the given job.
+func (s *Server) handleRetryFailedCells(w http.ResponseWriter, r *http.Request) {
+	if err := s.jobs.RetryFailed(chi.URLParam(r, "id")); err != nil {
+		if errors.Is(err, benchmark.ErrJobAlreadyRunning) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// handleJobProgress streams job snapshots over SSE. Uses a 500ms poll
+// interval for now — the cell loop saves on every status transition, so
+// polling the store is sufficient signal. A full pub/sub upgrade can
+// land later if the dashboard ever shows multiple jobs at once.
+//
+// One event type:
+//   - "snapshot": JSON-encoded BenchmarkJob with cells. Emitted only
+//     when something changed since the previous send.
+// Stream ends when the job reaches a terminal state.
+func (s *Server) handleJobProgress(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := s.bench.GetJob(id); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	sse, err := NewSSEWriter(w)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastSerialized []byte
+	emit := func() bool {
+		job, err := s.bench.GetJob(id)
+		if err != nil {
+			return false
+		}
+		data, err := json.Marshal(job)
+		if err != nil {
+			return false
+		}
+		if string(data) != string(lastSerialized) {
+			lastSerialized = data
+			_ = sse.SendEvent("snapshot", string(data))
+		}
+		return jobInTerminalState(job.Status)
+	}
+
+	if emit() {
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if emit() {
+				return
+			}
+		}
+	}
+}
+
+// handleExportJob is a minimal JSON-only export stub. Step 9 replaces
+// it with full CSV (per-cell rows + summary) and self-contained JSON.
+func (s *Server) handleExportJob(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	job, err := s.bench.GetJob(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "json"
+	}
+	if format != "json" {
+		http.Error(w, "only format=json is wired up; CSV ships with step 9", http.StatusNotImplemented)
+		return
+	}
+	payload := struct {
+		Job  *benchmark.BenchmarkJob   `json:"job"`
+		Runs []benchmark.BenchmarkRun  `json:"runs"`
+	}{
+		Job:  job,
+		Runs: s.bench.RunsForJob(id),
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="job-%s.json"`, id))
+	respondJSON(w, payload)
+}
+
+func jobInTerminalState(status string) bool {
+	switch status {
+	case benchmark.JobStatusCompleted, benchmark.JobStatusFailed, benchmark.JobStatusCanceled:
+		return true
+	}
+	return false
+}
+
+// newJobID returns a short, time-prefixed random ID. Time prefix keeps
+// IDs sortable; the random suffix avoids collisions when a UI submits
+// twice within the same millisecond.
+func newJobID() string {
+	var buf [4]byte
+	_, _ = rand.Read(buf[:])
+	return fmt.Sprintf("job-%d-%s", time.Now().UnixMilli(), hex.EncodeToString(buf[:]))
+}

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -3,6 +3,10 @@ package api
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -19,6 +23,59 @@ type jobEnv struct {
 }
 
 func newJobEnv(s *Server) *jobEnv { return &jobEnv{s: s} }
+
+// CheckBuildRunnable parses `ldd` output to detect missing shared
+// libraries (e.g. a build linked against an older ROCm SONAME than the
+// one the host now ships). Linux only; on other OSes returns nil so the
+// runner falls through to EnsureBuildActive and any failure surfaces
+// from the router instead.
+func (e *jobEnv) CheckBuildRunnable(ctx context.Context, buildID string) error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+	var binary string
+	for _, b := range e.s.builder.List() {
+		if b.ID == buildID {
+			binary = b.BinaryPath
+			break
+		}
+	}
+	if binary == "" {
+		return fmt.Errorf("build %s not found", buildID)
+	}
+	cmd := exec.CommandContext(ctx, "ldd", binary)
+	// Mirror what process.Manager does at launch: prepend the binary's
+	// directory to LD_LIBRARY_PATH so co-located libs (libllama.so,
+	// libggml*.so, etc.) resolve. Without this every build false-flags
+	// as broken.
+	binDir := filepath.Dir(binary)
+	env := os.Environ()
+	prepended := false
+	for i, kv := range env {
+		if strings.HasPrefix(kv, "LD_LIBRARY_PATH=") {
+			env[i] = "LD_LIBRARY_PATH=" + binDir + string(os.PathListSeparator) + kv[len("LD_LIBRARY_PATH="):]
+			prepended = true
+			break
+		}
+	}
+	if !prepended {
+		env = append(env, "LD_LIBRARY_PATH="+binDir)
+	}
+	cmd.Env = env
+	// ldd returns non-zero when there are unresolved libs but still
+	// prints them, so we deliberately ignore exit code and parse output.
+	out, _ := cmd.Output()
+	var missing []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, "=> not found") {
+			missing = append(missing, strings.TrimSpace(line))
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing shared libraries: %s — was the build compiled against a different version of the runtime libs (e.g. ROCm SONAME bump)? rebuild llama.cpp on this host", strings.Join(missing, "; "))
+	}
+	return nil
+}
 
 // EnsureBuildActive switches the router to buildID if it isn't already,
 // waiting up to 2 minutes for /health to pass.

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tmlabonte/llamactl/internal/benchmark"
+	"github.com/tmlabonte/llamactl/internal/builder"
+	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmlabonte/llamactl/internal/monitor"
+)
+
+// jobEnv adapts *Server to benchmark.JobEnv. Created once at server
+// startup and handed to the JobQueue; carries no state of its own.
+type jobEnv struct {
+	s *Server
+}
+
+func newJobEnv(s *Server) *jobEnv { return &jobEnv{s: s} }
+
+// EnsureBuildActive switches the router to buildID if it isn't already,
+// waiting up to 2 minutes for /health to pass.
+func (e *jobEnv) EnsureBuildActive(ctx context.Context, buildID string) error {
+	if buildID == "" {
+		return fmt.Errorf("empty build id")
+	}
+
+	// Find the build and verify it's a successful one we can run.
+	var target *builder.BuildResult
+	for _, b := range e.s.builder.List() {
+		if b.ID == buildID {
+			b := b
+			target = &b
+			break
+		}
+	}
+	if target == nil {
+		return fmt.Errorf("build %s not found", buildID)
+	}
+	if target.Status != builder.BuildStatusSuccess {
+		return fmt.Errorf("build %s is %s, not success", buildID, target.Status)
+	}
+
+	if e.s.cfg.ActiveBuild == buildID && e.s.process.IsRunning() {
+		return nil
+	}
+
+	e.s.cfg.ActiveBuild = buildID
+	e.s.saveConfig()
+
+	if e.s.process.IsRunning() {
+		if err := e.s.process.Stop(); err != nil {
+			return fmt.Errorf("stop router: %w", err)
+		}
+	}
+	if err := e.s.startRouter(); err != nil {
+		return fmt.Errorf("start router with %s: %w", buildID, err)
+	}
+
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if e.s.process.IsRunning() {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for router to come up on build %s", buildID)
+}
+
+// ResolveModel pulls registry data into the shape the JobRunner expects.
+func (e *jobEnv) ResolveModel(modelID string) (benchmark.ModelInfo, error) {
+	m, err := e.s.registry.Get(modelID)
+	if err != nil {
+		return benchmark.ModelInfo{}, err
+	}
+	cfg, err := e.s.registry.GetConfig(modelID)
+	if err != nil {
+		return benchmark.ModelInfo{}, err
+	}
+	return benchmark.ModelInfo{
+		HFRepoID:    m.ModelID,
+		Quant:       m.Quant,
+		SizeGB:      models.BytesToGB(m.SizeBytes),
+		DisplayName: shortenModelName(m.ModelID),
+		RouterName:  e.s.registry.RouterName(modelID),
+		Config: benchmark.ConfigSnapshot{
+			GPULayers:      cfg.GPULayers,
+			ContextSize:    cfg.ContextSize,
+			GPUAssign:      cfg.GPUAssign,
+			TensorSplit:    cfg.TensorSplit,
+			FlashAttention: cfg.FlashAttention,
+			KVCacheQuant:   cfg.KVCacheQuant,
+			DirectIO:       cfg.DirectIO,
+			Threads:        cfg.Threads,
+			SpecType:       cfg.SpecType,
+		},
+	}, nil
+}
+
+// ResolveBuild reuses the same builder lookup the migration uses.
+func (e *jobEnv) ResolveBuild(buildID string) benchmark.BuildSnapshot {
+	return builderResolver(e.s.builder)(buildID)
+}
+
+func (e *jobEnv) CurrentMetrics() monitor.Metrics { return e.s.monitor.Current() }
+
+func (e *jobEnv) RouterURL() string {
+	return fmt.Sprintf("http://localhost:%d", e.s.cfg.LlamaPort)
+}
+
+// shortenModelName mirrors the trim done in handleStartBenchmark so cell
+// runs label the same way as the existing single-run path.
+func shortenModelName(modelID string) string {
+	name := modelID
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	name = strings.TrimSuffix(name, "-GGUF")
+	name = strings.TrimSuffix(name, "-gguf")
+	return name
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -119,6 +119,12 @@ func (s *Server) parseTemplates() map[string]*template.Template {
 				}
 			}, s)
 		},
+		"shortSHA": func(s string) string {
+			if len(s) > 12 {
+				return s[:12]
+			}
+			return s
+		},
 		"divf": func(a, b interface{}) float64 {
 			af, bf := toFloat64(a), toFloat64(b)
 			if bf == 0 {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -38,10 +37,8 @@ type Server struct {
 	registry        *models.Registry
 	process         *process.Manager
 	monitor         *monitor.Monitor
-	bench           *benchmark.Store
-	jobs            *benchmark.JobQueue
-	benchProgress   map[string]chan benchmark.ProgressUpdate
-	benchProgressMu sync.RWMutex
+	bench *benchmark.Store
+	jobs  *benchmark.JobQueue
 	dirtyModels     map[string]bool // models whose config changed since last load
 }
 
@@ -66,7 +63,6 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 		process:       process.NewManager(),
 		monitor:       mon,
 		bench:         benchmark.NewStore(cfg.DataDir, builderResolver(bld)),
-		benchProgress: make(map[string]chan benchmark.ProgressUpdate),
 		dirtyModels:   make(map[string]bool),
 	}
 	s.jobs = benchmark.NewJobQueue(s.bench, newJobEnv(s))
@@ -278,7 +274,6 @@ func (s *Server) buildRouter() chi.Router {
 			r.Delete("/batch-delete", s.handleBatchDeleteBenchmarks)
 			r.Get("/{id}", s.handleGetBenchmark)
 			r.Delete("/{id}", s.handleDeleteBenchmark)
-			r.Get("/{id}/progress", s.handleBenchmarkProgress)
 		})
 		r.Get("/timings", s.handleTimings)
 		r.Get("/timings/{model_id}", s.handleTimings)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -268,6 +268,7 @@ func (s *Server) buildRouter() chi.Router {
 		r.Route("/benchmarks", func(r chi.Router) {
 			r.Get("/", s.handleListBenchmarks)
 			r.Post("/", s.handleStartBenchmark)
+			r.Get("/about", s.handleBenchmarksAbout)
 			r.Get("/form", s.handleBenchmarkForm)
 			r.Get("/compare", s.handleCompareBenchmarks)
 			r.Get("/export", s.handleExportBenchmarks)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -241,6 +241,16 @@ func (s *Server) buildRouter() chi.Router {
 			r.Delete("/{id}", s.handleDeleteBuild)
 		})
 		r.Get("/gpu-map", s.handleGPUMap)
+		r.Route("/benchmark-jobs", func(r chi.Router) {
+			r.Get("/", s.handleListJobs)
+			r.Post("/", s.handleCreateJob)
+			r.Get("/{id}", s.handleGetJob)
+			r.Delete("/{id}", s.handleDeleteJob)
+			r.Post("/{id}/cancel", s.handleCancelJob)
+			r.Post("/{id}/retry-failed", s.handleRetryFailedCells)
+			r.Get("/{id}/progress", s.handleJobProgress)
+			r.Get("/{id}/export", s.handleExportJob)
+		})
 		r.Route("/benchmarks", func(r chi.Router) {
 			r.Get("/", s.handleListBenchmarks)
 			r.Post("/", s.handleStartBenchmark)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	process         *process.Manager
 	monitor         *monitor.Monitor
 	bench           *benchmark.Store
+	jobs            *benchmark.JobQueue
 	benchProgress   map[string]chan benchmark.ProgressUpdate
 	benchProgressMu sync.RWMutex
 	dirtyModels     map[string]bool // models whose config changed since last load
@@ -67,6 +68,7 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 		benchProgress: make(map[string]chan benchmark.ProgressUpdate),
 		dirtyModels:   make(map[string]bool),
 	}
+	s.jobs = benchmark.NewJobQueue(s.bench, newJobEnv(s))
 	s.downloader.SetOnComplete(s.onDownloadComplete)
 	s.registry.BackfillGGUFMeta()
 	if n := s.registry.DeduplicateModels(); n > 0 {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -53,16 +53,17 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 	mon := monitor.New(3 * time.Second)
 	mon.Start()
 
+	bld := builder.NewBuilder(cfg.DataDir)
 	s := &Server{
 		cfg:           cfg,
 		configPath:    configPath,
-		builder:       builder.NewBuilder(cfg.DataDir),
+		builder:       bld,
 		hfClient:      huggingface.NewClient(cfg.HFToken),
 		downloader:    huggingface.NewDownloader(cfg.DataDir, cfg.ModelsPath(), cfg.HFToken),
 		registry:      models.NewRegistry(cfg.DataDir, cfg.ModelsPath()),
 		process:       process.NewManager(),
 		monitor:       mon,
-		bench:         benchmark.NewStore(cfg.DataDir),
+		bench:         benchmark.NewStore(cfg.DataDir, builderResolver(bld)),
 		benchProgress: make(map[string]chan benchmark.ProgressUpdate),
 		dirtyModels:   make(map[string]bool),
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -121,6 +122,22 @@ func (s *Server) parseTemplates() map[string]*template.Template {
 					return '_'
 				}
 			}, s)
+		},
+		// deref turns a pointer like *int / *bool / *string / *float64
+		// into its underlying value for templates. Non-pointers pass
+		// through; nil pointers return empty string.
+		"deref": func(v interface{}) interface{} {
+			if v == nil {
+				return ""
+			}
+			rv := reflect.ValueOf(v)
+			if rv.Kind() == reflect.Ptr {
+				if rv.IsNil() {
+					return ""
+				}
+				return rv.Elem().Interface()
+			}
+			return v
 		},
 		"shortSHA": func(s string) string {
 			if len(s) > 12 {
@@ -244,6 +261,7 @@ func (s *Server) buildRouter() chi.Router {
 		r.Route("/benchmark-jobs", func(r chi.Router) {
 			r.Get("/", s.handleListJobs)
 			r.Post("/", s.handleCreateJob)
+			r.Get("/form", s.handleJobForm)
 			r.Get("/{id}", s.handleGetJob)
 			r.Delete("/{id}", s.handleDeleteJob)
 			r.Post("/{id}/cancel", s.handleCancelJob)

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -593,6 +593,25 @@ func (s *Store) load() {
 		}
 	}
 
+	// Same fixup for jobs and any cells caught mid-flight.
+	for i := range s.jobs {
+		if s.jobs[i].Status != JobStatusRunning {
+			continue
+		}
+		s.jobs[i].Status = JobStatusFailed
+		s.jobs[i].FinishedAt = time.Now()
+		for ci := range s.jobs[i].Cells {
+			c := &s.jobs[i].Cells[ci]
+			if c.Status == CellStatusRunning {
+				c.Status = CellStatusFailed
+				if c.Error == "" {
+					c.Error = "interrupted: server restarted before job finished"
+				}
+			}
+		}
+		dirty = true
+	}
+
 	// Backfill JobID="adhoc" on every run that lacks one and ensure the
 	// adhoc pseudo-job exists. Track the earliest run's CreatedAt so the
 	// synthesized adhoc job sorts naturally with history.

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -138,15 +138,14 @@ const (
 
 // Preset defines benchmark parameters.
 type Preset struct {
-	Name          string
-	Label         string
-	Description   string
-	Source        string // "" | "internal" | "benchy"
-	PromptTokens  []int
-	GenTokens     int
-	Repetitions   int
-	Concurrency   []int // benchy only; defaults to [1] if empty
-	RunLlamaBench bool  // internal source only; benchy presets ignore this
+	Name         string
+	Label        string
+	Description  string
+	Source       string // "" | "internal" | "benchy"
+	PromptTokens []int
+	GenTokens    int
+	Repetitions  int
+	Concurrency  []int // benchy only; defaults to [1] if empty
 }
 
 // EffectiveSource returns the dispatch key, defaulting empty → internal.
@@ -161,22 +160,32 @@ func (p Preset) EffectiveSource() string {
 func Presets() []Preset {
 	return []Preset{
 		{
-			Name:         "quick",
-			Label:        "Quick — 1 rep, 256-token prompt (~10s)",
+			Name:         "internal-quick",
+			Label:        "internal-quick — 1 rep, 256-token prompt (~10s)",
 			Description:  "Single end-to-end request with a 256-token prompt and 128 generated tokens. Sanity check that the model loads and runs.",
-			PromptTokens: []int{256}, GenTokens: 128, Repetitions: 1, RunLlamaBench: false,
+			Source:       PresetSourceInternal,
+			PromptTokens: []int{256}, GenTokens: 128, Repetitions: 1,
 		},
 		{
-			Name:         "standard",
-			Label:        "Standard — 3 reps × 3 prompt sizes + llama-bench (~2 min)",
-			Description:  "Three repetitions of end-to-end requests at 128, 512, and 2048-token prompts (128 gen tokens each), plus llama-bench for raw kernel throughput.",
-			PromptTokens: []int{128, 512, 2048}, GenTokens: 128, Repetitions: 3, RunLlamaBench: true,
+			Name:         "internal-standard",
+			Label:        "internal-standard — 3 reps × 3 prompt sizes (~1 min)",
+			Description:  "Three repetitions of end-to-end requests at 128, 512, and 2048-token prompts (128 gen tokens each).",
+			Source:       PresetSourceInternal,
+			PromptTokens: []int{128, 512, 2048}, GenTokens: 128, Repetitions: 3,
 		},
 		{
-			Name:         "thorough",
-			Label:        "Thorough — 5 reps × 4 prompt sizes up to 8K + llama-bench (~10 min)",
-			Description:  "Five repetitions at 128 / 512 / 2048 / 8192-token prompts with 256 generated tokens each, plus llama-bench. Stresses long-context performance.",
-			PromptTokens: []int{128, 512, 2048, 8192}, GenTokens: 256, Repetitions: 5, RunLlamaBench: true,
+			Name:         "internal-thorough",
+			Label:        "internal-thorough — 5 reps × 4 prompt sizes up to 8K (~5 min)",
+			Description:  "Five repetitions at 128 / 512 / 2048 / 8192-token prompts with 256 generated tokens each. Stresses long-context performance.",
+			Source:       PresetSourceInternal,
+			PromptTokens: []int{128, 512, 2048, 8192}, GenTokens: 256, Repetitions: 5,
+		},
+		{
+			Name:         "internal-long-ctx",
+			Label:        "internal-long-ctx — 1 rep, 32K prompt / 512 gen",
+			Description:  "Single 32768-token prompt with 512 generated tokens. Stresses KV cache, flash-attention, and KV quantization on a long context.",
+			Source:       PresetSourceInternal,
+			PromptTokens: []int{32768}, GenTokens: 512, Repetitions: 1,
 		},
 		{
 			Name:         "benchy-quick",
@@ -195,14 +204,26 @@ func Presets() []Preset {
 	}
 }
 
-// GetPreset returns a preset by name, falling back to "standard".
+// presetAliases maps the pre-rename preset names (used by data persisted
+// before the internal-* / benchy-* split) onto their current equivalents,
+// so old runs render and re-runs find the right preset.
+var presetAliases = map[string]string{
+	"quick":    "internal-quick",
+	"standard": "internal-standard",
+	"thorough": "internal-thorough",
+}
+
+// GetPreset returns a preset by name, falling back to "internal-standard".
 func GetPreset(name string) Preset {
+	if alias, ok := presetAliases[name]; ok {
+		name = alias
+	}
 	for _, p := range Presets() {
 		if p.Name == name {
 			return p
 		}
 	}
-	return Presets()[1] // standard
+	return Presets()[1] // internal-standard
 }
 
 // GPUSnapshotsFromMetrics converts monitor metrics to GPU snapshots.

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -35,10 +35,14 @@ type BenchmarkRun struct {
 	// Configuration snapshot
 	Config ConfigSnapshot `json:"config"`
 
-	// Build info
-	BuildID      string `json:"build_id"`
-	BuildRef     string `json:"build_ref"`
-	BuildProfile string `json:"build_profile"`
+	// Build info. The flat BuildID/BuildRef/BuildProfile fields predate
+	// the Build snapshot and are preserved for already-persisted runs;
+	// new runs populate Build with the full snapshot. Use EffectiveBuild()
+	// to read; it falls back to the flat fields for legacy data.
+	BuildID      string        `json:"build_id"`
+	BuildRef     string        `json:"build_ref"`
+	BuildProfile string        `json:"build_profile"`
+	Build        BuildSnapshot `json:"build,omitempty"`
 
 	// Hardware
 	GPUs []GPUSnapshot `json:"gpus"`
@@ -86,6 +90,20 @@ type GPUSnapshot struct {
 	Index       int    `json:"index"`
 	Name        string `json:"name"`
 	VRAMTotalMB int    `json:"vram_total_mb"`
+}
+
+// BuildSnapshot freezes the llama.cpp build that produced a benchmark
+// run. Captured at run start so deleting/rebuilding the build later
+// doesn't strand the result without context.
+type BuildSnapshot struct {
+	ID         string            `json:"id"`
+	Tag        string            `json:"tag,omitempty"`
+	Profile    string            `json:"profile"` // rocm | cuda | vulkan | metal | cpu
+	Vendor     string            `json:"vendor"`  // currently == Profile; reserved for future split
+	GitSHA     string            `json:"git_sha,omitempty"`
+	GitRef     string            `json:"git_ref,omitempty"`
+	CMakeFlags map[string]string `json:"cmake_flags,omitempty"`
+	BinaryPath string            `json:"binary_path,omitempty"`
 }
 
 // BenchmarkResult is one test point.
@@ -224,6 +242,21 @@ func GetPreset(name string) Preset {
 		}
 	}
 	return Presets()[1] // internal-standard
+}
+
+// EffectiveBuild returns the run's Build snapshot, falling back to a
+// minimal snapshot synthesized from the legacy flat fields when the run
+// was persisted before BuildSnapshot existed.
+func (r *BenchmarkRun) EffectiveBuild() BuildSnapshot {
+	if r.Build.ID != "" || r.Build.GitRef != "" {
+		return r.Build
+	}
+	return BuildSnapshot{
+		ID:      r.BuildID,
+		GitRef:  r.BuildRef,
+		Profile: r.BuildProfile,
+		Vendor:  r.BuildProfile,
+	}
 }
 
 // GPUSnapshotsFromMetrics converts monitor metrics to GPU snapshots.

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -49,9 +49,14 @@ type BenchmarkRun struct {
 	GenTokens    int    `json:"gen_tokens"`
 
 	// Results
-	Results    []BenchmarkResult  `json:"results,omitempty"`
-	Summary    *BenchmarkSummary  `json:"summary,omitempty"`
-	LlamaBench *LlamaBenchResult  `json:"llama_bench,omitempty"`
+	Results     []BenchmarkResult   `json:"results,omitempty"`
+	Summary     *BenchmarkSummary   `json:"summary,omitempty"`
+	LlamaBench  *LlamaBenchResult   `json:"llama_bench,omitempty"`
+	LlamaBenchy []LlamaBenchyResult `json:"llama_benchy,omitempty"`
+
+	// Command line that was actually executed for benchy presets, captured
+	// at run time so the detail view and "About" modal can disclose it.
+	BenchyCommand string `json:"benchy_command,omitempty"`
 
 	// Warnings (non-fatal issues during the run)
 	Warnings []string `json:"warnings,omitempty"`
@@ -122,15 +127,34 @@ type TimingSample struct {
 	GenTokPerSec    float64   `json:"gen_tps"`
 }
 
+// PresetSourceInternal drives the in-process API benchmark loop in
+// runner.go (real chat completions through the router). PresetSourceBenchy
+// shells out to `uvx llama-benchy` against the same router. Empty defaults
+// to internal so older preset definitions stay valid.
+const (
+	PresetSourceInternal = "internal"
+	PresetSourceBenchy   = "benchy"
+)
+
 // Preset defines benchmark parameters.
 type Preset struct {
 	Name          string
 	Label         string
 	Description   string
+	Source        string // "" | "internal" | "benchy"
 	PromptTokens  []int
 	GenTokens     int
 	Repetitions   int
-	RunLlamaBench bool
+	Concurrency   []int // benchy only; defaults to [1] if empty
+	RunLlamaBench bool  // internal source only; benchy presets ignore this
+}
+
+// EffectiveSource returns the dispatch key, defaulting empty → internal.
+func (p Preset) EffectiveSource() string {
+	if p.Source == "" {
+		return PresetSourceInternal
+	}
+	return p.Source
 }
 
 // Presets returns the available benchmark presets.
@@ -153,6 +177,20 @@ func Presets() []Preset {
 			Label:        "Thorough — 5 reps × 4 prompt sizes up to 8K + llama-bench (~10 min)",
 			Description:  "Five repetitions at 128 / 512 / 2048 / 8192-token prompts with 256 generated tokens each, plus llama-bench. Stresses long-context performance.",
 			PromptTokens: []int{128, 512, 2048, 8192}, GenTokens: 256, Repetitions: 5, RunLlamaBench: true,
+		},
+		{
+			Name:         "benchy-quick",
+			Label:        "benchy-quick — 1 rep, 512 prompt / 32 gen via llama-benchy (~10s)",
+			Description:  "Single-shot llama-benchy run against the router. Smoke test for the API path; works with sharded GGUFs.",
+			Source:       PresetSourceBenchy,
+			PromptTokens: []int{512}, GenTokens: 32, Repetitions: 1, Concurrency: []int{1},
+		},
+		{
+			Name:         "benchy-standard",
+			Label:        "benchy-standard — 3 reps, 2048 prompt / 128 gen via llama-benchy (~1 min)",
+			Description:  "Three-run llama-benchy benchmark at 2048-token prompts. Replaces the legacy llama-bench raw inference test for sharded models.",
+			Source:       PresetSourceBenchy,
+			PromptTokens: []int{2048}, GenTokens: 128, Repetitions: 3, Concurrency: []int{1},
 		},
 	}
 }

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -22,6 +22,7 @@ const (
 // BenchmarkRun is one complete benchmark execution.
 type BenchmarkRun struct {
 	ID        string    `json:"id"`
+	JobID     string    `json:"job_id,omitempty"` // owning job; "adhoc" for migrated/legacy and quick-bench runs
 	CreatedAt time.Time `json:"created_at"`
 	Status    string    `json:"status"`
 	Error     string    `json:"error,omitempty"`
@@ -272,11 +273,21 @@ func GPUSnapshotsFromMetrics(m monitor.Metrics) []GPUSnapshot {
 	return snaps
 }
 
+// BuildResolver resolves a build ID to its full snapshot. Implemented by
+// the api layer over *builder.Builder; passed in so the benchmark
+// package doesn't import builder directly.
+//
+// A nil resolver, or one that returns the zero value, signals "not
+// known" — the migration falls back to the legacy flat fields.
+type BuildResolver func(buildID string) BuildSnapshot
+
 // Store manages benchmark persistence and timing samples.
 type Store struct {
-	mu      sync.RWMutex
-	dataDir string
-	runs    []BenchmarkRun
+	mu       sync.RWMutex
+	dataDir  string
+	runs     []BenchmarkRun
+	jobs     []BenchmarkJob
+	resolver BuildResolver
 
 	timingsMu sync.RWMutex
 	timings   map[string][]TimingSample // model ID → ring buffer
@@ -284,11 +295,26 @@ type Store struct {
 
 const maxTimingSamples = 1000
 
-// NewStore creates a store and loads persisted benchmarks.
-func NewStore(dataDir string) *Store {
+// schemaVersion is the on-disk envelope version this build writes. v1
+// was a bare JSON array of runs; v2 wraps them with a jobs list.
+const schemaVersion = 2
+
+// benchmarkFile is the v2 envelope. v1 files are detected by an
+// unmarshal failure into this shape and a successful retry as []BenchmarkRun.
+type benchmarkFile struct {
+	Version int            `json:"version"`
+	Jobs    []BenchmarkJob `json:"jobs"`
+	Runs    []BenchmarkRun `json:"runs"`
+}
+
+// NewStore creates a store and loads persisted benchmarks. resolver may
+// be nil; if provided, the v1→v2 migration uses it to backfill Build
+// snapshots for runs whose build still exists in the builder.
+func NewStore(dataDir string, resolver BuildResolver) *Store {
 	s := &Store{
-		dataDir: dataDir,
-		timings: make(map[string][]TimingSample),
+		dataDir:  dataDir,
+		resolver: resolver,
+		timings:  make(map[string][]TimingSample),
 	}
 	s.load()
 	return s
@@ -319,10 +345,18 @@ func (s *Store) Get(id string) (*BenchmarkRun, error) {
 	return nil, fmt.Errorf("benchmark not found: %s", id)
 }
 
-// Save adds or updates a benchmark run.
+// Save adds or updates a benchmark run. Runs with no JobID are assigned
+// to the synthetic Ad-Hoc Runs job so the "every run belongs to a job"
+// invariant holds across the existing single-run code path.
 func (s *Store) Save(run BenchmarkRun) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if run.JobID == "" {
+		run.JobID = AdhocJobID
+		if !s.hasJobLocked(AdhocJobID) {
+			s.jobs = append(s.jobs, newAdhocJob(run.CreatedAt))
+		}
+	}
 	for i := range s.runs {
 		if s.runs[i].ID == run.ID {
 			s.runs[i] = run
@@ -346,6 +380,111 @@ func (s *Store) Delete(id string) error {
 		}
 	}
 	return fmt.Errorf("benchmark not found: %s", id)
+}
+
+// ListJobs returns all jobs, newest CreatedAt first. The synthetic
+// AdhocJobID always sorts last, regardless of timestamp, so the user's
+// real batch jobs surface above their history.
+func (s *Store) ListJobs() []BenchmarkJob {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]BenchmarkJob, len(s.jobs))
+	copy(out, s.jobs)
+	sort.SliceStable(out, func(i, j int) bool {
+		if (out[i].ID == AdhocJobID) != (out[j].ID == AdhocJobID) {
+			return out[j].ID == AdhocJobID
+		}
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out
+}
+
+// GetJob returns a job by ID.
+func (s *Store) GetJob(id string) (*BenchmarkJob, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i := range s.jobs {
+		if s.jobs[i].ID == id {
+			job := s.jobs[i]
+			return &job, nil
+		}
+	}
+	return nil, fmt.Errorf("job not found: %s", id)
+}
+
+// SaveJob adds or updates a job.
+func (s *Store) SaveJob(job BenchmarkJob) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.jobs {
+		if s.jobs[i].ID == job.ID {
+			s.jobs[i] = job
+			s.persist()
+			return
+		}
+	}
+	s.jobs = append(s.jobs, job)
+	s.persist()
+}
+
+// DeleteJob removes a job. The disposition controls what happens to its
+// runs: DeleteCascade removes them with the job; DeleteOrphan reassigns
+// them to the AdhocJobID. Deleting AdhocJobID itself is rejected — it's
+// the migration target and the home of the existing single-run path.
+func (s *Store) DeleteJob(id string, disposition DeleteDisposition) error {
+	if id == AdhocJobID {
+		return fmt.Errorf("cannot delete the synthetic %q job", AdhocJobID)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := -1
+	for i := range s.jobs {
+		if s.jobs[i].ID == id {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("job not found: %s", id)
+	}
+	switch disposition {
+	case DeleteCascade:
+		filtered := s.runs[:0]
+		for _, r := range s.runs {
+			if r.JobID != id {
+				filtered = append(filtered, r)
+			}
+		}
+		s.runs = filtered
+	case DeleteOrphan:
+		if !s.hasJobLocked(AdhocJobID) {
+			s.jobs = append(s.jobs, newAdhocJob(time.Now()))
+		}
+		for i := range s.runs {
+			if s.runs[i].JobID == id {
+				s.runs[i].JobID = AdhocJobID
+			}
+		}
+	default:
+		return fmt.Errorf("unknown disposition: %q (want %q or %q)", disposition, DeleteCascade, DeleteOrphan)
+	}
+	s.jobs = append(s.jobs[:idx], s.jobs[idx+1:]...)
+	s.persist()
+	return nil
+}
+
+// RunsForJob returns all runs belonging to the given job, newest first.
+func (s *Store) RunsForJob(jobID string) []BenchmarkRun {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []BenchmarkRun
+	for _, r := range s.runs {
+		if r.JobID == jobID {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.After(out[j].CreatedAt) })
+	return out
 }
 
 // RecordTiming adds a passive timing sample.
@@ -424,13 +563,26 @@ func (s *Store) load() {
 	if err != nil {
 		return
 	}
-	if err := json.Unmarshal(data, &s.runs); err != nil {
-		slog.Error("failed to load benchmarks", "error", err)
-		return
+
+	dirty := false
+
+	// Try v2 envelope first; on failure, fall back to v1 bare array.
+	var file benchmarkFile
+	if jsonErr := json.Unmarshal(data, &file); jsonErr == nil && file.Version >= 2 {
+		s.jobs = file.Jobs
+		s.runs = file.Runs
+	} else {
+		var runs []BenchmarkRun
+		if v1Err := json.Unmarshal(data, &runs); v1Err != nil {
+			slog.Error("failed to load benchmarks (neither v2 envelope nor v1 array)", "v2_error", jsonErr, "v1_error", v1Err)
+			return
+		}
+		s.runs = runs
+		dirty = true // forces a v2 rewrite at end of load
 	}
+
 	// Any benchmark still marked running at startup belongs to a previous
 	// process that died mid-run — surface it as failed so it's deletable.
-	dirty := false
 	for i := range s.runs {
 		if s.runs[i].Status == StatusRunning {
 			s.runs[i].Status = StatusFailed
@@ -440,14 +592,75 @@ func (s *Store) load() {
 			dirty = true
 		}
 	}
+
+	// Backfill JobID="adhoc" on every run that lacks one and ensure the
+	// adhoc pseudo-job exists. Track the earliest run's CreatedAt so the
+	// synthesized adhoc job sorts naturally with history.
+	var earliest time.Time
+	needsAdhoc := false
+	for i := range s.runs {
+		if s.runs[i].JobID == "" {
+			s.runs[i].JobID = AdhocJobID
+			needsAdhoc = true
+			dirty = true
+		}
+		if s.runs[i].JobID == AdhocJobID {
+			if earliest.IsZero() || s.runs[i].CreatedAt.Before(earliest) {
+				earliest = s.runs[i].CreatedAt
+			}
+		}
+	}
+	if needsAdhoc && !s.hasJobLocked(AdhocJobID) {
+		s.jobs = append(s.jobs, newAdhocJob(earliest))
+	}
+
+	// Backfill Build snapshot for runs that pre-date step 3. Try the
+	// resolver first (gives full CMake flags / tag / SHA when the build
+	// still exists), then fall back to the legacy flat fields.
+	for i := range s.runs {
+		if s.runs[i].Build.ID != "" || s.runs[i].Build.GitRef != "" {
+			continue
+		}
+		if s.resolver != nil && s.runs[i].BuildID != "" {
+			if snap := s.resolver(s.runs[i].BuildID); snap.ID != "" {
+				s.runs[i].Build = snap
+				dirty = true
+				continue
+			}
+		}
+		if s.runs[i].BuildID != "" || s.runs[i].BuildRef != "" {
+			s.runs[i].Build = BuildSnapshot{
+				ID:      s.runs[i].BuildID,
+				GitRef:  s.runs[i].BuildRef,
+				Profile: s.runs[i].BuildProfile,
+				Vendor:  s.runs[i].BuildProfile,
+			}
+			dirty = true
+		}
+	}
+
 	if dirty {
 		s.persist()
 	}
 }
 
+func (s *Store) hasJobLocked(id string) bool {
+	for i := range s.jobs {
+		if s.jobs[i].ID == id {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Store) persist() {
 	os.MkdirAll(filepath.Dir(s.benchmarkPath()), 0o755)
-	data, err := json.MarshalIndent(s.runs, "", "  ")
+	file := benchmarkFile{
+		Version: schemaVersion,
+		Jobs:    s.jobs,
+		Runs:    s.runs,
+	}
+	data, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		slog.Error("failed to marshal benchmarks", "error", err)
 		return

--- a/internal/benchmark/benchy.go
+++ b/internal/benchmark/benchy.go
@@ -1,0 +1,205 @@
+package benchmark
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// LlamaBenchyMetric is the upstream metric shape: mean, std, and the raw
+// per-run values that produced them. Pointer fields on LlamaBenchyResult
+// because every metric is nullable in the upstream schema.
+type LlamaBenchyMetric struct {
+	Mean   float64   `json:"mean"`
+	Std    float64   `json:"std"`
+	Values []float64 `json:"values,omitempty"`
+}
+
+// LlamaBenchyResult is one entry in BenchmarkReport.benchmarks — a single
+// (concurrency × prompt_size × response_size × depth) test point.
+//
+// Schema source: github.com/eugr/llama-benchy → schemas/benchmark_report_schema.json
+type LlamaBenchyResult struct {
+	Concurrency           int  `json:"concurrency"`
+	ContextSize           int  `json:"context_size"`
+	PromptSize            int  `json:"prompt_size"`
+	ResponseSize          int  `json:"response_size"`
+	IsContextPrefillPhase bool `json:"is_context_prefill_phase"`
+
+	PPThroughput      *LlamaBenchyMetric `json:"pp_throughput,omitempty"`
+	PPReqThroughput   *LlamaBenchyMetric `json:"pp_req_throughput,omitempty"`
+	TGThroughput      *LlamaBenchyMetric `json:"tg_throughput,omitempty"`
+	TGReqThroughput   *LlamaBenchyMetric `json:"tg_req_throughput,omitempty"`
+	PeakThroughput    *LlamaBenchyMetric `json:"peak_throughput,omitempty"`
+	PeakReqThroughput *LlamaBenchyMetric `json:"peak_req_throughput,omitempty"`
+	TTFR              *LlamaBenchyMetric `json:"ttfr,omitempty"`
+	EstPPT            *LlamaBenchyMetric `json:"est_ppt,omitempty"`
+	E2ETTFT           *LlamaBenchyMetric `json:"e2e_ttft,omitempty"`
+}
+
+// LlamaBenchyReport is the top-level JSON object llama-benchy writes when
+// invoked with --format json --save-result.
+type LlamaBenchyReport struct {
+	Version              string              `json:"version"`
+	Timestamp            string              `json:"timestamp"`
+	LatencyMode          string              `json:"latency_mode"`
+	LatencyMs            float64             `json:"latency_ms"`
+	Model                string              `json:"model"`
+	PrefixCachingEnabled bool                `json:"prefix_caching_enabled"`
+	MaxConcurrency       int                 `json:"max_concurrency"`
+	Benchmarks           []LlamaBenchyResult `json:"benchmarks"`
+}
+
+// BenchyConfig captures the parameters needed to invoke llama-benchy.
+type BenchyConfig struct {
+	BaseURL         string
+	APIKey          string
+	ServedModelName string
+	Tokenizer       string
+	PromptSizes     []int
+	GenSizes        []int
+	Runs            int
+	Concurrency     []int
+	SaveResultPath  string
+}
+
+// BuildBenchyArgs returns the argument vector passed to `uvx`. Pure
+// function so the disclosure modal can render the same string the runner
+// will execute.
+func BuildBenchyArgs(c BenchyConfig) []string {
+	args := []string{"llama-benchy",
+		"--base-url", c.BaseURL,
+		"--api-key", c.APIKey,
+		"--model", c.ServedModelName,
+	}
+	if c.Tokenizer != "" {
+		args = append(args, "--tokenizer", c.Tokenizer)
+	}
+	for _, pp := range c.PromptSizes {
+		args = append(args, "--pp", strconv.Itoa(pp))
+	}
+	for _, tg := range c.GenSizes {
+		args = append(args, "--tg", strconv.Itoa(tg))
+	}
+	if c.Runs > 0 {
+		args = append(args, "--runs", strconv.Itoa(c.Runs))
+	}
+	for _, cc := range c.Concurrency {
+		args = append(args, "--concurrency", strconv.Itoa(cc))
+	}
+	args = append(args, "--format", "json", "--save-result", c.SaveResultPath)
+	return args
+}
+
+// FormatBenchyCommand returns a shell-quoted, single-line representation
+// of the command for disclosure to the user.
+func FormatBenchyCommand(c BenchyConfig) string {
+	var b strings.Builder
+	b.WriteString("uvx")
+	for _, a := range BuildBenchyArgs(c) {
+		b.WriteByte(' ')
+		if strings.ContainsAny(a, " \t\"'\\$") {
+			b.WriteString(strconv.Quote(a))
+		} else {
+			b.WriteString(a)
+		}
+	}
+	return b.String()
+}
+
+// summarizeBenchy folds llama-benchy results into the BenchmarkSummary
+// shape the existing list view uses. Picks the concurrency=1 result if
+// available (most directly comparable to internal API runs), otherwise
+// the first result.
+func summarizeBenchy(results []LlamaBenchyResult) *BenchmarkSummary {
+	if len(results) == 0 {
+		return nil
+	}
+	pick := results[0]
+	for _, r := range results {
+		if r.Concurrency == 1 {
+			pick = r
+			break
+		}
+	}
+	s := &BenchmarkSummary{}
+	if pick.PPThroughput != nil {
+		s.AvgPromptTokPerSec = pick.PPThroughput.Mean
+	}
+	if pick.TGThroughput != nil {
+		s.AvgGenTokPerSec = pick.TGThroughput.Mean
+		s.MinGenTokPerSec = pick.TGThroughput.Mean
+		s.MaxGenTokPerSec = pick.TGThroughput.Mean
+		for _, v := range pick.TGThroughput.Values {
+			if v < s.MinGenTokPerSec {
+				s.MinGenTokPerSec = v
+			}
+			if v > s.MaxGenTokPerSec {
+				s.MaxGenTokPerSec = v
+			}
+		}
+	}
+	if pick.E2ETTFT != nil {
+		s.AvgTTFTMs = pick.E2ETTFT.Mean
+	} else if pick.TTFR != nil {
+		s.AvgTTFTMs = pick.TTFR.Mean
+	}
+	return s
+}
+
+// runLlamaBenchy executes uvx llama-benchy and returns the parsed report.
+// The command string we ran is returned alongside the results so callers
+// can store it on the BenchmarkRun for disclosure.
+func runLlamaBenchy(ctx context.Context, c BenchyConfig) ([]LlamaBenchyResult, string, error) {
+	if _, err := exec.LookPath("uvx"); err != nil {
+		return nil, "", errors.New("uvx not found on PATH — install uv (https://astral.sh/uv) and re-try")
+	}
+
+	if c.SaveResultPath == "" {
+		f, err := os.CreateTemp("", "llama-benchy-*.json")
+		if err != nil {
+			return nil, "", fmt.Errorf("create result tempfile: %w", err)
+		}
+		c.SaveResultPath = f.Name()
+		f.Close()
+	}
+	defer os.Remove(c.SaveResultPath)
+
+	args := BuildBenchyArgs(c)
+	cmdStr := FormatBenchyCommand(c)
+	slog.Info("running llama-benchy", "command", cmdStr)
+
+	// llama-benchy can take many minutes for big prompt sizes; rely on
+	// the parent context for cancellation rather than imposing our own
+	// timeout.
+	cmd := exec.CommandContext(ctx, "uvx", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	if err := cmd.Run(); err != nil {
+		return nil, cmdStr, fmt.Errorf("llama-benchy exited with %w\nstderr: %s", err, stderr.String())
+	}
+	slog.Info("llama-benchy finished", "duration", time.Since(start))
+
+	data, err := os.ReadFile(c.SaveResultPath)
+	if err != nil {
+		return nil, cmdStr, fmt.Errorf("read benchy result: %w", err)
+	}
+	var report LlamaBenchyReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, cmdStr, fmt.Errorf("parse benchy result: %w", err)
+	}
+	if len(report.Benchmarks) == 0 {
+		return nil, cmdStr, errors.New("llama-benchy produced no benchmark results")
+	}
+	return report.Benchmarks, cmdStr, nil
+}

--- a/internal/benchmark/benchy.go
+++ b/internal/benchmark/benchy.go
@@ -74,8 +74,16 @@ type BenchyConfig struct {
 // BuildBenchyArgs returns the argument vector passed to `uvx`. Pure
 // function so the disclosure modal can render the same string the runner
 // will execute.
+//
+// `--with sentencepiece tiktoken` pulls in the tokenizer backends needed
+// for the common HF tokenizer formats (SentencePiece for LLaMA / Mistral /
+// DeepSeek-distill, tiktoken for OpenAI-style). Without these llama-benchy
+// silently falls back to GPT-2 and prompt-size accounting drifts.
 func BuildBenchyArgs(c BenchyConfig) []string {
-	args := []string{"llama-benchy",
+	args := []string{
+		"--with", "sentencepiece",
+		"--with", "tiktoken",
+		"llama-benchy",
 		"--base-url", c.BaseURL,
 		"--api-key", c.APIKey,
 		"--model", c.ServedModelName,

--- a/internal/benchmark/job.go
+++ b/internal/benchmark/job.go
@@ -1,0 +1,114 @@
+package benchmark
+
+import (
+	"time"
+)
+
+// AdhocJobID is the synthetic catch-all job that holds runs not produced
+// by an explicit batch (legacy migrated runs and the still-existing
+// single-run / quick-benchmark path).
+const AdhocJobID = "adhoc"
+
+const (
+	JobKindBatch = "batch"
+	JobKindAdhoc = "ad-hoc"
+)
+
+const (
+	JobStatusPending   = "pending"
+	JobStatusRunning   = "running"
+	JobStatusCompleted = "completed"
+	JobStatusFailed    = "failed"
+	JobStatusCanceled  = "canceled"
+)
+
+const (
+	CellStatusPending   = "pending"
+	CellStatusRunning   = "running"
+	CellStatusCompleted = "completed"
+	CellStatusFailed    = "failed"
+	CellStatusSkipped   = "skipped"
+)
+
+// DeleteDisposition controls what happens to a job's runs when the job
+// is deleted: cascade removes them, orphan reassigns them to AdhocJobID.
+type DeleteDisposition string
+
+const (
+	DeleteCascade DeleteDisposition = "cascade"
+	DeleteOrphan  DeleteDisposition = "orphan"
+)
+
+// BenchmarkJob is a named, persistent batch run sweeping a Cartesian
+// matrix of {ModelIDs} × {BuildIDs} × {Presets}. The expanded matrix
+// lives in Cells.
+type BenchmarkJob struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Kind        string `json:"kind"`   // "batch" | "ad-hoc"
+	Status      string `json:"status"` // pending|running|completed|failed|canceled
+
+	CreatedAt  time.Time `json:"created_at"`
+	StartedAt  time.Time `json:"started_at,omitempty"`
+	FinishedAt time.Time `json:"finished_at,omitempty"`
+
+	// Definition (immutable after first run)
+	ModelIDs  []string         `json:"model_ids,omitempty"`
+	BuildIDs  []string         `json:"build_ids,omitempty"`
+	Presets   []string         `json:"presets,omitempty"`
+	Overrides *ConfigOverrides `json:"overrides,omitempty"`
+
+	// Expanded matrix
+	Cells []JobCell `json:"cells,omitempty"`
+}
+
+// ConfigOverrides applies on top of each model's saved ModelConfig for
+// every cell. Pointer fields so nil = "use the model's saved value".
+type ConfigOverrides struct {
+	GPULayers      *int     `json:"gpu_layers,omitempty"`
+	ContextSize    *int     `json:"context_size,omitempty"`
+	Threads        *int     `json:"threads,omitempty"`
+	FlashAttention *bool    `json:"flash_attention,omitempty"`
+	KVCacheQuant   *string  `json:"kv_cache_quant,omitempty"`
+	DirectIO       *bool    `json:"direct_io,omitempty"`
+	GPUAssign      *string  `json:"gpu_assign,omitempty"`
+	TensorSplit    *string  `json:"tensor_split,omitempty"`
+	SpecType       *string  `json:"spec_type,omitempty"`
+	DraftModelPath *string  `json:"draft_model_path,omitempty"`
+	Temperature    *float64 `json:"temperature,omitempty"`
+	TopP           *float64 `json:"top_p,omitempty"`
+	TopK           *int     `json:"top_k,omitempty"`
+	MinP           *float64 `json:"min_p,omitempty"`
+	RepeatPenalty  *float64 `json:"repeat_penalty,omitempty"`
+}
+
+// JobCell is one (model, build, preset) point in the matrix. The cell
+// owns at most one BenchmarkRun at a time; on retry the run ID is
+// rewritten to point at the latest attempt.
+type JobCell struct {
+	ModelID        string `json:"model_id"`
+	BuildID        string `json:"build_id"`
+	Preset         string `json:"preset"`
+	Status         string `json:"status"` // pending|running|completed|failed|skipped
+	Attempt        int    `json:"attempt"`
+	BenchmarkRunID string `json:"benchmark_run_id,omitempty"`
+	Error          string `json:"error,omitempty"`
+}
+
+// newAdhocJob synthesizes the catch-all "Ad-Hoc Runs" pseudo-job that
+// holds runs not produced by an explicit batch. Its CreatedAt should
+// match the oldest run when a v1 file is being migrated, so the entry
+// sorts naturally with the user's history.
+func newAdhocJob(createdAt time.Time) BenchmarkJob {
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	return BenchmarkJob{
+		ID:        AdhocJobID,
+		Name:      "Ad-Hoc Runs",
+		Kind:      JobKindAdhoc,
+		Status:    JobStatusCompleted,
+		CreatedAt: createdAt,
+	}
+}

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -18,6 +18,13 @@ var ErrJobAlreadyRunning = errors.New("a benchmark job is already running")
 // benchmark package. The api layer implements it against the Server so
 // this package stays free of imports for builder / models / process.
 type JobEnv interface {
+	// CheckBuildRunnable returns nil if the build's binary can satisfy
+	// its dynamic-linker dependencies on this host, or an error
+	// describing what's missing. Lets the cell loop fail fast on stale
+	// builds (e.g. ROCm SONAME bumps that strand older llama-server
+	// binaries) instead of restarting the router and watching it crash.
+	CheckBuildRunnable(ctx context.Context, buildID string) error
+
 	// EnsureBuildActive switches the router to the build identified by
 	// buildID, restarting llama-server when the active build differs.
 	// Blocks until the router is reachable.
@@ -222,6 +229,9 @@ func (q *JobQueue) run(ctx context.Context, job BenchmarkJob, rj *runningJob) {
 // happened.
 func (q *JobQueue) runCell(ctx context.Context, job *BenchmarkJob, cell *JobCell, prevBuildID *string) error {
 	if cell.BuildID != *prevBuildID {
+		if err := q.env.CheckBuildRunnable(ctx, cell.BuildID); err != nil {
+			return fmt.Errorf("build %s not runnable on this host: %w", cell.BuildID, err)
+		}
 		if err := q.env.EnsureBuildActive(ctx, cell.BuildID); err != nil {
 			return fmt.Errorf("activate build %s: %w", cell.BuildID, err)
 		}

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -1,0 +1,341 @@
+package benchmark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/tmlabonte/llamactl/internal/monitor"
+)
+
+// ErrJobAlreadyRunning is returned by Submit when a job is in flight.
+var ErrJobAlreadyRunning = errors.New("a benchmark job is already running")
+
+// JobEnv is the integration point the JobRunner needs from outside the
+// benchmark package. The api layer implements it against the Server so
+// this package stays free of imports for builder / models / process.
+type JobEnv interface {
+	// EnsureBuildActive switches the router to the build identified by
+	// buildID, restarting llama-server when the active build differs.
+	// Blocks until the router is reachable.
+	EnsureBuildActive(ctx context.Context, buildID string) error
+
+	// ResolveModel returns everything the cell needs about a model from
+	// the registry (HF repo id for tokenizer, router-served name, saved
+	// config to apply overrides on top of, display fields).
+	ResolveModel(modelID string) (ModelInfo, error)
+
+	// ResolveBuild returns the snapshot for buildID. Empty struct means
+	// the build no longer exists; the cell will fail.
+	ResolveBuild(buildID string) BuildSnapshot
+
+	// CurrentMetrics returns the latest GPU metrics for snapshotting.
+	CurrentMetrics() monitor.Metrics
+
+	// RouterURL returns the base URL the runner should target.
+	RouterURL() string
+}
+
+// ModelInfo bundles registry data for a single model so the JobRunner
+// doesn't have to know about the models package.
+type ModelInfo struct {
+	HFRepoID    string         // model.ModelID — passed to llama-benchy --tokenizer
+	Quant       string
+	SizeGB      float64
+	DisplayName string         // short, human-readable name for the run
+	RouterName  string         // identifier the router responds to
+	Config      ConfigSnapshot // saved baseline; ConfigOverrides overlay on this
+}
+
+// JobQueue serializes job execution: only one job runs at a time. Submit
+// returns ErrJobAlreadyRunning when the queue is busy.
+type JobQueue struct {
+	mu      sync.Mutex
+	store   *Store
+	env     JobEnv
+	runner  *Runner
+	current *runningJob
+}
+
+type runningJob struct {
+	id     string
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewJobQueue wires up the queue. The returned queue holds no goroutines
+// until Submit is called.
+func NewJobQueue(store *Store, env JobEnv) *JobQueue {
+	return &JobQueue{
+		store:  store,
+		env:    env,
+		runner: NewRunner(store),
+	}
+}
+
+// Status returns the currently running job (if any).
+func (q *JobQueue) Status() (*BenchmarkJob, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.current == nil {
+		return nil, false
+	}
+	job, err := q.store.GetJob(q.current.id)
+	if err != nil {
+		return nil, false
+	}
+	return job, true
+}
+
+// Submit accepts a new job and starts it in a background goroutine.
+// Returns ErrJobAlreadyRunning when another job is in flight.
+func (q *JobQueue) Submit(job BenchmarkJob) error {
+	q.mu.Lock()
+	if q.current != nil {
+		q.mu.Unlock()
+		return ErrJobAlreadyRunning
+	}
+	if len(job.Cells) == 0 {
+		q.mu.Unlock()
+		return errors.New("job has no cells")
+	}
+	job.Status = JobStatusPending
+	q.store.SaveJob(job)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rj := &runningJob{id: job.ID, cancel: cancel, done: make(chan struct{})}
+	q.current = rj
+	q.mu.Unlock()
+
+	go q.run(ctx, job, rj)
+	return nil
+}
+
+// Cancel signals the running job (if it matches id) to stop. It does
+// not wait for the cell loop to wind down.
+func (q *JobQueue) Cancel(id string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.current == nil || q.current.id != id {
+		return fmt.Errorf("job %s is not running", id)
+	}
+	q.current.cancel()
+	return nil
+}
+
+// RetryFailed re-runs only the cells in CellStatusFailed for the given
+// job, treating completed cells as already done. The job must not
+// currently be running.
+func (q *JobQueue) RetryFailed(id string) error {
+	job, err := q.store.GetJob(id)
+	if err != nil {
+		return err
+	}
+	any := false
+	for i := range job.Cells {
+		if job.Cells[i].Status == CellStatusFailed {
+			job.Cells[i].Status = CellStatusPending
+			job.Cells[i].Error = ""
+			any = true
+		}
+	}
+	if !any {
+		return errors.New("no failed cells to retry")
+	}
+	return q.Submit(*job)
+}
+
+// run is the per-job orchestration loop. It assumes job.Cells is already
+// ordered builds → models → presets so the prevBuildID amortization
+// minimizes router restarts.
+func (q *JobQueue) run(ctx context.Context, job BenchmarkJob, rj *runningJob) {
+	defer func() {
+		q.mu.Lock()
+		q.current = nil
+		q.mu.Unlock()
+		close(rj.done)
+	}()
+
+	job.Status = JobStatusRunning
+	job.StartedAt = time.Now()
+	q.store.SaveJob(job)
+
+	var prevBuildID string
+	var anyCompleted bool
+
+	for i := range job.Cells {
+		cell := &job.Cells[i]
+
+		// Already-completed cells (from a prior attempt that's being
+		// resumed via RetryFailed) count toward "any completed" but
+		// don't re-run.
+		if cell.Status == CellStatusCompleted {
+			anyCompleted = true
+			continue
+		}
+
+		if ctx.Err() != nil {
+			cell.Status = CellStatusSkipped
+			q.store.SaveJob(job)
+			continue
+		}
+
+		cell.Status = CellStatusRunning
+		cell.Attempt++
+		cell.Error = ""
+		q.store.SaveJob(job)
+
+		if err := q.runCell(ctx, &job, cell, &prevBuildID); err != nil {
+			cell.Status = CellStatusFailed
+			cell.Error = err.Error()
+			q.store.SaveJob(job)
+			slog.Warn("job cell failed", "job", job.ID, "model", cell.ModelID, "build", cell.BuildID, "preset", cell.Preset, "error", err)
+			continue
+		}
+
+		cell.Status = CellStatusCompleted
+		anyCompleted = true
+		q.store.SaveJob(job)
+	}
+
+	job.FinishedAt = time.Now()
+	switch {
+	case ctx.Err() != nil:
+		job.Status = JobStatusCanceled
+	case anyCompleted:
+		job.Status = JobStatusCompleted
+	default:
+		job.Status = JobStatusFailed
+	}
+	q.store.SaveJob(job)
+}
+
+// runCell drives one (model, build, preset) cell to completion. The
+// caller is responsible for setting the cell to running and recording
+// the final status; runCell only returns an error or nil.
+//
+// prevBuildID is updated when this cell's build differs from the
+// previous one so the next iteration knows whether a switch already
+// happened.
+func (q *JobQueue) runCell(ctx context.Context, job *BenchmarkJob, cell *JobCell, prevBuildID *string) error {
+	if cell.BuildID != *prevBuildID {
+		if err := q.env.EnsureBuildActive(ctx, cell.BuildID); err != nil {
+			return fmt.Errorf("activate build %s: %w", cell.BuildID, err)
+		}
+		*prevBuildID = cell.BuildID
+	}
+
+	modelInfo, err := q.env.ResolveModel(cell.ModelID)
+	if err != nil {
+		return fmt.Errorf("resolve model %s: %w", cell.ModelID, err)
+	}
+	buildSnap := q.env.ResolveBuild(cell.BuildID)
+	if buildSnap.ID == "" {
+		return fmt.Errorf("build %s no longer exists", cell.BuildID)
+	}
+	preset := GetPreset(cell.Preset)
+	cfg := applyOverrides(modelInfo.Config, job.Overrides)
+
+	run := BenchmarkRun{
+		ID:           fmt.Sprintf("bench-%d-%d", time.Now().UnixMilli(), cell.Attempt),
+		JobID:        job.ID,
+		CreatedAt:    time.Now(),
+		Status:       StatusRunning,
+		ModelID:      cell.ModelID,
+		ModelName:    modelInfo.DisplayName,
+		Quant:        modelInfo.Quant,
+		SizeGB:       modelInfo.SizeGB,
+		Config:       cfg,
+		BuildID:      buildSnap.ID,
+		BuildRef:     buildSnap.GitRef,
+		BuildProfile: buildSnap.Profile,
+		Build:        buildSnap,
+		GPUs:         GPUSnapshotsFromMetrics(q.env.CurrentMetrics()),
+		Preset:       preset.Name,
+		PromptTokens: preset.PromptTokens,
+		GenTokens:    preset.GenTokens,
+	}
+	q.store.Save(run)
+	cell.BenchmarkRunID = run.ID
+	q.store.SaveJob(*job)
+
+	q.runner.Run(ctx, RunConfig{
+		Run:        run,
+		Preset:     preset,
+		RouterURL:  q.env.RouterURL(),
+		RouterName: modelInfo.RouterName,
+		HFRepoID:   modelInfo.HFRepoID,
+	}, nil)
+
+	final, err := q.store.Get(run.ID)
+	if err != nil {
+		return fmt.Errorf("read back run: %w", err)
+	}
+	if final.Status != StatusCompleted {
+		if final.Error != "" {
+			return errors.New(final.Error)
+		}
+		return fmt.Errorf("run ended with status %s", final.Status)
+	}
+	return nil
+}
+
+// applyOverrides returns base with non-nil ConfigOverrides fields
+// applied on top. A nil overrides argument returns base unchanged.
+func applyOverrides(base ConfigSnapshot, overrides *ConfigOverrides) ConfigSnapshot {
+	if overrides == nil {
+		return base
+	}
+	out := base
+	if overrides.GPULayers != nil {
+		out.GPULayers = *overrides.GPULayers
+	}
+	if overrides.ContextSize != nil {
+		out.ContextSize = *overrides.ContextSize
+	}
+	if overrides.Threads != nil {
+		out.Threads = *overrides.Threads
+	}
+	if overrides.FlashAttention != nil {
+		out.FlashAttention = *overrides.FlashAttention
+	}
+	if overrides.KVCacheQuant != nil {
+		out.KVCacheQuant = *overrides.KVCacheQuant
+	}
+	if overrides.DirectIO != nil {
+		out.DirectIO = *overrides.DirectIO
+	}
+	if overrides.GPUAssign != nil {
+		out.GPUAssign = *overrides.GPUAssign
+	}
+	if overrides.TensorSplit != nil {
+		out.TensorSplit = *overrides.TensorSplit
+	}
+	if overrides.SpecType != nil {
+		out.SpecType = *overrides.SpecType
+	}
+	return out
+}
+
+// ExpandCells builds the cell matrix in builds → models → presets order.
+// Builds is the outermost dimension specifically so EnsureBuildActive
+// fires at most once per build per job.
+func ExpandCells(modelIDs, buildIDs, presets []string) []JobCell {
+	cells := make([]JobCell, 0, len(buildIDs)*len(modelIDs)*len(presets))
+	for _, b := range buildIDs {
+		for _, m := range modelIDs {
+			for _, p := range presets {
+				cells = append(cells, JobCell{
+					ModelID: m,
+					BuildID: b,
+					Preset:  p,
+					Status:  CellStatusPending,
+				})
+			}
+		}
+	}
+	return cells
+}

--- a/internal/benchmark/runner.go
+++ b/internal/benchmark/runner.go
@@ -290,20 +290,31 @@ func (r *Runner) unloadModel(routerURL, modelName string) {
 	slog.Info("benchmark: unload requested", "name", modelName)
 }
 
-// benchPromptText is a fixed, deterministic text used for benchmarking.
-const benchPromptText = `The history of computing is a story of human ingenuity and the relentless pursuit of automation. From the earliest mechanical calculators of the 17th century to the modern silicon chips that power our world, each generation has built upon the discoveries of the last. Charles Babbage conceived of the Analytical Engine in the 1830s, a mechanical general-purpose computer that, had it been built, would have contained many features of modern computers. Ada Lovelace, working with Babbage, wrote what is often considered the first computer program. The 20th century brought electronic computing into reality. Alan Turing formalized the concept of computation itself, while engineers at the University of Pennsylvania built ENIAC, one of the first electronic general-purpose computers. The invention of the transistor at Bell Labs in 1947 revolutionized electronics, leading to smaller, faster, and more reliable computers. The integrated circuit, developed independently by Jack Kilby and Robert Noyce, made it possible to place thousands and eventually billions of transistors on a single chip. This exponential growth in computing power, described by Moore's Law, has driven decades of innovation. Personal computers brought computing to the masses in the 1980s, the internet connected them in the 1990s, and smartphones made computing truly ubiquitous in the 2000s. Today, artificial intelligence and machine learning represent the latest frontier, with large language models demonstrating remarkable capabilities in understanding and generating human language. These models, trained on vast amounts of text data, can engage in conversation, write code, analyze documents, and assist with creative tasks. The computational requirements for training and running these models have driven advances in GPU computing, distributed systems, and specialized hardware accelerators. `
+// BenchPromptText is the deterministic prose passage the internal API
+// benchmark repeats to fill prompts. Exported so the "About benchmarks"
+// modal can disclose it verbatim.
+const BenchPromptText = `The history of computing is a story of human ingenuity and the relentless pursuit of automation. From the earliest mechanical calculators of the 17th century to the modern silicon chips that power our world, each generation has built upon the discoveries of the last. Charles Babbage conceived of the Analytical Engine in the 1830s, a mechanical general-purpose computer that, had it been built, would have contained many features of modern computers. Ada Lovelace, working with Babbage, wrote what is often considered the first computer program. The 20th century brought electronic computing into reality. Alan Turing formalized the concept of computation itself, while engineers at the University of Pennsylvania built ENIAC, one of the first electronic general-purpose computers. The invention of the transistor at Bell Labs in 1947 revolutionized electronics, leading to smaller, faster, and more reliable computers. The integrated circuit, developed independently by Jack Kilby and Robert Noyce, made it possible to place thousands and eventually billions of transistors on a single chip. This exponential growth in computing power, described by Moore's Law, has driven decades of innovation. Personal computers brought computing to the masses in the 1980s, the internet connected them in the 1990s, and smartphones made computing truly ubiquitous in the 2000s. Today, artificial intelligence and machine learning represent the latest frontier, with large language models demonstrating remarkable capabilities in understanding and generating human language. These models, trained on vast amounts of text data, can engage in conversation, write code, analyze documents, and assist with creative tasks. The computational requirements for training and running these models have driven advances in GPU computing, distributed systems, and specialized hardware accelerators. `
+
+// BenchPromptPrefixTemplate is the per-repetition prefix prepended to
+// every internal prompt. The "%d" is filled with the repetition number,
+// which varies the prompt across runs to defeat llama.cpp's prompt
+// cache. Exposed so the About modal can show the actual template.
+const BenchPromptPrefixTemplate = "This is benchmark repetition number %d. Please analyze the following text carefully and provide a detailed response.\n\n"
+
+// BenchPromptCharsPerToken is the chars-per-token approximation used
+// when sizing prompts to a target token count (English prose averages
+// ~4 chars/token under most BPE tokenizers).
+const BenchPromptCharsPerToken = 4
 
 // buildPrompt constructs a prompt of approximately the target token count
 // by repeating the benchmark text. The repetition parameter varies the
 // prompt to defeat llama.cpp's prompt cache.
 func buildPrompt(targetTokens int, repetition int) string {
-	// Rough approximation: 1 token ≈ 4 characters for English text
-	targetChars := targetTokens * 4
+	targetChars := targetTokens * BenchPromptCharsPerToken
 	var b strings.Builder
-	// Prefix with repetition-specific text to defeat prompt caching
-	b.WriteString(fmt.Sprintf("This is benchmark repetition number %d. Please analyze the following text carefully and provide a detailed response.\n\n", repetition))
+	b.WriteString(fmt.Sprintf(BenchPromptPrefixTemplate, repetition))
 	for b.Len() < targetChars {
-		b.WriteString(benchPromptText)
+		b.WriteString(BenchPromptText)
 	}
 	text := b.String()
 	if len(text) > targetChars {

--- a/internal/benchmark/runner.go
+++ b/internal/benchmark/runner.go
@@ -8,9 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -19,10 +16,8 @@ import (
 type RunConfig struct {
 	Run        BenchmarkRun
 	Preset     Preset
-	ModelPath  string // GGUF file path for llama-bench
 	RouterURL  string // e.g. "http://localhost:8080"
 	RouterName string // model name the router knows
-	BinaryDir  string // build dir containing llama-bench
 	HFRepoID   string // HuggingFace repo id; passed to llama-benchy as --tokenizer
 }
 
@@ -190,31 +185,7 @@ func (r *Runner) Run(ctx context.Context, cfg RunConfig, progress chan<- Progres
 		return
 	}
 
-	// Step 4: llama-bench (if preset says so and binary exists)
-	if cfg.Preset.RunLlamaBench && cfg.BinaryDir != "" && cfg.ModelPath != "" {
-		benchBinary := filepath.Join(cfg.BinaryDir, "llama-bench")
-		if _, err := os.Stat(benchBinary); err == nil {
-			// Unload all models from server to free VRAM for llama-bench
-			send("llama-bench", "Unloading model from server for raw benchmark...", 88)
-			r.unloadAllModels(cfg.RouterURL)
-
-			send("llama-bench", "Running llama-bench — raw inference without server overhead...", 90)
-			lb, benchErr := r.runLlamaBench(ctx, cfg)
-			if benchErr != nil {
-				slog.Warn("llama-bench failed", "error", benchErr)
-				run.Warnings = append(run.Warnings, fmt.Sprintf("llama-bench failed: %v", benchErr))
-			} else {
-				run.LlamaBench = lb
-			}
-
-			// Don't reload — the router will auto-load on next request,
-			// and reloading here causes conflicts with back-to-back benchmarks.
-		} else {
-			run.Warnings = append(run.Warnings, "llama-bench binary not found — rebuild llama.cpp to include it")
-		}
-	}
-
-	// Step 5: Compute summary
+	// Compute summary
 	run.Summary = ComputeSummary(run.Results)
 	run.Status = StatusCompleted
 	send("done", "Benchmark complete", 100)
@@ -421,75 +392,3 @@ func (r *Runner) runOneTest(ctx context.Context, routerURL, model string, prompt
 	}, nil
 }
 
-// runLlamaBench executes the llama-bench binary for raw inference benchmarking.
-func (r *Runner) runLlamaBench(ctx context.Context, cfg RunConfig) (*LlamaBenchResult, error) {
-	benchBinary := filepath.Join(cfg.BinaryDir, "llama-bench")
-
-	args := []string{
-		"-m", cfg.ModelPath,
-		"-p", fmt.Sprintf("%d", cfg.Preset.PromptTokens[0]),
-		"-n", fmt.Sprintf("%d", cfg.Preset.GenTokens),
-		"-r", fmt.Sprintf("%d", cfg.Preset.Repetitions),
-		"-o", "json",
-		"-ngl", fmt.Sprintf("%d", cfg.Run.Config.GPULayers),
-		"-t", fmt.Sprintf("%d", cfg.Run.Config.Threads),
-	}
-	if cfg.Run.Config.FlashAttention {
-		args = append(args, "-fa", "1")
-	}
-	if cfg.Run.Config.TensorSplit != "" {
-		args = append(args, "-ts", cfg.Run.Config.TensorSplit)
-	}
-	if cfg.Run.Config.DirectIO {
-		args = append(args, "--direct-io", "1")
-	}
-	if cfg.Run.Config.KVCacheQuant != "" {
-		args = append(args, "-ctk", cfg.Run.Config.KVCacheQuant, "-ctv", cfg.Run.Config.KVCacheQuant)
-	}
-
-	// Set LD_LIBRARY_PATH for shared libs co-located with the binary
-	cmd := exec.CommandContext(ctx, benchBinary, args...)
-	cmd.Env = append(cmd.Environ(), "LD_LIBRARY_PATH="+cfg.BinaryDir)
-
-	slog.Info("running llama-bench", "binary", benchBinary, "args", strings.Join(args, " "))
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("llama-bench: %w\nstderr: %s", err, stderr.String())
-	}
-
-	return parseLlamaBenchJSON(out)
-}
-
-// parseLlamaBenchJSON parses llama-bench JSON output.
-// llama-bench outputs one JSON array with objects per test.
-func parseLlamaBenchJSON(data []byte) (*LlamaBenchResult, error) {
-	var entries []struct {
-		TestType string  `json:"test"`     // "pp" or "tg"
-		AvgTS    float64 `json:"avg_ts"`
-		NPrompt  int     `json:"n_prompt"`
-		NGen     int     `json:"n_gen"`
-		Reps     int     `json:"n_repetitions"`
-	}
-	if err := json.Unmarshal(data, &entries); err != nil {
-		return nil, fmt.Errorf("parse llama-bench output: %w", err)
-	}
-
-	result := &LlamaBenchResult{}
-	for _, e := range entries {
-		switch {
-		case e.NPrompt > 0 && e.NGen == 0:
-			result.PromptTokPerSec = e.AvgTS
-			result.PromptTokens = e.NPrompt
-			result.Repetitions = e.Reps
-		case e.NGen > 0 && e.NPrompt == 0:
-			result.GenTokPerSec = e.AvgTS
-			result.GenTokens = e.NGen
-		}
-	}
-	if result.PromptTokPerSec == 0 && result.GenTokPerSec == 0 {
-		return nil, fmt.Errorf("no results in llama-bench output")
-	}
-	return result, nil
-}

--- a/internal/benchmark/runner.go
+++ b/internal/benchmark/runner.go
@@ -23,6 +23,7 @@ type RunConfig struct {
 	RouterURL  string // e.g. "http://localhost:8080"
 	RouterName string // model name the router knows
 	BinaryDir  string // build dir containing llama-bench
+	HFRepoID   string // HuggingFace repo id; passed to llama-benchy as --tokenizer
 }
 
 // ProgressUpdate is sent during benchmark execution.
@@ -106,7 +107,46 @@ func (r *Runner) Run(ctx context.Context, cfg RunConfig, progress chan<- Progres
 		return
 	}
 
-	// Step 3: Run benchmarks
+	// Step 3: Run benchmarks (internal API loop or llama-benchy shell-out).
+	switch cfg.Preset.EffectiveSource() {
+	case PresetSourceBenchy:
+		send("benchmark", "Running llama-benchy via uvx — output will appear when finished...", 30)
+		concurrency := cfg.Preset.Concurrency
+		if len(concurrency) == 0 {
+			concurrency = []int{1}
+		}
+		results, cmdStr, err := runLlamaBenchy(ctx, BenchyConfig{
+			BaseURL:         cfg.RouterURL + "/v1",
+			APIKey:          "EMPTY",
+			ServedModelName: cfg.RouterName,
+			Tokenizer:       cfg.HFRepoID,
+			PromptSizes:     cfg.Preset.PromptTokens,
+			GenSizes:        []int{cfg.Preset.GenTokens},
+			Runs:            cfg.Preset.Repetitions,
+			Concurrency:     concurrency,
+		})
+		run.BenchyCommand = cmdStr
+		if err != nil {
+			run.Status = StatusFailed
+			run.Error = err.Error()
+			send("error", run.Error, 0)
+			return
+		}
+		run.LlamaBenchy = results
+		run.Summary = summarizeBenchy(results)
+		run.Status = StatusCompleted
+		send("done", "Benchmark complete", 100)
+		return
+
+	case PresetSourceInternal, "":
+		// fallthrough to internal API loop below
+	default:
+		run.Status = StatusFailed
+		run.Error = fmt.Sprintf("unknown preset source: %q", cfg.Preset.Source)
+		send("error", run.Error, 0)
+		return
+	}
+
 	totalTests := 0
 	for _, pp := range cfg.Preset.PromptTokens {
 		_ = pp

--- a/plan/batch-benchmarks.md
+++ b/plan/batch-benchmarks.md
@@ -95,8 +95,8 @@ existing entries.
 uvx llama-benchy \
   --base-url   http://127.0.0.1:{routerPort}/v1 \
   --api-key    EMPTY \
-  --model      {hfRepoIDForTokenizer} \
-  --served-model-name {router model ID} \
+  --model      {router served-model-name} \
+  --tokenizer  {hf repo id, e.g. unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF} \
   --pp         {prompt token sizes...} \
   --tg         {gen tokens} \
   --runs       {repetitions} \
@@ -105,34 +105,80 @@ uvx llama-benchy \
   --save-result {tempfile.json}
 ```
 
+`--model` is the identifier the router responds to in chat-completion
+calls (the auto-discovery name). `--tokenizer` is the HuggingFace repo
+ID — llama-benchy needs it to construct prompts of an exact target token
+count; without it the tool falls back to a default tokenizer and the
+prompt-size accounting drifts. Both come from the model registry
+(`router served name` and `model.ModelID` respectively).
+
+The actual `uvx` invocation injects two tokenizer backends via `--with`:
+
+```
+uvx --with sentencepiece --with tiktoken llama-benchy …
+```
+
+`sentencepiece` covers LLaMA / Mistral / DeepSeek-distill family
+tokenizers; `tiktoken` covers OpenAI-style. Without these, llama-benchy
+silently falls back to GPT-2 tokenization (warning visible in stderr)
+and reported prompt sizes drift by 5–15% on most modern models.
+
 We capture the JSON file llama-benchy writes (rather than parsing
 stdout, which is markdown by default).
 
 ### Result fields captured
 
-Mapped from llama-benchy's JSON output (see upstream
-`schemas/benchmark_report_schema.json`):
+The actual upstream schema (`schemas/benchmark_report_schema.json`)
+wraps a list of per-test runs in a top-level report. Every metric is a
+nullable `BenchmarkMetric { mean, std, values }` rather than a flat
+number — this matters because we want to surface std and the raw
+per-run values in the detail view.
 
 ```go
+// Top-level file written by --save-result.
+type LlamaBenchyReport struct {
+    Version              string              `json:"version"`
+    Timestamp            string              `json:"timestamp"`
+    LatencyMode          string              `json:"latency_mode"`
+    LatencyMs            float64             `json:"latency_ms"`
+    Model                string              `json:"model"`
+    PrefixCachingEnabled bool                `json:"prefix_caching_enabled"`
+    MaxConcurrency       int                 `json:"max_concurrency"`
+    Benchmarks           []LlamaBenchyResult `json:"benchmarks"`
+}
+
+// One row per (concurrency × prompt_size × response_size × depth) point.
 type LlamaBenchyResult struct {
-    Test           string   `json:"test"`            // e.g. "pp2048", "tg32"
-    PromptTokens   int      `json:"pp"`
-    GenTokens      int      `json:"tg"`
-    Depth          int      `json:"depth"`
-    Concurrency    int      `json:"concurrency"`
-    AvgTokPerSec   float64  `json:"t_s"`             // "t/s"
-    PeakTokPerSec  float64  `json:"peak_t_s"`        // "peak t/s"
-    TTFRMs         float64  `json:"ttfr_ms"`         // time-to-first-response
-    EstPPTMs       float64  `json:"est_ppt_ms"`      // estimated prompt-processing
-    E2ETTFTMs      float64  `json:"e2e_ttft_ms"`     // end-to-end TTFT
-    TotalTokPerSec float64  `json:"t_s_total"`       // present when concurrency>1
-    PerReqTokPerSec float64 `json:"t_s_req"`         // present when concurrency>1
+    Concurrency           int  `json:"concurrency"`
+    ContextSize           int  `json:"context_size"`
+    PromptSize            int  `json:"prompt_size"`
+    ResponseSize          int  `json:"response_size"`
+    IsContextPrefillPhase bool `json:"is_context_prefill_phase"`
+
+    PPThroughput      *LlamaBenchyMetric `json:"pp_throughput,omitempty"`       // prefill total t/s
+    PPReqThroughput   *LlamaBenchyMetric `json:"pp_req_throughput,omitempty"`   // prefill per-request t/s
+    TGThroughput      *LlamaBenchyMetric `json:"tg_throughput,omitempty"`       // generation total t/s
+    TGReqThroughput   *LlamaBenchyMetric `json:"tg_req_throughput,omitempty"`   // generation per-request t/s
+    PeakThroughput    *LlamaBenchyMetric `json:"peak_throughput,omitempty"`     // peak total t/s
+    PeakReqThroughput *LlamaBenchyMetric `json:"peak_req_throughput,omitempty"` // peak per-request t/s
+    TTFR              *LlamaBenchyMetric `json:"ttfr,omitempty"`                // time-to-first-response, ms
+    EstPPT            *LlamaBenchyMetric `json:"est_ppt,omitempty"`             // estimated pure processing time, ms
+    E2ETTFT           *LlamaBenchyMetric `json:"e2e_ttft,omitempty"`            // end-to-end TTFT, ms
+    // throughput_over_time and requests_throughput_over_time time-series
+    // arrays are present in the schema but skipped — bulky and unused.
+}
+
+type LlamaBenchyMetric struct {
+    Mean   float64   `json:"mean"`
+    Std    float64   `json:"std"`
+    Values []float64 `json:"values,omitempty"` // raw per-run values
 }
 ```
 
-A run carries `[]LlamaBenchyResult` instead of the previous single
-`LlamaBenchResult`. The legacy `LlamaBenchResult` type is removed
-along with `runner.runLlamaBench()`.
+A run carries `[]LlamaBenchyResult` (one entry per cell of the
+benchy-side matrix) instead of the previous single `LlamaBenchResult`.
+The legacy `LlamaBenchResult` type is removed along with
+`runner.runLlamaBench()`.
 
 ---
 
@@ -241,9 +287,10 @@ Additive (no removals):
 type BenchmarkRun struct {
     // ... existing fields ...
 
-    JobID         string         `json:"job_id"`         // every run belongs to one job
-    Build         BuildSnapshot  `json:"build"`          // full snapshot, not just IDs
+    JobID         string              `json:"job_id"`         // every run belongs to one job
+    Build         BuildSnapshot       `json:"build"`          // full snapshot, not just IDs
     LlamaBenchy   []LlamaBenchyResult `json:"llama_benchy,omitempty"`
+    BenchyCommand string              `json:"benchy_command,omitempty"` // exact uvx invocation, for disclosure
 
     // REMOVED: LlamaBench *LlamaBenchResult
 }
@@ -538,12 +585,16 @@ plus llama-benchy result rows. Columns prefixed by job context:
 ```
 job_id, job_name, model_id, model_name, quant, build_id, build_profile,
 git_ref, preset, source, prompt_tokens, gen_tokens, depth, concurrency,
-repetition, prompt_tps, gen_tps, peak_tps, ttft_ms, ttfr_ms,
-e2e_ttft_ms, total_ms
+repetition, pp_throughput, pp_throughput_std, tg_throughput,
+tg_throughput_std, peak_throughput, peak_throughput_std, ttft_ms,
+ttfr_ms, e2e_ttft_ms, total_ms
 ```
 
-`source` is `"internal"` or `"benchy"`. Fields irrelevant to a row's
-source are blank.
+`source` is `"internal"` or `"benchy"`. For benchy rows, throughput
+columns carry the `BenchmarkMetric.mean` and `_std` carries the
+standard deviation; raw per-run values from `BenchmarkMetric.values`
+are not exported in CSV (use JSON export for round-trip fidelity).
+Fields irrelevant to a row's source are blank.
 
 ### CSV — per-cell summary (`scope=summary`)
 

--- a/plan/batch-benchmarks.md
+++ b/plan/batch-benchmarks.md
@@ -1,0 +1,672 @@
+# Batch Benchmark Jobs
+
+Refactor the benchmarks system around **jobs**: named, persistent batch
+runs that sweep a Cartesian matrix of `{models} × {builds} × {presets}`,
+capture full reproducibility context, and surface results grouped by
+job. Replace `llama-bench` with **llama-benchy** to remove the
+multi-file (sharded) GGUF limitation and gain a benchmarking path that
+can later be pointed at non-llama.cpp inference engines. Disclose the
+prompts and commands the tool runs.
+
+---
+
+## Goals
+
+1. **Define jobs** — name, description, multi-select models, builds, and
+   presets; one optional set of config overrides applied to every cell.
+2. **Run jobs serially** — only one job runs at a time, cells run one
+   after another within a job, continue-on-failure with explicit retry.
+3. **Snapshot fully** — every run records the build (incl. CMake flags,
+   git ref, vendor), the model config in effect, and the GPU state at
+   benchmark time, so deleting the build/model later does not lose
+   context.
+4. **Replace `llama-bench` with llama-benchy** — API-only tool, MIT
+   licensed, works with sharded GGUFs, OpenAI-compatible so it can be
+   pointed at vLLM/SGLang/etc. in the future.
+5. **Expose what we run** — the "About benchmarks" modal shows the
+   internal prompt text, repetition prefix logic, and the exact
+   llama-benchy command line generated for each cell.
+6. **Group the page by job** — backfill all existing runs into a
+   synthetic "Ad-Hoc Runs" job; drop the standalone single-run path
+   going forward (a "Quick benchmark" still works — it just auto-creates
+   a 1-cell job).
+7. **Compare across jobs** — selection works within a job and across
+   jobs. Wider model column, native tooltips, sortable.
+8. **Export** — CSV (per-cell rows), CSV (per-cell summaries), and JSON,
+   per job and per arbitrary selection.
+
+---
+
+## Non-goals
+
+- Editable prompts in the UI (planned for a follow-up).
+- Parameter sweeps, e.g. testing the same model with `ngl=99` vs
+  `ngl=50` as separate cells — first pass uses one override set per job.
+- Concurrent jobs, parallel cells, distributed orchestration.
+- Auto-building missing build variants when a job references a build
+  that hasn't been compiled yet.
+
+---
+
+## llama-benchy
+
+Repository: <https://github.com/eugr/llama-benchy> (MIT). Python tool,
+runs via `uvx llama-benchy …` (no install if `uv` is present) or
+`pip install llama-benchy`. Hits any OpenAI-compatible endpoint
+(`/v1/models`, `/v1/chat/completions`) — we point it at our own router.
+
+### Why replace, not coexist
+
+- **Multi-file model support** — llama-benchy never touches a GGUF
+  file; it only sends API requests, so sharded models work without any
+  awareness on our side.
+- **Engine-agnostic** — same tool can later benchmark vLLM, SGLang, or
+  any OpenAI-compatible endpoint.
+- **Concurrency support** — exposes `t/s (total)` and `t/s (req)` under
+  load (out of scope for the first pass, but the data path is there).
+- **Standard-ish output** — JSON schema documented upstream; fields
+  align with what we already capture.
+
+### Runtime requirement
+
+`uv` must be available on `PATH` in whatever environment runs llama-toolchest:
+
+- **Container installs** — `uv` is baked into the runtime images. Add a
+  short `RUN curl -LsSf https://astral.sh/uv/install.sh | sh` (or distro
+  package where available) to `Dockerfile.cpu`, `Dockerfile.cuda`, and
+  `Dockerfile.rocm`, with the resulting binary placed on the system
+  `PATH` (e.g. `/usr/local/bin/uv`). No prompting at container build time.
+- **Host installs** — `setup.sh install --host` checks for `uv` as part
+  of the host prereq pass and, when missing, prompts with the standard
+  `prompt_confirm` flow (same pattern as the existing build-toolchain
+  prompt) before running the installer. A `--no-uv` (or equivalent) opt-out
+  isn't needed first pass; users can decline at the prompt.
+- **Runtime detection** — at startup the benchmark subsystem still calls
+  `uv --version`; if missing, `benchy-*` presets are disabled in the UI
+  with an inline hint pointing at `setup.sh install --host` (or
+  re-pulling the container image). `internal-*` presets keep working.
+
+`README.md` host-requirements section gets a `uv` bullet next to the
+existing entries.
+
+### Invocation
+
+```
+uvx llama-benchy \
+  --base-url   http://127.0.0.1:{routerPort}/v1 \
+  --api-key    EMPTY \
+  --model      {hfRepoIDForTokenizer} \
+  --served-model-name {router model ID} \
+  --pp         {prompt token sizes...} \
+  --tg         {gen tokens} \
+  --runs       {repetitions} \
+  --concurrency {concurrency levels...} \
+  --format     json \
+  --save-result {tempfile.json}
+```
+
+We capture the JSON file llama-benchy writes (rather than parsing
+stdout, which is markdown by default).
+
+### Result fields captured
+
+Mapped from llama-benchy's JSON output (see upstream
+`schemas/benchmark_report_schema.json`):
+
+```go
+type LlamaBenchyResult struct {
+    Test           string   `json:"test"`            // e.g. "pp2048", "tg32"
+    PromptTokens   int      `json:"pp"`
+    GenTokens      int      `json:"tg"`
+    Depth          int      `json:"depth"`
+    Concurrency    int      `json:"concurrency"`
+    AvgTokPerSec   float64  `json:"t_s"`             // "t/s"
+    PeakTokPerSec  float64  `json:"peak_t_s"`        // "peak t/s"
+    TTFRMs         float64  `json:"ttfr_ms"`         // time-to-first-response
+    EstPPTMs       float64  `json:"est_ppt_ms"`      // estimated prompt-processing
+    E2ETTFTMs      float64  `json:"e2e_ttft_ms"`     // end-to-end TTFT
+    TotalTokPerSec float64  `json:"t_s_total"`       // present when concurrency>1
+    PerReqTokPerSec float64 `json:"t_s_req"`         // present when concurrency>1
+}
+```
+
+A run carries `[]LlamaBenchyResult` instead of the previous single
+`LlamaBenchResult`. The legacy `LlamaBenchResult` type is removed
+along with `runner.runLlamaBench()`.
+
+---
+
+## Internal benchmark — disclosure & new presets
+
+The internal API benchmark stays. The fixed prose passage in
+`runner.go:283` and the per-repetition prefix in
+`buildPrompt()` (`runner.go:285–302`) are now exposed verbatim in the
+"About benchmarks" modal, alongside the parameters for each preset and
+the llama-benchy command line each cell generates.
+
+### Preset list (after this change)
+
+| Preset key            | Source        | Prompt sizes        | Gen | Reps | Concurrency | Use case                           |
+|-----------------------|---------------|---------------------|-----|------|-------------|------------------------------------|
+| `internal-quick`      | internal API  | 256                 | 128 | 1    | 1           | Smoke test (~10s)                  |
+| `internal-standard`   | internal API  | 128, 512, 2048      | 128 | 3    | 1           | Default real-prose run (~1 min)    |
+| `internal-thorough`   | internal API  | 128, 512, 2048, 8192| 256 | 5    | 1           | Long compare run (~5 min)          |
+| `internal-long-ctx`   | internal API  | 32768               | 512 | 1    | 1           | Stress KV / FA / quant on big ctx  |
+| `benchy-quick`        | llama-benchy  | 512                 | 32  | 1    | 1           | Smoke test, llama-benchy path      |
+| `benchy-standard`     | llama-benchy  | 2048                | 128 | 3    | 1           | Default benchy run                 |
+| `benchy-throughput`   | llama-benchy  | 2048                | 128 | 3    | 1, 4, 8 †   | Concurrency scaling                |
+
+† `benchy-throughput` always includes `concurrency=1` as a baseline
+because the model under test may not have multi-slot serving enabled.
+If the effective config (model's saved config + job overrides) reports
+fewer parallel slots than a higher level (e.g. `--parallel 1` while
+`concurrency=4` is requested), the runner skips that level for the cell
+and records a per-result note rather than failing the cell. The C=1
+result is always produced.
+
+The `internal-*` presets no longer invoke `llama-bench` — that integration
+is removed entirely. The `benchy-*` presets replace it, plus add
+options that didn't exist before (long context, concurrency).
+
+`internal-synthetic` (random-token prompts) was considered and dropped:
+the existing per-rep prefix already defeats prefix caching, and the
+prose-vs-random distinction in tok/s is small enough that it's not worth
+maintaining a fourth internal variant.
+
+---
+
+## Data model changes
+
+### New: `BenchmarkJob`
+
+```go
+type BenchmarkJob struct {
+    ID          string    `json:"id"`
+    Name        string    `json:"name"`
+    Description string    `json:"description,omitempty"`
+    Kind        string    `json:"kind"`        // "batch" | "ad-hoc"
+    Status      string    `json:"status"`      // "pending","running","completed","failed","canceled"
+
+    CreatedAt   time.Time `json:"created_at"`
+    StartedAt   time.Time `json:"started_at,omitempty"`
+    FinishedAt  time.Time `json:"finished_at,omitempty"`
+
+    // Definition (immutable after first run)
+    ModelIDs    []string  `json:"model_ids"`
+    BuildIDs    []string  `json:"build_ids"`
+    Presets     []string  `json:"presets"`
+    Overrides   *ConfigOverrides `json:"overrides,omitempty"`
+
+    // Expanded matrix
+    Cells       []JobCell `json:"cells"`
+}
+
+// ConfigOverrides — pointer fields so nil = "use saved model config".
+// Whatever is non-nil overrides the model's saved ModelConfig for every
+// cell that uses that model.
+type ConfigOverrides struct {
+    GPULayers      *int     `json:"gpu_layers,omitempty"`
+    ContextSize    *int     `json:"context_size,omitempty"`
+    Threads        *int     `json:"threads,omitempty"`
+    FlashAttention *bool    `json:"flash_attention,omitempty"`
+    KVCacheQuant   *string  `json:"kv_cache_quant,omitempty"`
+    DirectIO       *bool    `json:"direct_io,omitempty"`
+    GPUAssign      *string  `json:"gpu_assign,omitempty"`
+    TensorSplit    *string  `json:"tensor_split,omitempty"`
+    SpecType       *string  `json:"spec_type,omitempty"`
+    DraftModelPath *string  `json:"draft_model_path,omitempty"`
+    Temperature    *float64 `json:"temperature,omitempty"`
+    TopP           *float64 `json:"top_p,omitempty"`
+    TopK           *int     `json:"top_k,omitempty"`
+    MinP           *float64 `json:"min_p,omitempty"`
+    RepeatPenalty  *float64 `json:"repeat_penalty,omitempty"`
+}
+
+type JobCell struct {
+    ModelID         string `json:"model_id"`
+    BuildID         string `json:"build_id"`
+    Preset          string `json:"preset"`
+    Status          string `json:"status"`            // "pending","running","completed","failed","skipped"
+    Attempt         int    `json:"attempt"`
+    BenchmarkRunID  string `json:"benchmark_run_id,omitempty"` // set when run starts
+    Error           string `json:"error,omitempty"`
+}
+```
+
+### Changes to `BenchmarkRun`
+
+Additive (no removals):
+
+```go
+type BenchmarkRun struct {
+    // ... existing fields ...
+
+    JobID         string         `json:"job_id"`         // every run belongs to one job
+    Build         BuildSnapshot  `json:"build"`          // full snapshot, not just IDs
+    LlamaBenchy   []LlamaBenchyResult `json:"llama_benchy,omitempty"`
+
+    // REMOVED: LlamaBench *LlamaBenchResult
+}
+
+type BuildSnapshot struct {
+    ID         string            `json:"id"`
+    Tag        string            `json:"tag"`
+    Profile    string            `json:"profile"`     // rocm | cuda | vulkan | cpu
+    Vendor     string            `json:"vendor"`      // derived; same set as profile
+    GitSHA     string            `json:"git_sha"`
+    GitRef     string            `json:"git_ref"`
+    CMakeFlags map[string]string `json:"cmake_flags"`
+    BinaryPath string            `json:"binary_path"`
+}
+```
+
+Existing `BuildID`, `BuildRef`, `BuildProfile` fields on `BenchmarkRun`
+stay (read by old code paths) but become redundant with `Build.*`. New
+code reads from `Build`. A future cleanup can drop the flat fields.
+
+### Storage schema migration
+
+`{dataDir}/config/benchmarks.json` switches from a bare array to a
+versioned wrapper:
+
+```json
+{
+  "version": 2,
+  "jobs": [ ... ],
+  "runs": [ ... ]
+}
+```
+
+Migration on load (in `Store.Load`):
+
+1. If file is a JSON array (v1), wrap it: `{version:2, jobs:[adhoc], runs: <array>}`.
+2. Synthesize one `BenchmarkJob{ID:"adhoc", Kind:"ad-hoc", Name:"Ad-Hoc Runs", Status:"completed"}`.
+3. Backfill `JobID="adhoc"` on every run that lacks one.
+4. Backfill `Build` snapshot best-effort by looking up `BuildID` in the
+   builder; if the build is gone, fill `Build.ID/Profile/GitRef` from
+   the existing flat fields, leave `CMakeFlags` empty.
+5. Drop `LlamaBench` (legacy field) — it stays in JSON but is no longer
+   read; new code reads `LlamaBenchy`. Old data is preserved as raw
+   bytes for the detail view to render in a "Legacy llama-bench result"
+   section if present.
+6. Save back in v2 format.
+
+---
+
+## Job execution
+
+### Queue and serialization
+
+A package-level `JobQueue` enforces "one job at a time":
+
+```go
+type JobQueue struct {
+    mu      sync.Mutex
+    current *BenchmarkJob
+    runner  *Runner
+}
+
+func (q *JobQueue) Submit(job *BenchmarkJob) error  // 409 if a job is running
+func (q *JobQueue) Cancel(jobID string) error       // best-effort
+func (q *JobQueue) Status() (*BenchmarkJob, bool)   // current running job
+```
+
+Cells within a job are processed strictly sequentially in the order
+`builds → models → presets` (see "Build switching" below — this ordering
+exists specifically to minimize router restarts).
+
+### Per-cell flow
+
+For each cell:
+
+1. Mark cell `running`, persist.
+2. Resolve build's `llama-server` binary; switch the active build if it
+   differs from the previous cell (re-launch the router with the cell's
+   build binary). This is the only step that crosses cell boundaries.
+3. Apply the job's `Overrides` on top of the model's saved config to
+   get an effective `ConfigSnapshot`. This snapshot is stored on the run.
+4. Create a `BenchmarkRun{JobID, ModelID, Config, Build: snapshot}`,
+   set status `running`, save, set `cell.BenchmarkRunID`.
+5. Drive the run via the existing `runner.RunConfig` for `internal-*`
+   presets, or via a new `runLlamaBenchy()` for `benchy-*` presets.
+6. On success, mark run `completed`, mark cell `completed`. On error,
+   mark run `failed` with error message, mark cell `failed`, **continue
+   to the next cell** (do not abort the job).
+7. After the last cell, mark job `completed` if any cell completed,
+   `failed` if all cells failed.
+
+### Retry
+
+`POST /api/benchmark-jobs/{id}/retry-failed` re-queues only cells with
+`status="failed"`, increments their `Attempt`, and runs them through
+the same flow. The previous failed `BenchmarkRun` records are kept (a
+new run is created on retry); the cell's `BenchmarkRunID` is updated to
+the latest attempt.
+
+### Cancel
+
+Best-effort: stops accepting new cells, signals the in-flight cell's
+context to cancel, marks remaining cells `skipped`. The in-flight run is
+marked `failed` with `error="canceled"`.
+
+### Build switching
+
+The router currently runs one build at a time. Switching builds means
+restarting the router process with a different binary, which is the most
+expensive transition in a job (multi-second restart + model unload).
+**Builds are therefore the outermost dimension of cell ordering**: run
+every selected `(model × preset)` combination against build A, then
+restart the router onto build B and run every `(model × preset)`
+against B, and so on. Iteration order is strictly
+`builds → models → presets`, so each build switch happens at most once
+per build per job. Each switch waits for the router to come up before
+the next cell starts.
+
+---
+
+## API endpoints
+
+### Jobs
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`    | `/api/benchmark-jobs` | List jobs (HTMX or JSON) |
+| `POST`   | `/api/benchmark-jobs` | Create + start a job |
+| `GET`    | `/api/benchmark-jobs/{id}` | Job detail + cells |
+| `DELETE` | `/api/benchmark-jobs/{id}?runs=cascade\|orphan` | Delete job; `cascade` (default) deletes its runs, `orphan` reassigns them to the synthetic `adhoc` job |
+| `POST`   | `/api/benchmark-jobs/{id}/cancel` | Cancel running job |
+| `POST`   | `/api/benchmark-jobs/{id}/retry-failed` | Re-run failed cells |
+| `GET`    | `/api/benchmark-jobs/{id}/progress` | SSE stream: cell-level + run-level updates |
+| `GET`    | `/api/benchmark-jobs/{id}/export?format=csv\|json&scope=cells\|summary` | Export |
+
+### Runs (existing, augmented)
+
+| Method | Path | Change |
+|--------|------|--------|
+| `GET`    | `/api/benchmarks` | Adds `?job=<id>`, `?scope=adhoc\|batch` filters |
+| `GET`    | `/api/benchmarks/compare` | Already accepts `?ids=`; no schema change, response gains `build` block |
+| `GET`    | `/api/benchmarks/export` | Adds `format=json` alongside existing CSV |
+
+### "About" disclosure endpoint (new)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/benchmarks/about` | Returns prompt text, repetition prefix template, preset table, and a per-preset example llama-benchy command line. Rendered into the "About benchmarks" modal. |
+
+---
+
+## UI
+
+### Benchmarks page redesign
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Benchmark Jobs                       [About] [+ New Job ▾] │
+│                                       (Quick / Batch)        │
+├──────────────────────────────────────────────────────────────┤
+│  ▶ Q4_K_M sweep across 3 builds        running   12/27 cells │
+│      Qwen3.5-27B, granite-4.0          rocm/cuda/vulkan     │
+│      started 4m ago                                          │
+│  ▼ KV-quant comparison                  completed  9/9 cells │
+│      Qwen3.5-27B  ·  rocm b8461  ·  3 presets               │
+│      ┌──────────────────────────────────────────────────┐   │
+│      │ Build × Preset matrix                            │   │
+│      │              std    long-ctx   benchy-std        │   │
+│      │  Q4_K_M       ✓ 48.2  ✓ 39.1   ✓ 51.0           │   │
+│      │  Q8_0         ✓ 31.7  ✗ OOM    ✓ 33.2           │   │
+│      └──────────────────────────────────────────────────┘   │
+│      [Compare selected] [Retry failed] [Export ▾] [Delete ▾] │
+│      Delete menu: "Delete job and its runs" / "Delete job, keep runs (move to Ad-Hoc)" │
+│  ▶ Ad-Hoc Runs                          n/a       142 runs  │
+│      (legacy + quick-benchmark runs)                         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Each job row is collapsible. The "Ad-Hoc Runs" job is a synthetic
+container that holds all pre-migration runs and any future runs created
+via the Quick form.
+
+### New job form (modal or page)
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  New Batch Job                                              │
+│                                                              │
+│  Name        [_______________________________________]      │
+│  Description [_______________________________________]      │
+│                                                              │
+│  Models      ☑ Qwen3.5-27B Q4_K_M                          │
+│              ☑ Qwen3.5-27B Q8_0                            │
+│              ☑ DeepSeek-R1-0528-Qwen3-8B                   │
+│              ☐ granite-4.0                                  │
+│              [Select all] [Clear]                           │
+│                                                              │
+│  Builds      ☑ b8461 (rocm)                                │
+│              ☑ b8461 (cuda)                                │
+│              ☑ b8461 (vulkan)                              │
+│              ☐ b8390 (rocm)                                │
+│                                                              │
+│  Presets     ☑ internal-standard                           │
+│              ☑ benchy-standard                             │
+│              ☐ internal-long-ctx                           │
+│              ☐ benchy-throughput                           │
+│                                                              │
+│  ▼ Overrides (apply to all cells; leave blank to use       │
+│    each model's saved settings)                             │
+│      GPU layers    [   ]                                    │
+│      Context size  [   ]                                    │
+│      Flash attn    ( ) on  ( ) off  (•) inherit            │
+│      KV quant      [_____ ▾]                                │
+│      ...                                                    │
+│                                                              │
+│  Matrix preview: 3 models × 3 builds × 2 presets = 18 cells │
+│                                                              │
+│                                  [Cancel] [Create & Start]  │
+└────────────────────────────────────────────────────────────┘
+```
+
+The matrix preview updates live. A "deselect cells" grid (advanced) is
+out of scope; users prune by adjusting the multi-selects.
+
+### Quick benchmark (preserves existing UX)
+
+The existing form (model dropdown + preset dropdown + Run) becomes a
+"Quick Benchmark" entry that creates a 1-cell job with `Kind="batch"`,
+`Name="Quick: {model} / {preset}"`. The single-run code path is
+removed; it's now a thin wrapper that builds a 1-cell job spec.
+
+### Compare view fixes
+
+In `web/templates/partials/benchmark_compare.html`:
+
+1. Bump model-name column from `width:150px` → `width:280px` at
+   lines 18, 35, 52.
+2. Add `title="{{ .ModelFullName }}"` on the truncating div for native
+   tooltips.
+3. Add a `Build` column in the details table: shows
+   `{Build.Profile} · {Build.GitRef}` with `title` showing the full
+   `Tag` and `GitSHA`.
+4. Add a sort control above the bar charts:
+   `Sort by: [Name | Gen tok/s ▼ | Prompt tok/s | TTFT]`. Default:
+   Gen tok/s descending. Sort is client-side (no server round-trip),
+   re-orders both bar charts and the details table.
+
+Build CMake flags / full hardware snapshot are **not** shown in the
+compare view — they're available in the per-run detail view and JSON
+export only.
+
+### Detail view additions
+
+`benchmark_detail.html` gains a "Build" section:
+
+```
+Build
+  Tag         b8461
+  Profile     rocm
+  Git ref     b8461 (sha: a1b2c3d...)
+  CMake flags GGML_HIPBLAS=ON
+              GGML_BLAS=OFF
+              CMAKE_BUILD_TYPE=Release
+```
+
+And a "Command" section showing the exact llama-benchy invocation that
+produced the result (for benchy presets) or the prompt-construction
+parameters (for internal presets).
+
+### "About benchmarks" modal
+
+Reworked to render data from `GET /api/benchmarks/about`:
+
+1. **Internal benchmark** — full prompt passage in a `<pre>` block, the
+   per-rep prefix template, and the chars-per-token target.
+2. **llama-benchy** — short paragraph linking upstream, plus the exact
+   command line we generate for each `benchy-*` preset.
+3. **Preset table** — same data as the table in this doc, but rendered
+   live so it stays in sync if presets change.
+4. **Metrics glossary** — PP t/s, TG t/s, TTFT, TTFR (new), peak t/s
+   (new), e2e_ttft (new).
+
+---
+
+## Export formats
+
+### CSV — per-cell rows (`scope=cells`)
+
+One row per `BenchmarkResult` (existing internal-benchmark row format),
+plus llama-benchy result rows. Columns prefixed by job context:
+
+```
+job_id, job_name, model_id, model_name, quant, build_id, build_profile,
+git_ref, preset, source, prompt_tokens, gen_tokens, depth, concurrency,
+repetition, prompt_tps, gen_tps, peak_tps, ttft_ms, ttfr_ms,
+e2e_ttft_ms, total_ms
+```
+
+`source` is `"internal"` or `"benchy"`. Fields irrelevant to a row's
+source are blank.
+
+### CSV — per-cell summary (`scope=summary`)
+
+One row per cell with averaged stats — handy for spreadsheets.
+
+### JSON
+
+Full `BenchmarkJob` with all `Cells`, all linked `BenchmarkRun` objects
+(including `Build` snapshot, `Config` snapshot, `GPUs`, raw results,
+llama-benchy results). Self-contained; can be re-imported in the future.
+
+---
+
+## Modified / new files
+
+### New
+- `internal/benchmark/job.go` — `BenchmarkJob`, `JobCell`, `ConfigOverrides`, queue
+- `internal/benchmark/job_runner.go` — per-cell orchestration, build switching, retry
+- `internal/benchmark/benchy.go` — `runLlamaBenchy()`, `LlamaBenchyResult`, JSON parsing
+- `internal/api/bench_jobs.go` — HTTP handlers for `/api/benchmark-jobs/*`
+- `web/templates/partials/job_list.html`, `job_detail.html`, `job_form.html`, `job_progress.html`
+
+### Modified
+- `internal/benchmark/benchmark.go` — add `JobID`, `Build` snapshot to `BenchmarkRun`; v2 schema with migration; remove `LlamaBenchResult`
+- `internal/benchmark/runner.go` — drop `runLlamaBench()`, drop llama-bench from preset definitions
+- `internal/api/server.go` — register new routes and templates; serve `/api/benchmarks/about`
+- `internal/api/bench.go` — add filters to list endpoint, JSON export option
+- `web/templates/benchmarks.html` — replace top-level UI with jobs list; modal sources data from `/api/benchmarks/about`
+- `web/templates/partials/benchmark_compare.html` — column width, sort controls, build column, tooltips
+- `web/templates/partials/benchmark_detail.html` — build section, command section, legacy-llama-bench fallback render
+- `web/templates/partials/benchmark_form.html` — becomes the "Quick Benchmark" form that creates a 1-cell job
+- `Dockerfile.cpu`, `Dockerfile.cuda`, `Dockerfile.rocm` — install `uv` into each runtime image so `benchy-*` presets work out of the box in container mode
+- `setup.sh` / `scripts/lib/host.sh` — add `uv` to the host prereq check; offer to install via the upstream installer (`prompt_confirm` flow, mirroring existing toolchain prompts)
+- `README.md` — add `uv` to host requirements
+
+### Removed
+- `runner.go`'s `runLlamaBench()`, `parseLlamaBenchOutput()`, `findLlamaBench()`
+
+---
+
+## Implementation order
+
+1. **llama-benchy integration first, no jobs yet.** Add `benchy.go`,
+   wire it into the existing single-run path under a new
+   `benchy-quick` / `benchy-standard` preset. Confirm sharded models
+   benchmark cleanly. Disclose command in the modal.
+2. **Drop llama-bench.** Remove `runLlamaBench` and llama-bench preset
+   data. Migration for existing v1 data (`LlamaBench` field hidden but
+   not deleted from JSON for legacy detail view).
+3. **Build snapshot.** Add `Build` field to `BenchmarkRun`, populate at
+   start time, render in detail view. Migrate existing runs in v1→v2.
+4. **Job model & storage.** Types, schema v2 migration with synthetic
+   "Ad-Hoc Runs" job, `Store` CRUD for jobs.
+5. **Job runner & queue.** Sequential per-cell execution, build
+   switching, continue-on-fail, retry-failed, cancel.
+6. **Job API endpoints** + SSE progress.
+7. **UI: jobs list, job detail, job form.** Backfilled "Ad-Hoc Runs"
+   group renders as the existing list view inside that pseudo-job.
+8. **Compare view fixes** (column width, tooltips, sort, build column).
+   Decoupled from the rest — could ship earlier as a small PR.
+9. **Exports** (CSV per-cell, CSV summary, JSON).
+10. **About modal rework** — server-side render of presets + commands.
+
+Steps 1, 2, 8 can ship independently. Steps 3–7 are tightly coupled.
+
+---
+
+## Verification
+
+1. `go build ./...` clean compile after each step.
+2. `uv` missing → benchy preset shows clear error in UI, internal
+   presets still work.
+3. Existing v1 `benchmarks.json` loads cleanly, all runs appear under
+   "Ad-Hoc Runs", legacy llama-bench data still renders in detail view.
+4. Create a 2×2×2 job (2 models × 2 builds × 2 presets = 8 cells), run
+   to completion, confirm all 8 runs persisted with full Build snapshot.
+5. Force one cell to fail (e.g. point a model at an unavailable build);
+   confirm job continues, Retry Failed re-runs only that cell.
+6. Cancel a running job mid-cell; confirm in-flight run marked failed,
+   remaining cells skipped, no router process leak.
+7. Run a sharded GGUF (e.g. a multi-shard 70B Q4) under
+   `benchy-standard`. Confirm results captured (this is the headline
+   reason for the swap).
+8. Concurrent job submissions → second submission rejected with 409.
+9. Compare view: select 4 runs from 2 different jobs, confirm rendering
+   with full model names visible, hover shows tooltip, sort orders
+   work, build column populated.
+10. Export CSV (cells + summary) and JSON for one job; confirm fields
+    match the schema in this doc and JSON round-trips through a
+    re-import test.
+11. Quick benchmark form still works end-to-end and produces a 1-cell
+    job under the user's name.
+12. Delete a job with `runs=cascade` → job and all linked runs gone.
+    Delete a different job with `runs=orphan` → job gone, its runs now
+    appear under "Ad-Hoc Runs" with `JobID="adhoc"`.
+13. Build a container image fresh; confirm `uv --version` succeeds inside
+    the container and `benchy-*` presets run without further setup.
+14. On a host with `uv` absent, run `setup.sh install --host`; confirm
+    the prereq prompt appears, accepting it installs `uv`, declining
+    leaves `uv` missing and disables `benchy-*` presets at runtime with
+    the documented hint.
+
+---
+
+## Resolved decisions
+
+These were open questions in an earlier draft; the answers are now folded
+into the plan body and listed here for traceability.
+
+- **Delete-job cascade** — Both options exposed. The DELETE endpoint
+  takes `?runs=cascade|orphan`; the UI presents a two-option Delete
+  menu (delete with runs, or keep runs and move them to "Ad-Hoc Runs").
+  See API endpoints + UI sections.
+- **`uv` install bootstrap** — Containers ship `uv` baked into the
+  runtime images. Host installs check for it during `setup.sh` and offer
+  to install via the upstream installer with a `prompt_confirm`. See
+  llama-benchy → Runtime requirement.
+- **Preset names** — `internal-*` / `benchy-*` prefix scheme retained.
+- **`benchy-throughput` concurrency levels** — Default `[1, 4, 8]` with
+  `concurrency=1` always included as a baseline; higher levels are
+  silently skipped per-cell when the effective config can't honour them.
+  See preset table footnote.
+- **Build switching cost** — Builds are the outermost iteration
+  dimension specifically to minimize router restarts (run every model
+  against build A, restart, run every model against build B, …). See
+  "Build switching".

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -1,4 +1,56 @@
 {{define "content"}}
+<style>
+.job-list .job-row { border:1px solid var(--pico-muted-border-color); border-radius:0.25rem; padding:0.5rem 0.75rem; margin-bottom:0.5rem; background:var(--pico-card-background-color); }
+.job-list .job-row > summary { list-style:none; cursor:pointer; }
+.job-list .job-row > summary::marker, .job-list .job-row > summary::-webkit-details-marker { display:none; }
+.job-list .job-row > summary::before { content:"▸"; display:inline-block; width:1rem; color:var(--pico-muted-color); }
+.job-list .job-row[open] > summary::before { content:"▾"; }
+.job-row-line1 { display:inline-flex; gap:0.6rem; align-items:baseline; }
+.job-row-line2 { display:block; margin-left:1rem; margin-top:0.1rem; color:var(--pico-muted-color); }
+.job-status, .cell-status { display:inline-block; padding:0.05rem 0.4rem; border-radius:0.2rem; font-size:0.75rem; line-height:1.4; background:var(--pico-muted-border-color); color:var(--pico-color); text-transform:uppercase; letter-spacing:0.03em; }
+.status-running   { background:#3b82f6; color:#fff; }
+.status-completed { background:#22c55e; color:#fff; }
+.status-failed    { background:var(--pico-del-color); color:#fff; }
+.status-canceled, .status-skipped { background:var(--pico-muted-color); color:#fff; }
+.status-pending   { background:transparent; border:1px solid var(--pico-muted-border-color); color:var(--pico-muted-color); }
+.cell-failed-tag  { color:var(--pico-del-color); font-size:0.75rem; }
+.job-progress     { font-size:0.8rem; color:var(--pico-muted-color); }
+.job-detail-slot  { padding:0.5rem 0 0; }
+.job-meta, .job-desc { font-size:0.75rem; }
+</style>
+
+<article id="jobs-section">
+    <header>
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+            <span>Benchmark Jobs</span>
+            <span style="display:flex;gap:0.5rem;">
+                <button type="button" class="outline secondary"
+                        style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
+                        onclick="document.getElementById('bench-help').showModal();">?</button>
+                <button type="button" class="outline secondary"
+                        style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
+                        onclick="openJobForm()">+ New Batch Job</button>
+            </span>
+        </div>
+    </header>
+    <div id="job-list"
+         hx-get="/api/benchmark-jobs"
+         hx-trigger="load, jobChanged from:body"
+         hx-swap="innerHTML">
+        Loading…
+    </div>
+</article>
+
+<dialog id="job-form-modal" style="max-width:720px;">
+    <article>
+        <header>
+            <button type="button" aria-label="Close" rel="prev" onclick="closeJobForm();"></button>
+            New Batch Job
+        </header>
+        <div id="job-form-slot">Loading…</div>
+    </article>
+</dialog>
+
 <div id="benchmark-form"
      hx-get="/api/benchmarks/form"
      hx-trigger="load"
@@ -162,6 +214,112 @@ function filterBenchmarks(q) {
         var name = tb.dataset.model || '';
         tb.style.display = (tb._matches && !collapsed[name]) ? '' : 'none';
     });
+}
+
+// --- Job form modal ---
+function openJobForm() {
+    var modal = document.getElementById('job-form-modal');
+    var slot = document.getElementById('job-form-slot');
+    slot.innerHTML = 'Loading…';
+    fetch('/api/benchmark-jobs/form', {headers:{'HX-Request':'true'}})
+        .then(function(r){return r.text();})
+        .then(function(html){
+            slot.innerHTML = html;
+            htmx.process(slot);
+            updateMatrixCount();
+        });
+    modal.showModal();
+}
+function closeJobForm() {
+    document.getElementById('job-form-modal').close();
+}
+function updateMatrixCount() {
+    var form = document.getElementById('new-job-form');
+    if (!form) return;
+    var m = form.querySelectorAll('input[name=model]:checked').length;
+    var b = form.querySelectorAll('input[name=build]:checked').length;
+    var p = form.querySelectorAll('input[name=preset]:checked').length;
+    var preview = document.getElementById('job-matrix-preview');
+    var btn = document.getElementById('job-submit-btn');
+    if (m && b && p) {
+        preview.textContent = m+' models × '+b+' builds × '+p+' presets = '+(m*b*p)+' cells';
+        btn.disabled = false;
+    } else {
+        preview.textContent = 'Select models, builds, and presets to compute the matrix size.';
+        btn.disabled = true;
+    }
+}
+function readOverrides(form) {
+    var ov = {};
+    var num = function(name){ var v=form.elements[name].value; return v===''?null:parseInt(v,10); };
+    var bool = function(name){ var v=form.elements[name].value; return v===''?null:(v==='true'); };
+    var str = function(name){ var v=form.elements[name].value; return v===''?null:v; };
+    if (num('ov_gpu_layers')!==null)       ov.gpu_layers = num('ov_gpu_layers');
+    if (num('ov_context_size')!==null)     ov.context_size = num('ov_context_size');
+    if (num('ov_threads')!==null)          ov.threads = num('ov_threads');
+    if (bool('ov_flash_attention')!==null) ov.flash_attention = bool('ov_flash_attention');
+    if (str('ov_kv_cache_quant')!==null)   ov.kv_cache_quant = str('ov_kv_cache_quant');
+    if (bool('ov_direct_io')!==null)       ov.direct_io = bool('ov_direct_io');
+    if (str('ov_gpu_assign')!==null)       ov.gpu_assign = str('ov_gpu_assign');
+    if (str('ov_tensor_split')!==null)     ov.tensor_split = str('ov_tensor_split');
+    if (str('ov_spec_type')!==null)        ov.spec_type = str('ov_spec_type');
+    return Object.keys(ov).length ? ov : null;
+}
+function submitNewJob() {
+    var form = document.getElementById('new-job-form');
+    var err = document.getElementById('job-form-error');
+    err.style.display = 'none';
+    var picked = function(name){ return Array.from(form.querySelectorAll('input[name='+name+']:checked')).map(function(c){return c.value;}); };
+    var payload = {
+        name: form.elements.name.value.trim(),
+        description: form.elements.description.value.trim(),
+        model_ids: picked('model'),
+        build_ids: picked('build'),
+        presets: picked('preset'),
+        overrides: readOverrides(form),
+    };
+    fetch('/api/benchmark-jobs', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)})
+        .then(function(r){
+            if (r.status === 201) {
+                closeJobForm();
+                document.body.dispatchEvent(new CustomEvent('jobChanged'));
+                return;
+            }
+            return r.text().then(function(t){ throw new Error('HTTP '+r.status+': '+t); });
+        })
+        .catch(function(e){ err.textContent = e.message; err.style.display = ''; });
+}
+
+// --- Job actions ---
+function cancelJob(id) {
+    if (!confirm('Cancel job '+id+'?')) return;
+    fetch('/api/benchmark-jobs/'+id+'/cancel', {method:'POST'}).then(function(){
+        document.body.dispatchEvent(new CustomEvent('jobChanged'));
+    });
+}
+function retryFailed(id) {
+    fetch('/api/benchmark-jobs/'+id+'/retry-failed', {method:'POST'}).then(function(r){
+        if (!r.ok) { return r.text().then(function(t){alert(t);}); }
+        document.body.dispatchEvent(new CustomEvent('jobChanged'));
+    });
+}
+function deleteJob(id, disposition) {
+    var msg = disposition==='cascade' ? 'Delete job '+id+' AND its runs?' : 'Delete job '+id+' but keep runs (move to Ad-Hoc)?';
+    if (!confirm(msg)) return;
+    fetch('/api/benchmark-jobs/'+id+'?runs='+disposition, {method:'DELETE'}).then(function(r){
+        if (!r.ok) { return r.text().then(function(t){alert(t);}); }
+        document.body.dispatchEvent(new CustomEvent('jobChanged'));
+        document.body.dispatchEvent(new CustomEvent('benchmarkChanged'));
+    });
+}
+function compareSelectedCells(btn) {
+    var checks = btn.closest('.job-detail').querySelectorAll('.cell-check:checked');
+    if (checks.length < 2) { alert('Select at least 2 cells to compare.'); return; }
+    var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
+    var view = document.getElementById('comparison-view');
+    fetch('/api/benchmarks/compare?ids='+ids, {headers:{'HX-Request':'true'}})
+        .then(function(r){return r.text();})
+        .then(function(h){ view.innerHTML = h; view.scrollIntoView({behavior:'smooth'}); });
 }
 
 (function() {

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -57,9 +57,6 @@
      hx-swap="innerHTML">
 </div>
 
-<div id="benchmark-progress"
-     style="padding:0.75rem 1rem;border-radius:0.25rem;margin-bottom:1rem;display:none;border:1px solid var(--pico-muted-border-color);"></div>
-
 <article>
     <header>
         <div style="display:flex;justify-content:space-between;align-items:center;">
@@ -322,32 +319,5 @@ function compareSelectedCells(btn) {
         .then(function(h){ view.innerHTML = h; view.scrollIntoView({behavior:'smooth'}); });
 }
 
-(function() {
-    var pollTimer = null;
-    document.body.addEventListener('benchmarkStarted', function(e) {
-        var id = e.detail && e.detail.id;
-        if (!id) return;
-        var el = document.getElementById('benchmark-progress');
-        el.style.display = '';
-        // Clear any existing poll
-        if (pollTimer) clearInterval(pollTimer);
-        pollTimer = setInterval(function() {
-            fetch('/api/benchmarks/' + id + '/progress', {headers: {'HX-Request': 'true'}})
-                .then(function(r) { return r.text(); })
-                .then(function(html) {
-                    el.innerHTML = html;
-                    // Check if done
-                    if (html.indexOf('complete') !== -1 || html.indexOf('failed') !== -1) {
-                        clearInterval(pollTimer);
-                        pollTimer = null;
-                        // Refresh the list
-                        htmx.ajax('GET', '/api/benchmarks', {target: '#benchmark-list', swap: 'innerHTML'});
-                        // Hide progress after a moment
-                        setTimeout(function() { el.style.display = 'none'; }, 5000);
-                    }
-                });
-        }, 2000);
-    });
-})();
 </script>
 {{end}}

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -35,7 +35,7 @@
     </header>
     <div id="job-list"
          hx-get="/api/benchmark-jobs"
-         hx-trigger="load, jobChanged from:body, every 5s"
+         hx-trigger="load, jobChanged from:body"
          hx-swap="innerHTML">
         Loading…
     </div>
@@ -215,38 +215,6 @@ function filterBenchmarks(q) {
         tb.style.display = (tb._matches && !collapsed[name]) ? '' : 'none';
     });
 }
-
-// --- Preserve job-row expansion state across list refreshes (the list
-//     polls itself every 5s and also re-fetches on jobChanged events).
-//     Without this, the user's expanded view collapses every poll cycle.
-(function() {
-    var openSet = new Set();
-    document.body.addEventListener('htmx:beforeSwap', function(e) {
-        var t = e.detail && e.detail.target;
-        if (t && t.id === 'job-list') {
-            openSet.clear();
-            t.querySelectorAll('details.job-row[open]').forEach(function(d) {
-                openSet.add(d.dataset.jobId);
-            });
-        }
-    });
-    document.body.addEventListener('htmx:afterSwap', function(e) {
-        var t = e.detail && e.detail.target;
-        if (t && t.id === 'job-list') {
-            t.querySelectorAll('details.job-row').forEach(function(d) {
-                if (!openSet.has(d.dataset.jobId)) return;
-                d.open = true;
-                d.dataset.loaded = '1';
-                var slot = d.querySelector('.job-detail-slot');
-                if (!slot) return;
-                // Don't rely on the brand-new slot having its hx-trigger
-                // wired up yet — fetch directly via the URL on the slot.
-                var url = slot.getAttribute('hx-get');
-                if (url) htmx.ajax('GET', url, {target: slot, swap: 'innerHTML'});
-            });
-        }
-    });
-})();
 
 // --- Job form modal ---
 function openJobForm() {

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -143,9 +143,10 @@ function compareSelectedRuns(btn) {
     if (checks.length < 2) { alert('Select at least 2 benchmarks to compare.'); return; }
     var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
     var view = document.getElementById('comparison-view');
-    fetch('/api/benchmarks/compare?ids='+ids, {headers:{'HX-Request':'true'}})
-        .then(function(r){return r.text();})
-        .then(function(h){ view.innerHTML = h; view.scrollIntoView({behavior:'smooth'}); });
+    // Use htmx.ajax (not raw fetch + innerHTML) so the inline <script> in
+    // the compare partial actually runs — innerHTML doesn't execute scripts.
+    htmx.ajax('GET', '/api/benchmarks/compare?ids='+ids, {target: view, swap: 'innerHTML'})
+        .then(function(){ view.scrollIntoView({behavior:'smooth'}); });
 }
 
 function exportSelectedRuns(btn) {
@@ -346,9 +347,8 @@ function compareSelectedCells(btn) {
     if (checks.length < 2) { alert('Select at least 2 cells to compare.'); return; }
     var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
     var view = document.getElementById('comparison-view');
-    fetch('/api/benchmarks/compare?ids='+ids, {headers:{'HX-Request':'true'}})
-        .then(function(r){return r.text();})
-        .then(function(h){ view.innerHTML = h; view.scrollIntoView({behavior:'smooth'}); });
+    htmx.ajax('GET', '/api/benchmarks/compare?ids='+ids, {target: view, swap: 'innerHTML'})
+        .then(function(){ view.scrollIntoView({behavior:'smooth'}); });
 }
 
 </script>

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -234,14 +234,15 @@ function filterBenchmarks(q) {
         var t = e.detail && e.detail.target;
         if (t && t.id === 'job-list') {
             t.querySelectorAll('details.job-row').forEach(function(d) {
-                if (openSet.has(d.dataset.jobId)) {
-                    d.open = true;
-                    if (!d.dataset.loaded) {
-                        d.dataset.loaded = '1';
-                        var slot = d.querySelector('.job-detail-slot');
-                        if (slot) htmx.trigger(slot, 'showJobDetail');
-                    }
-                }
+                if (!openSet.has(d.dataset.jobId)) return;
+                d.open = true;
+                d.dataset.loaded = '1';
+                var slot = d.querySelector('.job-detail-slot');
+                if (!slot) return;
+                // Don't rely on the brand-new slot having its hx-trigger
+                // wired up yet — fetch directly via the URL on the slot.
+                var url = slot.getAttribute('hx-get');
+                if (url) htmx.ajax('GET', url, {target: slot, swap: 'innerHTML'});
             });
         }
     });

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -26,7 +26,7 @@
             <span style="display:flex;gap:0.5rem;">
                 <button type="button" class="outline secondary"
                         style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
-                        onclick="document.getElementById('bench-help').showModal();">?</button>
+                        onclick="openBenchHelp()">?</button>
                 <button type="button" class="outline secondary"
                         style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
                         onclick="openJobForm()">+ New Batch Job</button>
@@ -58,44 +58,13 @@
      hx-swap="innerHTML">
 </div>
 
-<dialog id="bench-help" style="max-width:600px;">
+<dialog id="bench-help" style="max-width:720px;">
     <article>
         <header>
             <button type="button" aria-label="Close" rel="prev" onclick="this.closest('dialog').close();"></button>
             About Benchmarks
         </header>
-        <h5>What benchmarks measure</h5>
-        <p>Benchmarks send real chat completion requests to the running server and measure the response timings reported by llama.cpp. This captures true end-to-end performance including server overhead, GPU scheduling, and memory transfer.</p>
-
-        <h5>Metrics</h5>
-        <dl>
-            <dt><strong>PP t/s</strong> (Prompt Processing tokens/sec)</dt>
-            <dd>How fast the model reads and processes your input prompt. Higher is better. This is GPU compute-bound and benefits from batching.</dd>
-
-            <dt><strong>TG t/s</strong> (Token Generation tokens/sec)</dt>
-            <dd>How fast the model generates its response, token by token. This is the speed you feel during chat. Memory bandwidth-bound on GPU.</dd>
-
-            <dt><strong>TTFT</strong> (Time To First Token)</dt>
-            <dd>Wall-clock time from sending the request until the first response token appears. Lower is better. Includes prompt processing.</dd>
-        </dl>
-
-        <h5>Presets</h5>
-        <dl>
-            <dt><strong>Quick</strong> (~10 seconds)</dt>
-            <dd>Single test: 256 prompt tokens, 128 generated tokens, 1 repetition. Good for a fast sanity check.</dd>
-
-            <dt><strong>Standard</strong> (~2 minutes)</dt>
-            <dd>Tests 128, 512, and 2048 prompt tokens with 3 repetitions each. Also runs <code>llama-bench</code> for raw inference numbers without server overhead.</dd>
-
-            <dt><strong>Thorough</strong> (~10 minutes)</dt>
-            <dd>Tests 128, 512, 2048, and 8192 prompt tokens with 5 repetitions and 256 generated tokens. Includes <code>llama-bench</code>.</dd>
-        </dl>
-
-        <h5>llama-bench</h5>
-        <p>When included (Standard and Thorough presets), <code>llama-bench</code> runs the model directly without the HTTP server layer. This gives a performance ceiling — the fastest the model can run on your hardware. Comparing API results to llama-bench results shows how much overhead the server adds.</p>
-
-        <h5>Live Performance</h5>
-        <p>Live Performance (on the Server tab) passively captures timing data from every chat completion request made through the API — no explicit benchmark needed. It shows a rolling average of real-world performance across recent requests.</p>
+        <div id="bench-about-slot">Loading…</div>
     </article>
 </dialog>
 
@@ -247,6 +216,21 @@ function filterBenchmarks(input, q) {
         }
     });
 })();
+
+// --- About Benchmarks modal: lazy-loads its content on first open so
+//     the preset table + sample commands stay in sync with whatever the
+//     server is currently configured to do.
+function openBenchHelp() {
+    var dialog = document.getElementById('bench-help');
+    var slot = document.getElementById('bench-about-slot');
+    if (!slot.dataset.loaded) {
+        slot.dataset.loaded = '1';
+        fetch('/api/benchmarks/about', {headers:{'HX-Request':'true'}})
+            .then(function(r){ return r.text(); })
+            .then(function(html){ slot.innerHTML = html; });
+    }
+    dialog.showModal();
+}
 
 // --- Job form modal ---
 function openJobForm() {

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -149,13 +149,14 @@ function compareSelectedRuns(btn) {
         .then(function(){ view.scrollIntoView({behavior:'smooth'}); });
 }
 
-function exportSelectedRuns(btn) {
+function exportSelectedRuns(btn, format) {
     var root = benchContainer(btn);
     if (!root) return;
     var checks = root.querySelectorAll('.bench-check:checked');
     if (checks.length === 0) { alert('Select benchmarks to export.'); return; }
     var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
-    window.location = '/api/benchmarks/export?ids='+ids;
+    var fmt = format || 'csv';
+    window.location = '/api/benchmarks/export?ids=' + ids + '&format=' + fmt;
 }
 
 function deleteSelectedRuns(btn) {

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -35,7 +35,7 @@
     </header>
     <div id="job-list"
          hx-get="/api/benchmark-jobs"
-         hx-trigger="load, jobChanged from:body"
+         hx-trigger="load, jobChanged from:body, every 5s"
          hx-swap="innerHTML">
         Loading…
     </div>
@@ -215,6 +215,37 @@ function filterBenchmarks(q) {
         tb.style.display = (tb._matches && !collapsed[name]) ? '' : 'none';
     });
 }
+
+// --- Preserve job-row expansion state across list refreshes (the list
+//     polls itself every 5s and also re-fetches on jobChanged events).
+//     Without this, the user's expanded view collapses every poll cycle.
+(function() {
+    var openSet = new Set();
+    document.body.addEventListener('htmx:beforeSwap', function(e) {
+        var t = e.detail && e.detail.target;
+        if (t && t.id === 'job-list') {
+            openSet.clear();
+            t.querySelectorAll('details.job-row[open]').forEach(function(d) {
+                openSet.add(d.dataset.jobId);
+            });
+        }
+    });
+    document.body.addEventListener('htmx:afterSwap', function(e) {
+        var t = e.detail && e.detail.target;
+        if (t && t.id === 'job-list') {
+            t.querySelectorAll('details.job-row').forEach(function(d) {
+                if (openSet.has(d.dataset.jobId)) {
+                    d.open = true;
+                    if (!d.dataset.loaded) {
+                        d.dataset.loaded = '1';
+                        var slot = d.querySelector('.job-detail-slot');
+                        if (slot) htmx.trigger(slot, 'showJobDetail');
+                    }
+                }
+            });
+        }
+    });
+})();
 
 // --- Job form modal ---
 function openJobForm() {

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -33,6 +33,7 @@
             </span>
         </div>
     </header>
+    <div id="comparison-view"></div>
     <div id="job-list"
          hx-get="/api/benchmark-jobs"
          hx-trigger="load, jobChanged from:body"
@@ -56,43 +57,6 @@
      hx-trigger="load"
      hx-swap="innerHTML">
 </div>
-
-<article>
-    <header>
-        <div style="display:flex;justify-content:space-between;align-items:center;">
-            <span>Benchmark Results</span>
-            <span style="display:flex;gap:0.5rem;">
-                <button type="button" class="outline secondary"
-                        style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
-                        onclick="document.getElementById('bench-help').showModal();">
-                    ?
-                </button>
-                <button type="button" class="outline secondary"
-                        style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
-                        onclick="var checks=document.querySelectorAll('.bench-check:checked');if(checks.length<2){alert('Select at least 2 benchmarks to compare');return;}var ids=Array.from(checks).map(function(c){return c.value}).join(',');var el=document.getElementById('comparison-view');fetch('/api/benchmarks/compare?ids='+ids,{headers:{'HX-Request':'true'}}).then(function(r){return r.text()}).then(function(h){el.innerHTML=h});">
-                    Compare
-                </button>
-                <button type="button" class="outline secondary"
-                        style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
-                        onclick="var checks=document.querySelectorAll('.bench-check:checked');if(checks.length===0){alert('Select benchmarks to export');return;}var ids=Array.from(checks).map(function(c){return c.value}).join(',');window.location='/api/benchmarks/export?ids='+ids;">
-                    Export CSV
-                </button>
-                <button type="button" class="outline secondary"
-                        style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
-                        onclick="var checks=document.querySelectorAll('.bench-check:checked');if(checks.length===0){alert('Select benchmarks to delete');return;}if(!confirm('Delete '+checks.length+' benchmark(s)?'))return;var ids=Array.from(checks).map(function(c){return c.value}).join(',');fetch('/api/benchmarks/batch-delete?ids='+ids,{method:'DELETE',headers:{'HX-Request':'true'}}).then(function(){htmx.ajax('GET','/api/benchmarks',{target:'#benchmark-list',swap:'innerHTML'})});">
-                    Delete Selected
-                </button>
-            </span>
-        </div>
-    </header>
-    <div id="comparison-view"></div>
-    <div id="benchmark-list"
-         hx-get="/api/benchmarks"
-         hx-trigger="load, benchmarkChanged from:body"
-         hx-swap="innerHTML">
-        Loading...
-    </div>
-</article>
 
 <dialog id="bench-help" style="max-width:600px;">
     <article>
@@ -152,25 +116,63 @@ function toggleBenchGroup(header) {
     });
 }
 
-function collapseAllBenchGroups() {
-    var root = document.getElementById('benchmark-list');
+function benchContainer(btn) {
+    return btn && btn.closest ? btn.closest('.bench-runs-container') : null;
+}
+
+function collapseAllBenchGroups(btn) {
+    var root = benchContainer(btn);
     if (!root) return;
     root.querySelectorAll('tbody.bench-group-header').forEach(function(h) {
         if (!h.classList.contains('collapsed')) toggleBenchGroup(h);
     });
 }
 
-function expandAllBenchGroups() {
-    var root = document.getElementById('benchmark-list');
+function expandAllBenchGroups(btn) {
+    var root = benchContainer(btn);
     if (!root) return;
     root.querySelectorAll('tbody.bench-group-header').forEach(function(h) {
         if (h.classList.contains('collapsed')) toggleBenchGroup(h);
     });
 }
 
-function filterBenchmarks(q) {
+function compareSelectedRuns(btn) {
+    var root = benchContainer(btn);
+    if (!root) return;
+    var checks = root.querySelectorAll('.bench-check:checked');
+    if (checks.length < 2) { alert('Select at least 2 benchmarks to compare.'); return; }
+    var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
+    var view = document.getElementById('comparison-view');
+    fetch('/api/benchmarks/compare?ids='+ids, {headers:{'HX-Request':'true'}})
+        .then(function(r){return r.text();})
+        .then(function(h){ view.innerHTML = h; view.scrollIntoView({behavior:'smooth'}); });
+}
+
+function exportSelectedRuns(btn) {
+    var root = benchContainer(btn);
+    if (!root) return;
+    var checks = root.querySelectorAll('.bench-check:checked');
+    if (checks.length === 0) { alert('Select benchmarks to export.'); return; }
+    var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
+    window.location = '/api/benchmarks/export?ids='+ids;
+}
+
+function deleteSelectedRuns(btn) {
+    var root = benchContainer(btn);
+    if (!root) return;
+    var checks = root.querySelectorAll('.bench-check:checked');
+    if (checks.length === 0) { alert('Select benchmarks to delete.'); return; }
+    if (!confirm('Delete '+checks.length+' benchmark(s)?')) return;
+    var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
+    fetch('/api/benchmarks/batch-delete?ids='+ids, {method:'DELETE',headers:{'HX-Request':'true'}})
+        .then(function(){
+            document.body.dispatchEvent(new CustomEvent('jobChanged'));
+        });
+}
+
+function filterBenchmarks(input, q) {
     q = (q || '').trim().toLowerCase();
-    var root = document.getElementById('benchmark-list');
+    var root = benchContainer(input);
     if (!root) return;
 
     var rows = root.querySelectorAll('tbody.bench-row-group');
@@ -212,6 +214,37 @@ function filterBenchmarks(q) {
         tb.style.display = (tb._matches && !collapsed[name]) ? '' : 'none';
     });
 }
+
+// --- Preserve job-row expansion state across list refreshes (the list
+//     only refreshes on jobChanged now — no auto-poll — so this only
+//     fires when the user does something explicit, but still important
+//     so e.g. deleting one job doesn't collapse all the others.
+(function() {
+    var openSet = new Set();
+    document.body.addEventListener('htmx:beforeSwap', function(e) {
+        var t = e.detail && e.detail.target;
+        if (t && t.id === 'job-list') {
+            openSet.clear();
+            t.querySelectorAll('details.job-row[open]').forEach(function(d) {
+                openSet.add(d.dataset.jobId);
+            });
+        }
+    });
+    document.body.addEventListener('htmx:afterSwap', function(e) {
+        var t = e.detail && e.detail.target;
+        if (t && t.id === 'job-list') {
+            t.querySelectorAll('details.job-row').forEach(function(d) {
+                if (!openSet.has(d.dataset.jobId)) return;
+                d.open = true;
+                d.dataset.loaded = '1';
+                var slot = d.querySelector('.job-detail-slot');
+                if (!slot) return;
+                var url = slot.getAttribute('hx-get');
+                if (url) htmx.ajax('GET', url, {target: slot, swap: 'innerHTML'});
+            });
+        }
+    });
+})();
 
 // --- Job form modal ---
 function openJobForm() {
@@ -306,7 +339,6 @@ function deleteJob(id, disposition) {
     fetch('/api/benchmark-jobs/'+id+'?runs='+disposition, {method:'DELETE'}).then(function(r){
         if (!r.ok) { return r.text().then(function(t){alert(t);}); }
         document.body.dispatchEvent(new CustomEvent('jobChanged'));
-        document.body.dispatchEvent(new CustomEvent('benchmarkChanged'));
     });
 }
 function compareSelectedCells(btn) {

--- a/web/templates/partials/bench_about.html
+++ b/web/templates/partials/bench_about.html
@@ -1,0 +1,80 @@
+{{define "bench_about"}}
+<h5>What benchmarks measure</h5>
+<p>Two source paths produce results, both via real HTTP requests through the running router:</p>
+<ul>
+    <li><strong>internal-*</strong> presets drive an in-process loop that sends chat completion requests with a known prose prompt sized to a target token count and reads the timings llama.cpp returns in the response body.</li>
+    <li><strong>benchy-*</strong> presets shell out to <a href="https://github.com/eugr/llama-benchy" target="_blank" rel="noopener">llama-benchy</a> via <code>uvx</code>, an external API benchmarker that supports concurrency and works with sharded GGUFs (where the legacy <code>llama-bench</code> tool fell over).</li>
+</ul>
+
+<h5>Internal prompt</h5>
+<p>Every internal request is built by repeating a fixed prose passage until it hits the target character count, prefixed with a per-rep header to defeat llama.cpp's prompt cache. Approximate sizing: <code>{{.InternalPrompt.CharsPerToken}}</code> chars/token (English BPE average).</p>
+<details>
+    <summary><small>Per-repetition prefix template</small></summary>
+    <pre style="font-size:0.75rem;white-space:pre-wrap;margin:0.25rem 0 0;">{{.InternalPrompt.RepetitionPrefix}}</pre>
+</details>
+<details>
+    <summary><small>Prose passage</small></summary>
+    <pre style="font-size:0.75rem;white-space:pre-wrap;margin:0.25rem 0 0;max-height:240px;overflow-y:auto;">{{.InternalPrompt.Text}}</pre>
+</details>
+
+<h5>Presets</h5>
+<table role="grid" style="font-size:0.8rem;">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Source</th>
+            <th>Prompt sizes</th>
+            <th>Gen</th>
+            <th>Reps</th>
+            <th>Concurrency</th>
+        </tr>
+    </thead>
+    <tbody>
+    {{range .Presets}}
+        <tr title="{{.Description}}">
+            <td><kbd>{{.Name}}</kbd></td>
+            <td>{{.EffectiveSource}}</td>
+            <td>{{range $i, $p := .PromptTokens}}{{if $i}}, {{end}}{{$p}}{{end}}</td>
+            <td>{{.GenTokens}}</td>
+            <td>{{.Repetitions}}</td>
+            <td>{{if .Concurrency}}{{range $i, $c := .Concurrency}}{{if $i}}, {{end}}{{$c}}{{end}}{{else}}—{{end}}</td>
+        </tr>
+    {{end}}
+    </tbody>
+</table>
+
+{{if .BenchyCommands}}
+<h5>llama-benchy commands</h5>
+<p>Exact <code>uvx</code> invocation generated for each benchy preset. Placeholders in <code>{braces}</code> are filled per cell at run time.</p>
+{{range .BenchyCommands}}
+    <details>
+        <summary><small><kbd>{{.PresetName}}</kbd></small></summary>
+        <pre style="font-size:0.75rem;white-space:pre-wrap;word-break:break-all;margin:0.25rem 0 0;">{{.Command}}</pre>
+    </details>
+{{end}}
+{{end}}
+
+<h5>Metrics</h5>
+<dl>
+    <dt><strong>PP t/s</strong> (Prompt Processing tokens/sec)</dt>
+    <dd>How fast the model reads and processes input prompt tokens. GPU compute-bound; benefits from batching.</dd>
+
+    <dt><strong>TG t/s</strong> (Token Generation tokens/sec)</dt>
+    <dd>How fast the model generates response tokens. Memory bandwidth-bound on GPU; this is the speed you feel during chat.</dd>
+
+    <dt><strong>TTFT</strong> (Time To First Token, ms)</dt>
+    <dd>Wall-clock time from request to first response token. Includes prompt processing.</dd>
+
+    <dt><strong>TTFR</strong> (Time To First Response, ms) <small style="color:var(--pico-muted-color);">— benchy only</small></dt>
+    <dd>llama-benchy's separately-timed first-response measurement, distinct from end-to-end TTFT.</dd>
+
+    <dt><strong>peak t/s</strong> <small style="color:var(--pico-muted-color);">— benchy only</small></dt>
+    <dd>Peak observed throughput within the run, useful when concurrency &gt; 1 to spot saturation.</dd>
+
+    <dt><strong>e2e_ttft</strong> (end-to-end TTFT, ms) <small style="color:var(--pico-muted-color);">— benchy only</small></dt>
+    <dd>llama-benchy's end-to-end first-token timing, comparable to TTFT above.</dd>
+</dl>
+
+<h5>Live performance</h5>
+<p>The Server tab's Live Performance panel passively captures timing data from every chat completion routed through the proxy — no explicit benchmark needed. It shows a rolling average of real-world performance across recent requests.</p>
+{{end}}

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -1,4 +1,38 @@
 {{define "benchmark_compare"}}
+<style>
+.bench-compare-bars { display:block; margin-bottom: 0.75rem; }
+.bench-compare-row {
+    display:flex; align-items:center; gap:0.5rem; margin:0.25rem 0;
+}
+.bench-compare-label {
+    width:280px; font-size:0.8rem; text-align:right;
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+}
+.bench-compare-bartrack {
+    flex:1; background:var(--pico-muted-border-color);
+    border-radius:4px; height:1.2rem;
+}
+.bench-compare-barfill { border-radius:4px; height:100%; min-width:2px; }
+.bench-compare-value { width:60px; font-size:0.85rem; }
+
+.bench-compare-table th[data-run-id] {
+    min-width:160px; max-width:280px;
+    overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+}
+.bench-sort-bar {
+    display:flex; gap:0.4rem; align-items:center;
+    margin-bottom:0.5rem; flex-wrap:wrap;
+}
+.bench-sort-bar button {
+    margin:0; padding:0.15rem 0.55rem; font-size:0.8rem; width:auto;
+}
+.bench-sort-bar button.active {
+    background:var(--pico-primary);
+    color:var(--pico-primary-inverse);
+    border-color:var(--pico-primary);
+}
+</style>
+
 <div style="margin-bottom: 1rem;">
     <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem;">
         <h5 style="margin:0;">Comparison: {{len .Runs}} runs</h5>
@@ -9,17 +43,31 @@
         </button>
     </div>
 
+    <div class="bench-sort-bar">
+        <small>Sort by:</small>
+        <button type="button" class="outline secondary" data-sort-key="name"   data-sort-dir="asc"  onclick="sortBenchCompare(this)">Name</button>
+        <button type="button" class="outline secondary active" data-sort-key="gen"    data-sort-dir="desc" onclick="sortBenchCompare(this)">Gen tok/s ▼</button>
+        <button type="button" class="outline secondary" data-sort-key="prompt" data-sort-dir="desc" onclick="sortBenchCompare(this)">Prompt tok/s ▼</button>
+        <button type="button" class="outline secondary" data-sort-key="ttft"   data-sort-dir="asc"  onclick="sortBenchCompare(this)">TTFT ▲</button>
+    </div>
+
     {{if gt .MaxGenTPS 0.0}}
     <small><strong>Generation Speed (tokens/sec)</strong></small>
-    <div style="margin-bottom: 0.75rem;">
+    <div class="bench-compare-bars">
         {{range .Runs}}
         {{if .Summary}}
-        <div style="display:flex;align-items:center;gap:0.5rem;margin:0.25rem 0;">
-            <div style="width:150px;font-size:0.8rem;text-align:right;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{.ModelName}} ({{.Quant}})</div>
-            <div style="flex:1;background:var(--pico-muted-border-color);border-radius:4px;height:1.2rem;">
-                <div style="width:{{printf "%.1f" (pctOf .Summary.AvgGenTokPerSec $.MaxGenTPS)}}%;background:var(--pico-primary);border-radius:4px;height:100%;min-width:2px;"></div>
+        {{$build := .EffectiveBuild}}
+        <div class="bench-compare-row"
+             data-run-id="{{.ID}}"
+             data-sort-name="{{.ModelName}}"
+             data-sort-gen="{{printf "%.4f" .Summary.AvgGenTokPerSec}}"
+             data-sort-prompt="{{printf "%.4f" .Summary.AvgPromptTokPerSec}}"
+             data-sort-ttft="{{printf "%.4f" .Summary.AvgTTFTMs}}">
+            <div class="bench-compare-label" title="{{.ModelID}}">{{.ModelName}} ({{.Quant}})</div>
+            <div class="bench-compare-bartrack">
+                <div class="bench-compare-barfill" style="width:{{printf "%.1f" (pctOf .Summary.AvgGenTokPerSec $.MaxGenTPS)}}%;background:var(--pico-primary);"></div>
             </div>
-            <div style="width:60px;font-size:0.85rem;"><strong>{{printf "%.1f" .Summary.AvgGenTokPerSec}}</strong></div>
+            <div class="bench-compare-value"><strong>{{printf "%.1f" .Summary.AvgGenTokPerSec}}</strong></div>
         </div>
         {{end}}
         {{end}}
@@ -28,15 +76,20 @@
 
     {{if gt .MaxPromptTPS 0.0}}
     <small><strong>Prompt Processing (tokens/sec)</strong></small>
-    <div style="margin-bottom: 0.75rem;">
+    <div class="bench-compare-bars">
         {{range .Runs}}
         {{if .Summary}}
-        <div style="display:flex;align-items:center;gap:0.5rem;margin:0.25rem 0;">
-            <div style="width:150px;font-size:0.8rem;text-align:right;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{.ModelName}} ({{.Quant}})</div>
-            <div style="flex:1;background:var(--pico-muted-border-color);border-radius:4px;height:1.2rem;">
-                <div style="width:{{printf "%.1f" (pctOf .Summary.AvgPromptTokPerSec $.MaxPromptTPS)}}%;background:var(--pico-ins-color);border-radius:4px;height:100%;min-width:2px;"></div>
+        <div class="bench-compare-row"
+             data-run-id="{{.ID}}"
+             data-sort-name="{{.ModelName}}"
+             data-sort-gen="{{printf "%.4f" .Summary.AvgGenTokPerSec}}"
+             data-sort-prompt="{{printf "%.4f" .Summary.AvgPromptTokPerSec}}"
+             data-sort-ttft="{{printf "%.4f" .Summary.AvgTTFTMs}}">
+            <div class="bench-compare-label" title="{{.ModelID}}">{{.ModelName}} ({{.Quant}})</div>
+            <div class="bench-compare-bartrack">
+                <div class="bench-compare-barfill" style="width:{{printf "%.1f" (pctOf .Summary.AvgPromptTokPerSec $.MaxPromptTPS)}}%;background:var(--pico-ins-color);"></div>
             </div>
-            <div style="width:60px;font-size:0.85rem;"><strong>{{printf "%.0f" .Summary.AvgPromptTokPerSec}}</strong></div>
+            <div class="bench-compare-value"><strong>{{printf "%.0f" .Summary.AvgPromptTokPerSec}}</strong></div>
         </div>
         {{end}}
         {{end}}
@@ -45,58 +98,128 @@
 
     <small><strong>Details</strong></small>
     <div style="overflow-x:auto;">
-    <table role="grid" style="font-size:0.85rem;">
+    <table role="grid" class="bench-compare-table" style="font-size:0.85rem;">
         <thead>
             <tr>
                 <th></th>
-                {{range .Runs}}<th>{{.ModelName}}<br><small>{{.Quant}}</small></th>{{end}}
+                {{range .Runs}}
+                <th data-run-id="{{.ID}}" title="{{.ModelID}}">{{.ModelName}}<br><small>{{.Quant}}</small></th>
+                {{end}}
             </tr>
         </thead>
         <tbody>
             <tr>
                 <td>PP t/s</td>
-                {{range .Runs}}<td>{{if .Summary}}{{printf "%.0f" .Summary.AvgPromptTokPerSec}}{{else}}—{{end}}</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Summary}}{{printf "%.0f" .Summary.AvgPromptTokPerSec}}{{else}}—{{end}}</td>{{end}}
             </tr>
             <tr>
                 <td>TG t/s</td>
-                {{range .Runs}}<td>{{if .Summary}}<strong>{{printf "%.1f" .Summary.AvgGenTokPerSec}}</strong>{{else}}—{{end}}</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Summary}}<strong>{{printf "%.1f" .Summary.AvgGenTokPerSec}}</strong>{{else}}—{{end}}</td>{{end}}
             </tr>
             <tr>
                 <td>TTFT (ms)</td>
-                {{range .Runs}}<td>{{if .Summary}}{{printf "%.0f" .Summary.AvgTTFTMs}}{{else}}—{{end}}</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Summary}}{{printf "%.0f" .Summary.AvgTTFTMs}}{{else}}—{{end}}</td>{{end}}
             </tr>
             <tr>
                 <td>Size</td>
-                {{range .Runs}}<td>{{printf "%.1f" .SizeGB}} GB</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{printf "%.1f" .SizeGB}} GB</td>{{end}}
             </tr>
             <tr>
                 <td>GPUs</td>
-                {{range .Runs}}<td>{{if .Config.GPUAssign}}{{.Config.GPUAssign}}{{else}}all{{end}}</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Config.GPUAssign}}{{.Config.GPUAssign}}{{else}}all{{end}}</td>{{end}}
             </tr>
             <tr>
                 <td>Context</td>
-                {{range .Runs}}<td>{{.Config.ContextSize}}</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{.Config.ContextSize}}</td>{{end}}
             </tr>
             <tr>
                 <td>KV Quant</td>
-                {{range .Runs}}<td>{{if .Config.KVCacheQuant}}{{.Config.KVCacheQuant}}{{else}}—{{end}}</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Config.KVCacheQuant}}{{.Config.KVCacheQuant}}{{else}}—{{end}}</td>{{end}}
             </tr>
             <tr>
                 <td>Flash Attn</td>
-                {{range .Runs}}<td>{{if .Config.FlashAttention}}yes{{else}}no{{end}}</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Config.FlashAttention}}yes{{else}}no{{end}}</td>{{end}}
             </tr>
             <tr>
                 <td>Build</td>
-                {{range .Runs}}<td>{{if .BuildID}}<small><kbd>{{.BuildID}}</kbd></small>{{else if .BuildRef}}{{.BuildRef}}{{else}}—{{end}}</td>{{end}}
+                {{range .Runs}}
+                {{$b := .EffectiveBuild}}
+                <td data-run-id="{{.ID}}" title="{{$b.Tag}}{{if $b.GitSHA}} · {{$b.GitSHA}}{{end}}">
+                    {{if $b.Profile}}{{$b.Profile}}{{end}}{{if $b.GitRef}} · {{$b.GitRef}}{{end}}{{if and (not $b.Profile) (not $b.GitRef)}}—{{end}}
+                </td>
+                {{end}}
             </tr>
             {{if .HasLlamaBench}}
             <tr>
                 <td>llama-bench TG</td>
-                {{range .Runs}}<td>{{if .LlamaBench}}{{printf "%.1f" .LlamaBench.GenTokPerSec}}{{else}}—{{end}}</td>{{end}}
+                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .LlamaBench}}{{printf "%.1f" .LlamaBench.GenTokPerSec}}{{else}}—{{end}}</td>{{end}}
             </tr>
             {{end}}
         </tbody>
     </table>
     </div>
 </div>
+
+<script>
+(function() {
+    // Initial sort matches the active button (Gen tok/s desc).
+    sortBenchCompare(document.querySelector('.bench-sort-bar button.active'));
+})();
+
+function sortBenchCompare(btn) {
+    if (!btn) return;
+    var bar = btn.closest('.bench-sort-bar');
+    if (!bar) return;
+    bar.querySelectorAll('button').forEach(function(b) { b.classList.remove('active'); });
+    btn.classList.add('active');
+
+    var key = btn.dataset.sortKey;     // name | gen | prompt | ttft
+    var dir = btn.dataset.sortDir;     // asc | desc
+    var attr = 'sort' + key.charAt(0).toUpperCase() + key.slice(1);
+    var view = btn.closest('#comparison-view');
+    if (!view) return;
+
+    // Collect run IDs + sort values from any one of the bar charts (they
+    // all carry the same dataset attributes per run).
+    var anyRow = view.querySelector('.bench-compare-row[data-run-id]');
+    if (!anyRow) return;
+    var rows = view.querySelectorAll('.bench-compare-row[data-run-id]');
+    var byId = {};
+    rows.forEach(function(r) {
+        if (byId[r.dataset.runId] !== undefined) return;
+        var v = r.dataset[attr];
+        var num = parseFloat(v);
+        byId[r.dataset.runId] = isNaN(num) ? v : num;
+    });
+    var ids = Object.keys(byId);
+    ids.sort(function(a, b) {
+        var va = byId[a], vb = byId[b];
+        var cmp;
+        if (typeof va === 'string' || typeof vb === 'string') {
+            cmp = String(va).localeCompare(String(vb), undefined, {numeric:true, sensitivity:'base'});
+        } else {
+            cmp = va - vb;
+        }
+        return dir === 'desc' ? -cmp : cmp;
+    });
+
+    // Re-order each bar chart's row siblings.
+    view.querySelectorAll('.bench-compare-bars').forEach(function(container) {
+        var rowMap = {};
+        container.querySelectorAll('.bench-compare-row').forEach(function(r) { rowMap[r.dataset.runId] = r; });
+        ids.forEach(function(id) { if (rowMap[id]) container.appendChild(rowMap[id]); });
+    });
+
+    // Re-order table columns row by row. The first <td>/<th> per row is
+    // a label without data-run-id, so re-appending only the run-id'd
+    // cells preserves the label position naturally.
+    view.querySelectorAll('.bench-compare-table tr').forEach(function(tr) {
+        var cellMap = {};
+        Array.from(tr.children).forEach(function(td) {
+            if (td.dataset.runId) cellMap[td.dataset.runId] = td;
+        });
+        ids.forEach(function(id) { if (cellMap[id]) tr.appendChild(cellMap[id]); });
+    });
+}
+</script>
 {{end}}

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -131,7 +131,7 @@
             <td>{{printf "%.1f" .SizeGB}} GB</td>
             <td>{{if .Config.GPUAssign}}{{.Config.GPUAssign}}{{else}}all{{end}}</td>
             <td>{{.Config.ContextSize}}</td>
-            <td>{{if .Config.KVCacheQuant}}{{.Config.KVCacheQuant}}{{else}}—{{end}}</td>
+            <td>{{or .Config.KVCacheQuant "f16"}}</td>
             <td>{{if .Config.FlashAttention}}yes{{else}}no{{end}}</td>
             <td title="{{$b.Tag}}{{if $b.GitSHA}} · {{$b.GitSHA}}{{end}}">
                 {{if $b.Profile}}{{$b.Profile}}{{end}}{{if $b.GitRef}} · {{$b.GitRef}}{{end}}{{if and (not $b.Profile) (not $b.GitRef)}}—{{end}}

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -101,60 +101,44 @@
     <table role="grid" class="bench-compare-table" style="font-size:0.85rem;">
         <thead>
             <tr>
-                <th></th>
-                {{range .Runs}}
-                <th data-run-id="{{.ID}}" title="{{.ModelID}}">{{.ModelName}}<br><small>{{.Quant}}</small></th>
-                {{end}}
+                <th>Model</th>
+                <th>Quant</th>
+                <th title="Prompt Processing tokens/sec">PP t/s</th>
+                <th title="Token Generation tokens/sec">TG t/s</th>
+                <th title="Time To First Token, milliseconds">TTFT (ms)</th>
+                <th>Size</th>
+                <th>GPUs</th>
+                <th>Context</th>
+                <th>KV Quant</th>
+                <th>Flash Attn</th>
+                <th>Build</th>
+                {{if .HasLlamaBench}}<th title="llama-bench TG t/s (legacy)">lb TG</th>{{end}}
             </tr>
         </thead>
         <tbody>
-            <tr>
-                <td>PP t/s</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Summary}}{{printf "%.0f" .Summary.AvgPromptTokPerSec}}{{else}}—{{end}}</td>{{end}}
-            </tr>
-            <tr>
-                <td>TG t/s</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Summary}}<strong>{{printf "%.1f" .Summary.AvgGenTokPerSec}}</strong>{{else}}—{{end}}</td>{{end}}
-            </tr>
-            <tr>
-                <td>TTFT (ms)</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Summary}}{{printf "%.0f" .Summary.AvgTTFTMs}}{{else}}—{{end}}</td>{{end}}
-            </tr>
-            <tr>
-                <td>Size</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{printf "%.1f" .SizeGB}} GB</td>{{end}}
-            </tr>
-            <tr>
-                <td>GPUs</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Config.GPUAssign}}{{.Config.GPUAssign}}{{else}}all{{end}}</td>{{end}}
-            </tr>
-            <tr>
-                <td>Context</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{.Config.ContextSize}}</td>{{end}}
-            </tr>
-            <tr>
-                <td>KV Quant</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Config.KVCacheQuant}}{{.Config.KVCacheQuant}}{{else}}—{{end}}</td>{{end}}
-            </tr>
-            <tr>
-                <td>Flash Attn</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .Config.FlashAttention}}yes{{else}}no{{end}}</td>{{end}}
-            </tr>
-            <tr>
-                <td>Build</td>
-                {{range .Runs}}
-                {{$b := .EffectiveBuild}}
-                <td data-run-id="{{.ID}}" title="{{$b.Tag}}{{if $b.GitSHA}} · {{$b.GitSHA}}{{end}}">
-                    {{if $b.Profile}}{{$b.Profile}}{{end}}{{if $b.GitRef}} · {{$b.GitRef}}{{end}}{{if and (not $b.Profile) (not $b.GitRef)}}—{{end}}
-                </td>
-                {{end}}
-            </tr>
-            {{if .HasLlamaBench}}
-            <tr>
-                <td>llama-bench TG</td>
-                {{range .Runs}}<td data-run-id="{{.ID}}">{{if .LlamaBench}}{{printf "%.1f" .LlamaBench.GenTokPerSec}}{{else}}—{{end}}</td>{{end}}
-            </tr>
-            {{end}}
+        {{range .Runs}}
+        {{$b := .EffectiveBuild}}
+        <tr data-run-id="{{.ID}}"
+            data-sort-name="{{.ModelName}}"
+            {{if .Summary}}data-sort-gen="{{printf "%.4f" .Summary.AvgGenTokPerSec}}"
+            data-sort-prompt="{{printf "%.4f" .Summary.AvgPromptTokPerSec}}"
+            data-sort-ttft="{{printf "%.4f" .Summary.AvgTTFTMs}}"{{end}}>
+            <td title="{{.ModelID}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{.ModelName}}</td>
+            <td><kbd>{{.Quant}}</kbd></td>
+            <td>{{if .Summary}}{{printf "%.0f" .Summary.AvgPromptTokPerSec}}{{else}}—{{end}}</td>
+            <td>{{if .Summary}}<strong>{{printf "%.1f" .Summary.AvgGenTokPerSec}}</strong>{{else}}—{{end}}</td>
+            <td>{{if .Summary}}{{printf "%.0f" .Summary.AvgTTFTMs}}{{else}}—{{end}}</td>
+            <td>{{printf "%.1f" .SizeGB}} GB</td>
+            <td>{{if .Config.GPUAssign}}{{.Config.GPUAssign}}{{else}}all{{end}}</td>
+            <td>{{.Config.ContextSize}}</td>
+            <td>{{if .Config.KVCacheQuant}}{{.Config.KVCacheQuant}}{{else}}—{{end}}</td>
+            <td>{{if .Config.FlashAttention}}yes{{else}}no{{end}}</td>
+            <td title="{{$b.Tag}}{{if $b.GitSHA}} · {{$b.GitSHA}}{{end}}">
+                {{if $b.Profile}}{{$b.Profile}}{{end}}{{if $b.GitRef}} · {{$b.GitRef}}{{end}}{{if and (not $b.Profile) (not $b.GitRef)}}—{{end}}
+            </td>
+            {{if $.HasLlamaBench}}<td>{{if .LlamaBench}}{{printf "%.1f" .LlamaBench.GenTokPerSec}}{{else}}—{{end}}</td>{{end}}
+        </tr>
+        {{end}}
         </tbody>
     </table>
     </div>
@@ -210,15 +194,12 @@ function sortBenchCompare(btn) {
         ids.forEach(function(id) { if (rowMap[id]) container.appendChild(rowMap[id]); });
     });
 
-    // Re-order table columns row by row. The first <td>/<th> per row is
-    // a label without data-run-id, so re-appending only the run-id'd
-    // cells preserves the label position naturally.
-    view.querySelectorAll('.bench-compare-table tr').forEach(function(tr) {
-        var cellMap = {};
-        Array.from(tr.children).forEach(function(td) {
-            if (td.dataset.runId) cellMap[td.dataset.runId] = td;
-        });
-        ids.forEach(function(id) { if (cellMap[id]) tr.appendChild(cellMap[id]); });
+    // Re-order rows in the details table tbody. One <tr> per run, so
+    // re-appending in sorted order moves them all into place.
+    view.querySelectorAll('.bench-compare-table tbody').forEach(function(tbody) {
+        var rowMap = {};
+        tbody.querySelectorAll('tr[data-run-id]').forEach(function(tr) { rowMap[tr.dataset.runId] = tr; });
+        ids.forEach(function(id) { if (rowMap[id]) tbody.appendChild(rowMap[id]); });
     });
 }
 </script>

--- a/web/templates/partials/benchmark_detail.html
+++ b/web/templates/partials/benchmark_detail.html
@@ -27,6 +27,26 @@
         </div>
     </div>
 
+    {{with .EffectiveBuild}}{{if or .ID .GitRef}}
+    <div style="margin-bottom:0.5rem;">
+        <small><strong>Build</strong></small><br>
+        <small>
+            {{if .ID}}<kbd>{{.ID}}</kbd>{{end}}
+            {{if .Tag}} &middot; tag {{.Tag}}{{end}}
+            {{if .Profile}} &middot; {{.Profile}}{{end}}
+            {{if .GitRef}} &middot; ref {{.GitRef}}{{end}}
+            {{if .GitSHA}} &middot; <span title="{{.GitSHA}}">sha {{shortSHA .GitSHA}}</span>{{end}}
+        </small>
+        {{if .CMakeFlags}}
+        <details style="margin-top:0.25rem;">
+            <summary><small>CMake flags</small></summary>
+            <pre style="font-size:0.75rem;margin:0.25rem 0 0;">{{range $k, $v := .CMakeFlags}}{{$k}}={{$v}}
+{{end}}</pre>
+        </details>
+        {{end}}
+    </div>
+    {{end}}{{end}}
+
     {{if .Results}}
     <small><strong>API Benchmark</strong> — real chat completion requests through the server</small>
     <table role="grid" style="font-size:0.85rem;">

--- a/web/templates/partials/benchmark_detail.html
+++ b/web/templates/partials/benchmark_detail.html
@@ -69,6 +69,42 @@
     </table>
     {{end}}
 
+    {{if .LlamaBenchy}}
+    <small><strong>llama-benchy</strong> — OpenAI-compatible API benchmark via uvx</small>
+    <table role="grid" style="font-size:0.85rem;">
+        <thead>
+            <tr>
+                <th title="Concurrent requests issued for this row">Conc</th>
+                <th title="Prompt tokens">Prompt</th>
+                <th title="Generated tokens">Gen</th>
+                <th title="Prompt processing throughput (mean ± std, tokens/sec)">PP t/s</th>
+                <th title="Token generation throughput (mean ± std, tokens/sec)">TG t/s</th>
+                <th title="Time-to-first-response, milliseconds">TTFR</th>
+                <th title="End-to-end time-to-first-token, milliseconds">e2e TTFT</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .LlamaBenchy}}
+        <tr>
+            <td>{{.Concurrency}}</td>
+            <td>{{.PromptSize}}</td>
+            <td>{{.ResponseSize}}</td>
+            <td>{{if .PPThroughput}}{{printf "%.0f" .PPThroughput.Mean}} ± {{printf "%.0f" .PPThroughput.Std}}{{else}}—{{end}}</td>
+            <td>{{if .TGThroughput}}<strong>{{printf "%.1f" .TGThroughput.Mean}}</strong> ± {{printf "%.1f" .TGThroughput.Std}}{{else}}—{{end}}</td>
+            <td>{{if .TTFR}}{{printf "%.0f" .TTFR.Mean}} ms{{else}}—{{end}}</td>
+            <td>{{if .E2ETTFT}}{{printf "%.0f" .E2ETTFT.Mean}} ms{{else}}—{{end}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    {{if .BenchyCommand}}
+    <details style="margin-top:0.25rem;">
+        <summary><small>Command</small></summary>
+        <pre style="font-size:0.75rem;white-space:pre-wrap;word-break:break-all;">{{.BenchyCommand}}</pre>
+    </details>
+    {{end}}
+    {{end}}
+
     {{if .Warnings}}
     <div style="margin-top:0.5rem;">
     {{range .Warnings}}

--- a/web/templates/partials/benchmark_detail.html
+++ b/web/templates/partials/benchmark_detail.html
@@ -14,7 +14,7 @@
                 {{if .Config.GPUAssign}}GPU Assign: {{.Config.GPUAssign}} | {{end}}
                 {{if .Config.TensorSplit}}Tensor Split: {{.Config.TensorSplit}} | {{end}}
                 Flash Attn: {{if .Config.FlashAttention}}on{{else}}off{{end}}
-                {{if .Config.KVCacheQuant}} | KV Quant: {{.Config.KVCacheQuant}}{{end}}
+                | KV Quant: {{or .Config.KVCacheQuant "f16"}}
                 {{if .Config.DirectIO}} | Direct I/O: on{{end}}
                 {{if .Config.SpecType}} | Spec: {{.Config.SpecType}}{{end}}
             </small>

--- a/web/templates/partials/benchmark_detail.html
+++ b/web/templates/partials/benchmark_detail.html
@@ -58,7 +58,7 @@
     {{end}}
 
     {{if .LlamaBench}}
-    <small><strong>Raw Inference (llama-bench)</strong> — direct model benchmark, no server overhead</small>
+    <small><strong>Legacy llama-bench result</strong> — captured before the llama-benchy switch; new runs no longer produce this</small>
     <table role="grid" style="font-size:0.85rem;">
         <thead><tr><th>Metric</th><th>Value</th></tr></thead>
         <tbody>
@@ -111,9 +111,7 @@
     <small style="color:var(--pico-del-color);">&#x26A0; {{.}}</small><br>
     {{end}}
     </div>
-    {{else if not .LlamaBench}}{{if .Results}}
-    <small style="color:var(--pico-muted-color);">No llama-bench results — use Standard or Thorough preset to include raw inference benchmarks.</small>
-    {{end}}{{end}}
+    {{end}}
 
     {{if .DurationMs}}
     <small>Total duration: {{printf "%.1f" (divf .DurationMs 1000.0)}}s</small>

--- a/web/templates/partials/benchmark_form.html
+++ b/web/templates/partials/benchmark_form.html
@@ -1,12 +1,13 @@
 {{define "benchmark_form"}}
 <article>
-    <header>Run Benchmark</header>
+    <header>Quick Benchmark <small style="color:var(--pico-muted-color);">(creates a 1-cell job using the active build)</small></header>
     {{if not .Running}}
     <p>Start the server before running benchmarks.</p>
     {{else}}
     <form hx-post="/api/benchmarks"
-          hx-target="#benchmark-progress"
-          hx-swap="innerHTML">
+          hx-target="#quick-bench-result"
+          hx-swap="innerHTML"
+          hx-on::after-request="if(event.detail.successful) this.reset();">
         <div class="grid">
             <label title="Select an enabled model to benchmark. The model will be loaded automatically if not already in VRAM.">
                 Model
@@ -29,19 +30,11 @@
             </label>
             <label>
                 &nbsp;
-                <button type="submit" style="margin:0;white-space:nowrap;">Run Benchmark</button>
+                <button type="submit" style="margin:0;white-space:nowrap;">Run</button>
             </label>
         </div>
+        <div id="quick-bench-result" style="margin-top:0.25rem;"></div>
     </form>
     {{end}}
 </article>
-{{if .ActiveID}}
-<script>
-// A benchmark was already running when we loaded this tab. Reattach
-// the progress UI by firing the same event the form submit fires.
-document.body.dispatchEvent(new CustomEvent('benchmarkStarted', {
-    detail: {id: {{.ActiveID}}}
-}));
-</script>
-{{end}}
 {{end}}

--- a/web/templates/partials/benchmark_progress.html
+++ b/web/templates/partials/benchmark_progress.html
@@ -1,9 +1,0 @@
-{{define "benchmark_progress"}}
-{{if eq .Status "running"}}
-&#x23F3; {{if .Detail}}{{.Detail}}{{else}}Benchmark starting...{{end}}
-{{else if eq .Status "completed"}}
-Benchmark complete!
-{{else if eq .Status "failed"}}
-Benchmark failed: {{.Error}}
-{{end}}
-{{end}}

--- a/web/templates/partials/job_detail.html
+++ b/web/templates/partials/job_detail.html
@@ -39,6 +39,7 @@
                 <th style="width:2rem;"><input type="checkbox" style="margin:0;"
                     onchange="this.closest('table').querySelectorAll('.cell-check').forEach(function(c){c.checked=this.checked}.bind(this));"></th>
                 <th>Model</th>
+                <th>Quant</th>
                 <th>Build</th>
                 <th>Preset</th>
                 <th>Status</th>
@@ -50,9 +51,10 @@
         </thead>
         <tbody>
         {{range .Rows}}
-        <tr>
+        <tr id="cell-row-{{$j.ID}}-{{.Idx}}">
             <td>{{if .Cell.BenchmarkRunID}}<input type="checkbox" class="cell-check" value="{{.Cell.BenchmarkRunID}}" style="margin:0;">{{end}}</td>
             <td>{{.ModelName}}</td>
+            <td>{{if .Quant}}<kbd>{{.Quant}}</kbd>{{else}}—{{end}}</td>
             <td><kbd>{{.BuildLbl}}</kbd></td>
             <td><small>{{.Cell.Preset}}</small></td>
             <td><span class="cell-status status-{{.Cell.Status}}">{{.Cell.Status}}</span>
@@ -69,7 +71,12 @@
                 {{end}}
             </td>
         </tr>
-        <tr><td colspan="9" class="bench-detail"></td></tr>
+        {{/*
+          hx-preserve keeps the user's expanded inline detail across the
+          parent's 2s polling swaps. The id needs to be stable, which
+          .Idx (the cell's position in the immutable Cells slice) gives us.
+        */}}
+        <tr id="cell-detail-{{$j.ID}}-{{.Idx}}" hx-preserve="true"><td colspan="10" class="bench-detail"></td></tr>
         {{end}}
         </tbody>
     </table>

--- a/web/templates/partials/job_detail.html
+++ b/web/templates/partials/job_detail.html
@@ -1,5 +1,16 @@
 {{define "job_detail"}}
 {{$j := .Job}}
+{{/*
+  OOB swaps target the summary spans rendered by job_list.html so the
+  collapsed-view status badge and cell-progress text stay live without
+  re-rendering the whole list (which causes a visible flash). HTMX
+  silently ignores OOB targets that don't exist on the page yet.
+*/}}
+<span id="job-status-{{$j.ID}}" hx-swap-oob="true" class="job-status status-{{$j.Status}}" title="status: {{$j.Status}}">{{$j.Status}}</span>
+<span id="job-progress-{{$j.ID}}" hx-swap-oob="true" class="job-progress">
+    {{.Done}}/{{.Total}} cells
+    {{if gt .Failed 0}}<span class="cell-failed-tag" title="failed cells">· {{.Failed}} failed</span>{{end}}
+</span>
 <div class="job-detail"
      {{if eq $j.Status "running"}}
      hx-get="/api/benchmark-jobs/{{$j.ID}}"

--- a/web/templates/partials/job_detail.html
+++ b/web/templates/partials/job_detail.html
@@ -1,6 +1,11 @@
 {{define "job_detail"}}
 {{$j := .Job}}
-<div class="job-detail">
+<div class="job-detail"
+     {{if eq $j.Status "running"}}
+     hx-get="/api/benchmark-jobs/{{$j.ID}}"
+     hx-trigger="every 2s"
+     hx-swap="outerHTML"
+     {{end}}>
     {{if $j.Overrides}}
     <small><strong>Overrides applied:</strong>
         {{with $j.Overrides}}

--- a/web/templates/partials/job_detail.html
+++ b/web/templates/partials/job_detail.html
@@ -92,7 +92,11 @@
                 onclick="retryFailed('{{$j.ID}}')">Retry failed</button>
         {{end}}
         <a class="outline secondary" role="button" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;text-decoration:none;"
-           href="/api/benchmark-jobs/{{$j.ID}}/export?format=json" download>Export JSON</a>
+           href="/api/benchmark-jobs/{{$j.ID}}/export?format=csv&scope=cells" download>CSV (cells)</a>
+        <a class="outline secondary" role="button" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;text-decoration:none;"
+           href="/api/benchmark-jobs/{{$j.ID}}/export?format=csv&scope=summary" download>CSV (summary)</a>
+        <a class="outline secondary" role="button" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;text-decoration:none;"
+           href="/api/benchmark-jobs/{{$j.ID}}/export?format=json" download>JSON</a>
         <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
                 onclick="deleteJob('{{$j.ID}}','cascade')">Delete (with runs)</button>
         <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"

--- a/web/templates/partials/job_detail.html
+++ b/web/templates/partials/job_detail.html
@@ -1,0 +1,79 @@
+{{define "job_detail"}}
+{{$j := .Job}}
+<div class="job-detail">
+    {{if $j.Overrides}}
+    <small><strong>Overrides applied:</strong>
+        {{with $j.Overrides}}
+        {{if .GPULayers}}gpu_layers={{deref .GPULayers}}{{end}}
+        {{if .ContextSize}} · context_size={{deref .ContextSize}}{{end}}
+        {{if .Threads}} · threads={{deref .Threads}}{{end}}
+        {{if .FlashAttention}} · flash_attention={{deref .FlashAttention}}{{end}}
+        {{if .KVCacheQuant}} · kv_cache_quant={{deref .KVCacheQuant}}{{end}}
+        {{if .DirectIO}} · direct_io={{deref .DirectIO}}{{end}}
+        {{if .GPUAssign}} · gpu_assign={{deref .GPUAssign}}{{end}}
+        {{if .TensorSplit}} · tensor_split={{deref .TensorSplit}}{{end}}
+        {{if .SpecType}} · spec_type={{deref .SpecType}}{{end}}
+        {{end}}
+    </small>
+    {{end}}
+
+    <table role="grid" style="font-size:0.85rem;margin-top:0.5rem;">
+        <thead>
+            <tr>
+                <th style="width:2rem;"><input type="checkbox" style="margin:0;"
+                    onchange="this.closest('table').querySelectorAll('.cell-check').forEach(function(c){c.checked=this.checked}.bind(this));"></th>
+                <th>Model</th>
+                <th>Build</th>
+                <th>Preset</th>
+                <th>Status</th>
+                <th title="Token Generation tokens/sec">TG t/s</th>
+                <th title="Prompt Processing tokens/sec">PP t/s</th>
+                <th>Attempt</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Rows}}
+        <tr>
+            <td>{{if .Cell.BenchmarkRunID}}<input type="checkbox" class="cell-check" value="{{.Cell.BenchmarkRunID}}" style="margin:0;">{{end}}</td>
+            <td>{{.ModelName}}</td>
+            <td><kbd>{{.BuildLbl}}</kbd></td>
+            <td><small>{{.Cell.Preset}}</small></td>
+            <td><span class="cell-status status-{{.Cell.Status}}">{{.Cell.Status}}</span>
+                {{if .ErrorShort}}<br><small style="color:var(--pico-del-color);" title="{{.Cell.Error}}">{{.ErrorShort}}</small>{{end}}
+            </td>
+            <td>{{.TGTPS}}</td>
+            <td>{{.PPTPS}}</td>
+            <td><small>{{.Cell.Attempt}}</small></td>
+            <td>
+                {{if .Cell.BenchmarkRunID}}
+                <button type="button" class="outline secondary" style="padding:0.2rem 0.5rem;font-size:0.8rem;width:auto;"
+                        hx-get="/api/benchmarks/{{.Cell.BenchmarkRunID}}" hx-target="next .bench-detail" hx-swap="innerHTML"
+                        hx-on::before-request="var d=this.closest('tr').nextElementSibling.querySelector('td');if(d.innerHTML.trim()){d.innerHTML='';event.preventDefault();}">Detail</button>
+                {{end}}
+            </td>
+        </tr>
+        <tr><td colspan="9" class="bench-detail"></td></tr>
+        {{end}}
+        </tbody>
+    </table>
+
+    <div style="display:flex;gap:0.5rem;margin-top:0.5rem;flex-wrap:wrap;">
+        <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
+                onclick="compareSelectedCells(this)">Compare selected</button>
+        {{if eq $j.Status "running"}}
+        <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
+                onclick="cancelJob('{{$j.ID}}')">Cancel</button>
+        {{else}}
+        <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
+                onclick="retryFailed('{{$j.ID}}')">Retry failed</button>
+        {{end}}
+        <a class="outline secondary" role="button" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;text-decoration:none;"
+           href="/api/benchmark-jobs/{{$j.ID}}/export?format=json" download>Export JSON</a>
+        <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
+                onclick="deleteJob('{{$j.ID}}','cascade')">Delete (with runs)</button>
+        <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
+                onclick="deleteJob('{{$j.ID}}','orphan')">Delete (keep runs)</button>
+    </div>
+</div>
+{{end}}

--- a/web/templates/partials/job_form.html
+++ b/web/templates/partials/job_form.html
@@ -43,7 +43,19 @@
         <summary>Overrides <small style="color:var(--pico-muted-color);">(blank = use each model's saved value)</small></summary>
         <div class="grid">
             <label>GPU layers <input type="number" name="ov_gpu_layers" placeholder=""></label>
-            <label>Context size <input type="number" name="ov_context_size" placeholder=""></label>
+            <label>Context size
+                <select name="ov_context_size">
+                    <option value="">inherit</option>
+                    <option value="2048">2K</option>
+                    <option value="4096">4K</option>
+                    <option value="8192">8K</option>
+                    <option value="16384">16K</option>
+                    <option value="32768">32K</option>
+                    <option value="65536">64K</option>
+                    <option value="131072">128K</option>
+                    <option value="262144">256K</option>
+                </select>
+            </label>
             <label>Threads <input type="number" name="ov_threads" placeholder=""></label>
         </div>
         <div class="grid">
@@ -70,9 +82,26 @@
             </label>
         </div>
         <div class="grid">
-            <label>GPU assign <input type="text" name="ov_gpu_assign" placeholder="e.g. all, 0, 0-1"></label>
+            <label>GPU assign
+                <select name="ov_gpu_assign">
+                    <option value="">inherit</option>
+                    {{range .GPUOptions}}
+                    <option value="{{.Value}}" {{if .Disabled}}disabled{{end}}>{{.Label}}</option>
+                    {{end}}
+                </select>
+            </label>
             <label>Tensor split <input type="text" name="ov_tensor_split" placeholder="e.g. 50,50"></label>
-            <label>Spec type <input type="text" name="ov_spec_type" placeholder="e.g. draft"></label>
+            <label>Spec type
+                <select name="ov_spec_type">
+                    <option value="">inherit</option>
+                    <option value="draft">Draft Model</option>
+                    <option value="ngram-simple">N-gram Simple</option>
+                    <option value="ngram-cache">N-gram Cache</option>
+                    <option value="ngram-map-k">N-gram Map-K</option>
+                    <option value="ngram-map-k4v">N-gram Map-K4V</option>
+                    <option value="ngram-mod">N-gram Mod</option>
+                </select>
+            </label>
         </div>
     </details>
 

--- a/web/templates/partials/job_form.html
+++ b/web/templates/partials/job_form.html
@@ -1,0 +1,90 @@
+{{define "job_form"}}
+<form id="new-job-form" onsubmit="event.preventDefault();submitNewJob();">
+    <label>
+        Name
+        <input type="text" name="name" required placeholder="Q4 vs Q8 sweep" oninput="updateMatrixCount()">
+    </label>
+    <label>
+        Description <small style="color:var(--pico-muted-color);">(optional)</small>
+        <input type="text" name="description" placeholder="What's this job exploring?">
+    </label>
+
+    <fieldset>
+        <legend>Models {{if not .Models}}<small style="color:var(--pico-del-color);">(no enabled models — enable at least one on the Models tab)</small>{{end}}</legend>
+        {{range .Models}}
+        <label>
+            <input type="checkbox" name="model" value="{{.ID}}" onchange="updateMatrixCount()">
+            <span>{{.ModelID}} <small style="color:var(--pico-muted-color);">({{.Quant}}, {{printf "%.1f" (divGB .SizeBytes)}} GB)</small></span>
+        </label>
+        {{end}}
+    </fieldset>
+
+    <fieldset>
+        <legend>Builds {{if not .Builds}}<small style="color:var(--pico-del-color);">(no successful builds — build llama.cpp first)</small>{{end}}</legend>
+        {{range .Builds}}
+        <label>
+            <input type="checkbox" name="build" value="{{.ID}}" onchange="updateMatrixCount()">
+            <span><kbd>{{.ID}}</kbd> <small style="color:var(--pico-muted-color);">({{.Profile}}{{if .GitRef}}, ref {{.GitRef}}{{end}}{{if .Tag}}, tag {{.Tag}}{{end}})</small></span>
+        </label>
+        {{end}}
+    </fieldset>
+
+    <fieldset>
+        <legend>Presets</legend>
+        {{range .Presets}}
+        <label>
+            <input type="checkbox" name="preset" value="{{.Name}}" onchange="updateMatrixCount()">
+            <span>{{.Label}}</span>
+        </label>
+        {{end}}
+    </fieldset>
+
+    <details>
+        <summary>Overrides <small style="color:var(--pico-muted-color);">(blank = use each model's saved value)</small></summary>
+        <div class="grid">
+            <label>GPU layers <input type="number" name="ov_gpu_layers" placeholder=""></label>
+            <label>Context size <input type="number" name="ov_context_size" placeholder=""></label>
+            <label>Threads <input type="number" name="ov_threads" placeholder=""></label>
+        </div>
+        <div class="grid">
+            <label>Flash attention
+                <select name="ov_flash_attention">
+                    <option value="">inherit</option>
+                    <option value="true">on</option>
+                    <option value="false">off</option>
+                </select>
+            </label>
+            <label>KV cache quant
+                <select name="ov_kv_cache_quant">
+                    <option value="">inherit</option>
+                    <option value="q8_0">q8_0</option>
+                    <option value="q4_0">q4_0</option>
+                </select>
+            </label>
+            <label>Direct I/O
+                <select name="ov_direct_io">
+                    <option value="">inherit</option>
+                    <option value="true">on</option>
+                    <option value="false">off</option>
+                </select>
+            </label>
+        </div>
+        <div class="grid">
+            <label>GPU assign <input type="text" name="ov_gpu_assign" placeholder="e.g. all, 0, 0-1"></label>
+            <label>Tensor split <input type="text" name="ov_tensor_split" placeholder="e.g. 50,50"></label>
+            <label>Spec type <input type="text" name="ov_spec_type" placeholder="e.g. draft"></label>
+        </div>
+    </details>
+
+    <p id="job-matrix-preview" style="margin:0.5rem 0;color:var(--pico-muted-color);">
+        Select models, builds, and presets to compute the matrix size.
+    </p>
+
+    <p id="job-form-error" style="margin:0.25rem 0;color:var(--pico-del-color);display:none;"></p>
+
+    <div style="display:flex;gap:0.5rem;justify-content:flex-end;">
+        <button type="button" class="outline secondary" onclick="closeJobForm()">Cancel</button>
+        <button type="submit" id="job-submit-btn">Create &amp; Start</button>
+    </div>
+</form>
+{{end}}

--- a/web/templates/partials/job_list.html
+++ b/web/templates/partials/job_list.html
@@ -10,11 +10,11 @@
     <summary>
         <span class="job-row-line1">
             <strong>{{$j.Name}}</strong>
-            <span class="job-status status-{{$j.Status}}" title="status: {{$j.Status}}">{{$j.Status}}</span>
+            <span id="job-status-{{$j.ID}}" class="job-status status-{{$j.Status}}" title="status: {{$j.Status}}">{{$j.Status}}</span>
             {{if eq $j.ID "adhoc"}}
-                <span class="job-progress">{{$entry.AdhocRuns}} run{{if ne $entry.AdhocRuns 1}}s{{end}}</span>
+                <span id="job-progress-{{$j.ID}}" class="job-progress">{{$entry.AdhocRuns}} run{{if ne $entry.AdhocRuns 1}}s{{end}}</span>
             {{else}}
-                <span class="job-progress">
+                <span id="job-progress-{{$j.ID}}" class="job-progress">
                     {{$entry.Done}}/{{$entry.Total}} cells
                     {{if gt $entry.Failed 0}}<span class="cell-failed-tag" title="failed cells">· {{$entry.Failed}} failed</span>{{end}}
                 </span>

--- a/web/templates/partials/job_list.html
+++ b/web/templates/partials/job_list.html
@@ -1,0 +1,41 @@
+{{define "job_list"}}
+{{if not .}}
+<p>No benchmark jobs yet. Click <strong>+ New Batch Job</strong> to create one.</p>
+{{else}}
+<div class="job-list">
+{{range $entry := .}}
+{{$j := $entry.Job}}
+<details class="job-row" data-job-id="{{$j.ID}}"
+         ontoggle="if(this.open && !this.dataset.loaded){this.dataset.loaded='1';htmx.trigger(this.querySelector('.job-detail-slot'),'showJobDetail');}">
+    <summary>
+        <span class="job-row-line1">
+            <strong>{{$j.Name}}</strong>
+            <span class="job-status status-{{$j.Status}}" title="status: {{$j.Status}}">{{$j.Status}}</span>
+            {{if eq $j.ID "adhoc"}}
+                <span class="job-progress">{{$entry.AdhocRuns}} run{{if ne $entry.AdhocRuns 1}}s{{end}}</span>
+            {{else}}
+                <span class="job-progress">
+                    {{$entry.Done}}/{{$entry.Total}} cells
+                    {{if gt $entry.Failed 0}}<span class="cell-failed-tag" title="failed cells">· {{$entry.Failed}} failed</span>{{end}}
+                </span>
+            {{end}}
+        </span>
+        <span class="job-row-line2">
+            {{if $j.Description}}<small class="job-desc">{{$j.Description}}</small>{{end}}
+            <small class="job-meta">
+                {{if not $j.CreatedAt.IsZero}}created {{$j.CreatedAt.Format "Jan 2 15:04"}}{{end}}
+                {{if not $j.FinishedAt.IsZero}} · finished {{$j.FinishedAt.Format "Jan 2 15:04"}}{{end}}
+            </small>
+        </span>
+    </summary>
+    <div class="job-detail-slot"
+         hx-get="/api/benchmark-jobs/{{$j.ID}}"
+         hx-trigger="showJobDetail"
+         hx-swap="innerHTML">
+        Loading…
+    </div>
+</details>
+{{end}}
+</div>
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary

Refactor the benchmarks system around **named, persistent batch jobs** that sweep `{models} × {builds} × {presets}`, capture full reproducibility context, and group all runs by job. Replaces `llama-bench` with `llama-benchy` so sharded GGUFs work, and folds the standalone single-run path into a 1-cell job builder so every run belongs to a job. Implementation followed `plan/batch-benchmarks.md` (committed in this branch).

### Headline changes
- **JobQueue** with single-job-at-a-time semantics, builds → models → presets cell ordering (one router restart per build), continue-on-fail, retry-failed, cancel.
- **`benchmarks.json` v1 → v2** envelope migration on load: synthesizes the `adhoc` job, backfills `JobID` and `Build` snapshot per run.
- **`/api/benchmark-jobs`** CRUD + SSE progress + cancel + retry-failed + export (CSV cells/summary + JSON envelope), plus `?job=` / `?scope=adhoc|batch` filters on the existing run list.
- **UI**: jobs list with collapsible per-job detail (live cells table, OOB summary updates, no-flash refresh), New Batch Job modal with multi-select models/builds/presets + overrides + live cell-count, Quick Benchmark form now creates a 1-cell job, redundant flat run list removed.
- **Compare view fixes**: wider model column, full-id tooltips, Build column with Tag·SHA hover, client-side sort across bar charts + pivoted (one-row-per-run) details table.
- **Build pre-flight guard**: `ldd` check before activating a build catches stale binaries (e.g. ROCm SONAME bumps) and fails the cell with a clear message instead of crashing the router.
- **About modal**: rendered live from `/api/benchmarks/about` — preset table, internal prompt prose + per-rep prefix, exact `uvx llama-benchy` command per benchy preset, metric glossary including TTFR / peak / e2e_ttft.

### Implementation order (10 steps from the plan)
1. llama-benchy integration alongside existing presets (`benchy-quick`, `benchy-standard`)
2. Drop `llama-bench`, rename to `internal-*`, add `internal-long-ctx`
3. `BuildSnapshot` on every `BenchmarkRun`
4. `BenchmarkJob` / `JobCell` / `ConfigOverrides` types + v2 storage migration
5. `JobQueue` + `JobRunner` orchestration
6. `/api/benchmark-jobs` HTTP endpoints + SSE
7. Jobs list / detail / new-job form UI; Quick Benchmark folded into 1-cell job
8. Compare view fixes
9. Full CSV (cells + summary) + JSON exports
10. About modal live-rendered from `/api/benchmarks/about`

### Container / host notes
- Containers (`Dockerfile.{cpu,cuda,rocm}`) and the setup-prompted host install both need `uv` available on `PATH` for `benchy-*` presets. Each invocation passes `--with sentencepiece --with tiktoken` to llama-benchy so the right tokenizer backend is used (without it the tool falls back to GPT-2 and prompt sizes drift).
- `JobEnv.CheckBuildRunnable` parses `ldd` output (with `LD_LIBRARY_PATH=$binDir` set, mirroring `process.Manager`) so cells against a stale build fail fast instead of restarting the router.

### Backwards compatibility
- `benchmarks.json` migrates v1 → v2 transparently on first load. Old preset names (`quick`/`standard`/`thorough`) resolve via an alias map so persisted runs render correctly.
- Legacy `LlamaBench` field is retained on `BenchmarkRun` for old data; the detail view labels it "Legacy llama-bench result".
- The previous `/api/benchmarks/export` CSV column layout is intentionally replaced by the documented schema.

## Test plan
- [ ] Restart llama-toolchest after pulling — verify the v1 → v2 migration completes and existing runs land under "Ad-Hoc Runs".
- [ ] Create a 2×2×2 batch job (2 models × 2 builds × 2 presets), confirm `EnsureBuildActive` fires exactly twice.
- [ ] Force a failed cell (point a model at a stale or unrunnable build), confirm the rest of the job continues; Retry Failed re-runs only the failed cell.
- [ ] Cancel a running job mid-cell — final status is `canceled`, remaining cells `skipped`, no router process leak.
- [ ] Run a sharded GGUF under `benchy-standard` — confirms the headline reason for the swap.
- [ ] Concurrent submit while a job is running → 409.
- [ ] Compare 4+ runs from 2+ jobs: full model names visible, Build column populated, sort buttons re-order rows.
- [ ] Per-job + per-selection exports: CSV (cells), CSV (summary), JSON. Inspect the columns match `plan/batch-benchmarks.md`.
- [ ] Open About modal — preset table + prose passage + per-benchy-preset commands + glossary all rendered from server.
- [ ] Quick Benchmark form still works end-to-end and produces a 1-cell job with `Quick: <model> / <preset>` name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)