### PR TITLE
feat(setup): auto-route up/down/logs and harden host cuda install

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -418,7 +418,50 @@ func (b *Builder) runBuild(ctx context.Context, prof BuildProfile, srcDir string
 		cmakeArgs = append(cmakeArgs, fmt.Sprintf("-D%s=%s", k, v))
 	}
 
-	if err := b.runCmd(ctx, buildDir, logCh, result.ID, "cmake", cmakeArgs...); err != nil {
+	// NVIDIA's official RPM/DEB installs nvcc at /usr/local/cuda/bin without
+	// adding it to PATH. The systemd-managed service inherits a minimal PATH,
+	// so cmake's enable_language(CUDA) probe fails with "No CMAKE_CUDA_COMPILER
+	// could be found" even when the toolkit is installed. Locate nvcc and pin
+	// it explicitly when building the cuda profile.
+	//
+	// Separately, modern distros now ship a default g++ that nvcc rejects
+	// (e.g. Fedora 44 ships gcc 16, but CUDA 12.x's host_config.h refuses
+	// anything past gcc 13/14/15 depending on toolkit version). Probe for
+	// a compatible side-by-side g++ and hand it to cmake as the host
+	// compiler — without this, build fails on "unsupported GNU version".
+	buildEnv := os.Environ()
+	if prof.Backend == "cuda" {
+		if nvcc, dir := findNVCC(); nvcc != "" {
+			alreadySet := false
+			for _, a := range cmakeArgs {
+				if strings.HasPrefix(a, "-DCMAKE_CUDA_COMPILER=") {
+					alreadySet = true
+					break
+				}
+			}
+			if !alreadySet {
+				cmakeArgs = append(cmakeArgs, "-DCMAKE_CUDA_COMPILER="+nvcc)
+				sendLog(fmt.Sprintf("==> Using nvcc at %s", nvcc))
+			}
+			buildEnv = prependPath(buildEnv, dir)
+		}
+		hostCC := findCUDAHostCompiler()
+		if hostCC != "" {
+			hostCCAlreadySet := false
+			for _, a := range cmakeArgs {
+				if strings.HasPrefix(a, "-DCMAKE_CUDA_HOST_COMPILER=") {
+					hostCCAlreadySet = true
+					break
+				}
+			}
+			if !hostCCAlreadySet {
+				cmakeArgs = append(cmakeArgs, "-DCMAKE_CUDA_HOST_COMPILER="+hostCC)
+				sendLog(fmt.Sprintf("==> Using CUDA host compiler %s", hostCC))
+			}
+		}
+	}
+
+	if err := b.runCmd(ctx, buildDir, logCh, result.ID, buildEnv, "cmake", cmakeArgs...); err != nil {
 		b.finishBuild(result, BuildStatusFailed, fmt.Sprintf("cmake failed: %v", err))
 		sendLog(fmt.Sprintf("==> cmake FAILED: %v", err))
 		return
@@ -426,7 +469,7 @@ func (b *Builder) runBuild(ctx context.Context, prof BuildProfile, srcDir string
 
 	// ninja — build all targets (target names vary across llama.cpp versions)
 	sendLog("==> Running ninja...")
-	if err := b.runCmd(ctx, buildDir, logCh, result.ID, "ninja", "-j", fmt.Sprintf("%d", runtime.NumCPU())); err != nil {
+	if err := b.runCmd(ctx, buildDir, logCh, result.ID, buildEnv, "ninja", "-j", fmt.Sprintf("%d", runtime.NumCPU())); err != nil {
 		b.finishBuild(result, BuildStatusFailed, fmt.Sprintf("ninja failed: %v", err))
 		sendLog(fmt.Sprintf("==> ninja FAILED: %v", err))
 		return
@@ -532,11 +575,11 @@ func (b *Builder) finishBuild(result *BuildResult, status, errMsg string) {
 func (b *Builder) ensureRepo(ctx context.Context, srcDir string, logCh chan string) error {
 	if _, err := os.Stat(filepath.Join(srcDir, ".git")); err == nil {
 		sendLog(logCh, "==> Fetching latest from llama.cpp...")
-		return b.runCmd(ctx, srcDir, logCh, "", "git", "fetch", "--all", "--tags")
+		return b.runCmd(ctx, srcDir, logCh, "", nil, "git", "fetch", "--all", "--tags")
 	}
 
 	sendLog(logCh, "==> Cloning llama.cpp...")
-	return b.runCmd(ctx, filepath.Dir(srcDir), logCh, "", "git", "clone", llamaCppRepo, filepath.Base(srcDir))
+	return b.runCmd(ctx, filepath.Dir(srcDir), logCh, "", nil, "git", "clone", llamaCppRepo, filepath.Base(srcDir))
 }
 
 // checkoutRef checks out the given ref and returns (resolvedRef, sha, error).
@@ -559,7 +602,7 @@ func (b *Builder) checkoutRef(ctx context.Context, srcDir string, ref string, lo
 	}
 
 	sendLog(logCh, fmt.Sprintf("==> Checking out %s...", ref))
-	if err := b.runCmd(ctx, srcDir, logCh, "", "git", "checkout", ref); err != nil {
+	if err := b.runCmd(ctx, srcDir, logCh, "", nil, "git", "checkout", ref); err != nil {
 		return "", "", err
 	}
 
@@ -634,9 +677,14 @@ func (b *Builder) HasBuild(id string) bool {
 }
 
 // runCmd runs a command, streaming stdout+stderr line-by-line to the log channel.
-func (b *Builder) runCmd(ctx context.Context, dir string, logCh chan string, buildID string, name string, args ...string) error {
+// If env is non-nil it overrides the inherited environment; pass nil to inherit
+// os.Environ() unchanged (the common case for git operations).
+func (b *Builder) runCmd(ctx context.Context, dir string, logCh chan string, buildID string, env []string, name string, args ...string) error {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
+	if env != nil {
+		cmd.Env = env
+	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -764,5 +812,64 @@ func copyFile(src, dst string) error {
 
 	_, err = io.Copy(out, in)
 	return err
+}
+
+// findCUDAHostCompiler probes for a side-by-side g++ that nvcc will
+// accept as host compiler. Modern distros (Fedora 44 with gcc 16,
+// Ubuntu 24.04 with gcc 13/14) ship a default g++ that exceeds CUDA's
+// supported range; the side-by-side packages (gcc15-c++, g++-13, ...)
+// land at /usr/bin/g++-N. Returns the absolute path of the highest
+// available version, or "" if none is installed.
+func findCUDAHostCompiler() string {
+	for _, c := range []string{
+		"/usr/bin/g++-15",
+		"/usr/bin/g++-14",
+		"/usr/bin/g++-13",
+		"/usr/bin/g++-12",
+	} {
+		if st, err := os.Stat(c); err == nil && !st.IsDir() {
+			return c
+		}
+	}
+	return ""
+}
+
+// findNVCC locates the CUDA compiler. NVIDIA's official RPM/DEB installs
+// nvcc under /usr/local/cuda/bin without adding it to PATH, so PATH alone
+// isn't enough. Returns (full path, containing dir) or ("", "") if absent.
+func findNVCC() (string, string) {
+	if p, err := exec.LookPath("nvcc"); err == nil {
+		return p, filepath.Dir(p)
+	}
+	for _, c := range []string{"/usr/local/cuda/bin/nvcc", "/opt/cuda/bin/nvcc"} {
+		if st, err := os.Stat(c); err == nil && !st.IsDir() {
+			return c, filepath.Dir(c)
+		}
+	}
+	return "", ""
+}
+
+// prependPath returns env with dir prepended to PATH (no-op if dir is
+// already first). Operates on a copy so the caller's slice is unchanged.
+func prependPath(env []string, dir string) []string {
+	out := make([]string, 0, len(env)+1)
+	found := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			cur := strings.TrimPrefix(kv, "PATH=")
+			if cur == dir || strings.HasPrefix(cur, dir+":") {
+				out = append(out, kv)
+			} else {
+				out = append(out, "PATH="+dir+":"+cur)
+			}
+			found = true
+		} else {
+			out = append(out, kv)
+		}
+	}
+	if !found {
+		out = append(out, "PATH="+dir)
+	}
+	return out
 }
 

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -24,6 +24,10 @@
 #   host_install
 #   host_uninstall
 #   host_status
+#   host_is_installed
+#   host_up
+#   host_down
+#   host_logs
 
 host_scope() {
     if [[ $EUID -eq 0 ]]; then
@@ -88,6 +92,40 @@ host_check_build_toolchain() {
     return 0
 }
 
+# Locate a side-by-side g++ that nvcc will accept as host compiler. The
+# default system g++ on modern distros (gcc 16 on Fedora 44) outpaces what
+# CUDA's host_config.h will allow, so the builder explicitly hands nvcc a
+# compat compiler when one is installed. Echoes the absolute path on
+# success (returns 0); silent on miss (returns 1).
+host_find_cuda_host_compiler() {
+    for c in /usr/bin/g++-15 /usr/bin/g++-14 /usr/bin/g++-13 /usr/bin/g++-12; do
+        if [[ -x "$c" ]]; then
+            echo "$c"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Locate nvcc, looking past PATH. NVIDIA's official RPM/DEB installs it
+# under /usr/local/cuda/bin without touching PATH, so a plain `command -v`
+# misses it. Echoes the absolute path if found and returns 0; otherwise
+# returns 1 with no output. Used by both the SDK-presence check and the
+# builder PATH augmentation guidance.
+host_find_nvcc() {
+    if command -v nvcc >/dev/null 2>&1; then
+        command -v nvcc
+        return 0
+    fi
+    for candidate in /usr/local/cuda/bin/nvcc /opt/cuda/bin/nvcc; do
+        if [[ -x "$candidate" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Map a GPU backend to the package list needed for llama.cpp to compile
 # against it on this distro family. Echoes a space-separated list (empty
 # if everything is already present, or if we don't know how to detect
@@ -117,9 +155,41 @@ host_missing_gpu_sdk_packages() {
             esac
             ;;
         cuda)
-            # Detect by binary presence — CUDA toolkit ships nvcc; if it's
-            # on PATH we have what we need to compile.
-            command -v nvcc >/dev/null 2>&1 || need+=("cuda-toolkit")
+            # Detect by binary presence — CUDA toolkit ships nvcc. NVIDIA's
+            # RPM/DEB drops it under /usr/local/cuda/bin (not on PATH);
+            # Fedora's RPMFusion cuda-devel and Arch's cuda put it on PATH.
+            # Treat any of these as "installed" so we don't try to dnf-install
+            # a package that's already there.
+            host_find_nvcc >/dev/null || need+=("cuda-toolkit")
+            # nvcc rejects host compilers newer than its supported ceiling
+            # (e.g. CUDA 12.x refuses gcc 16). Pull in a side-by-side gcc
+            # the builder can hand to cmake via CMAKE_CUDA_HOST_COMPILER.
+            # Names differ per distro — and on Fedora, the version of the
+            # compat package shifts each release (Fedora 44 ships gcc15
+            # only; older releases shipped gcc13/gcc14). Pick the first one
+            # the distro actually offers.
+            case "$DISTRO_FAMILY" in
+                fedora)
+                    if ! host_find_cuda_host_compiler >/dev/null 2>&1; then
+                        for pkg in gcc15-c++ gcc14-c++ gcc13-c++; do
+                            if dnf info "$pkg" >/dev/null 2>&1; then
+                                need+=("$pkg")
+                                break
+                            fi
+                        done
+                    fi
+                    ;;
+                debian)
+                    if ! host_find_cuda_host_compiler >/dev/null 2>&1; then
+                        for pkg in g++-13 g++-12 g++-14; do
+                            if apt-cache show "$pkg" >/dev/null 2>&1; then
+                                need+=("$pkg")
+                                break
+                            fi
+                        done
+                    fi
+                    ;;
+            esac
             ;;
         vulkan)
             # llama.cpp's Vulkan backend pulls in the Vulkan loader/headers
@@ -159,6 +229,76 @@ host_missing_gpu_sdk_packages() {
     echo "${need[*]}"
 }
 
+# Ensure NVIDIA's CUDA dnf repository is configured. The base Fedora repos
+# don't carry cuda-toolkit, so without this `dnf install cuda-toolkit` only
+# works if the user manually downloaded an RPM (which is how stale 12.6
+# installs end up locked to a release that doesn't support newer GPUs).
+# NVIDIA publishes a per-Fedora-version repo file; we probe the running
+# version first, then walk back through known-good releases. No-op if a
+# cuda-fedora*.repo is already present.
+host_install_nvidia_cuda_repo_fedora() {
+    if compgen -G "/etc/yum.repos.d/cuda-fedora*.repo" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    local current_ver
+    current_ver="$(rpm -E %fedora 2>/dev/null || echo 41)"
+
+    log "NVIDIA CUDA dnf repository is not configured."
+    if ! prompt_confirm "Add it now? (needed to install or upgrade cuda-toolkit on Fedora)"; then
+        warn "Skipped — cuda-toolkit install will likely fail without this repo."
+        return 1
+    fi
+
+    local versions=("$current_ver")
+    # Walk back through Fedora releases NVIDIA has historically published.
+    # Newer releases are tried first; the first reachable one wins.
+    for v in 44 43 42 41; do
+        [[ "$v" == "$current_ver" ]] && continue
+        versions+=("$v")
+    done
+
+    local repo_url
+    for ver in "${versions[@]}"; do
+        repo_url="https://developer.download.nvidia.com/compute/cuda/repos/fedora${ver}/x86_64/cuda-fedora${ver}.repo"
+        log "Probing $repo_url"
+        if curl -fsI "$repo_url" >/dev/null 2>&1; then
+            curl -fsSL "$repo_url" | run_sudo tee "/etc/yum.repos.d/cuda-fedora${ver}.repo" >/dev/null || return 1
+            ok "NVIDIA CUDA repository configured (fedora${ver})"
+            return 0
+        fi
+    done
+    warn "Couldn't reach NVIDIA's CUDA repo for any tested Fedora version."
+    log "Configure it manually from https://developer.nvidia.com/cuda-downloads and re-run."
+    return 1
+}
+
+# Parse the installed cuda-toolkit version. Echoes the major.minor (e.g.
+# "12.6") if a versioned cuda-toolkit package is installed; empty if
+# nothing's installed or if rpm isn't usable. Used to nudge users off
+# stale CUDA versions that don't support modern GPUs.
+host_installed_cuda_version() {
+    [[ "$DISTRO_FAMILY" == "fedora" ]] || return 0
+    rpm -qa 'cuda-toolkit-*-config-common' 2>/dev/null \
+        | sed -n 's/^cuda-toolkit-\([0-9]\+\)-\([0-9]\+\)-config-common.*/\1.\2/p' \
+        | sort -V | tail -n 1
+}
+
+# Detect the highest GPU compute capability via nvidia-smi. Echoes "X.Y"
+# (e.g. "12.0" for Blackwell / RTX 50xx) or empty if nvidia-smi isn't
+# available. Best-effort — we use it only to scale up warnings, never to
+# block an install.
+host_gpu_compute_cap() {
+    command -v nvidia-smi >/dev/null 2>&1 || return 0
+    nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null \
+        | sort -V | tail -n 1 | tr -d ' '
+}
+
+# Compare two dotted versions. Returns 0 (true) if $1 >= $2.
+host_version_ge() {
+    [[ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | tail -n 1)" == "$1" ]]
+}
+
 # Offer to install missing GPU SDK packages for the chosen backend.
 # Returns 0 if everything is in place (or user declined), 1 on install
 # failure. Distro-aware: fedora and debian get auto-install; others get
@@ -173,6 +313,8 @@ host_install_gpu_sdk() {
             cpu|metal) ;;
             *) ok "GPU SDK ($backend): all required packages installed" ;;
         esac
+        host_warn_cuda_offpath "$backend"
+        host_warn_cuda_version_for_gpu "$backend"
         return 0
     fi
 
@@ -181,6 +323,11 @@ host_install_gpu_sdk() {
 
     case "$DISTRO_FAMILY" in
         fedora)
+            # cuda-toolkit isn't in Fedora's base repos — make sure NVIDIA's
+            # is wired up before dnf goes hunting for it.
+            if [[ "$backend" == "cuda" ]] && [[ "$missing" == *cuda-toolkit* ]]; then
+                host_install_nvidia_cuda_repo_fedora || true
+            fi
             log "Run: sudo dnf install $missing"
             if prompt_confirm "Install now?"; then
                 # shellcheck disable=SC2086
@@ -215,7 +362,60 @@ host_install_gpu_sdk() {
             return 1
             ;;
     esac
+    host_warn_cuda_offpath "$backend"
+    host_warn_cuda_version_for_gpu "$backend"
     return 0
+}
+
+# Loud-warn if the installed CUDA toolkit predates the GPU's compute
+# capability. RTX 50xx (Blackwell, sm_120) needs CUDA 12.8+; CUDA 12.6 will
+# build but silently fall back to an older arch and won't actually run on
+# the GPU. We can't auto-upgrade safely (NVIDIA's repo split keeps multiple
+# versions on disk), so spell out the manual fix.
+host_warn_cuda_version_for_gpu() {
+    [[ "$1" == "cuda" ]] || return 0
+    local cuda_ver gpu_cap
+    cuda_ver="$(host_installed_cuda_version)"
+    gpu_cap="$(host_gpu_compute_cap)"
+    [[ -z "$cuda_ver" || -z "$gpu_cap" ]] && return 0
+
+    # Required CUDA toolkit major.minor by GPU compute capability.
+    # Blackwell needs 12.8; Hopper (9.0) was already on 11.8/12.0.
+    local needed=""
+    if host_version_ge "$gpu_cap" "12.0"; then
+        needed="12.8"
+    fi
+    [[ -z "$needed" ]] && return 0
+
+    if ! host_version_ge "$cuda_ver" "$needed"; then
+        warn "CUDA toolkit $cuda_ver is older than the GPU requires (compute $gpu_cap → CUDA >= $needed)."
+        log "llama.cpp will build but won't actually run on this GPU."
+        # Offer to wire up NVIDIA's repo so the user can upgrade in-place.
+        # We don't run the upgrade ourselves — that's a multi-package shuffle
+        # and the user should see what dnf is about to do.
+        if [[ "$DISTRO_FAMILY" == "fedora" ]]; then
+            host_install_nvidia_cuda_repo_fedora || true
+            log "To upgrade, run:"
+            echo "    sudo dnf install cuda-toolkit"
+        fi
+    fi
+}
+
+# NVIDIA's official RPM/DEB drops nvcc at /usr/local/cuda/bin without
+# touching PATH, which breaks cmake's CUDA detection for anyone running
+# the build outside the llama-toolchest service (which sets the path
+# explicitly in the builder). Emit a heads-up so users know how to wire
+# it into their shell.
+host_warn_cuda_offpath() {
+    [[ "$1" == "cuda" ]] || return 0
+    if command -v nvcc >/dev/null 2>&1; then
+        return 0
+    fi
+    local nvcc_path
+    nvcc_path="$(host_find_nvcc 2>/dev/null)" || return 0
+    log "nvcc is installed at $nvcc_path but not on PATH."
+    log "llama-toolchest's builder picks it up automatically. To run cmake/nvcc by hand, add:"
+    echo "    export PATH=\"$(dirname "$nvcc_path"):\$PATH\""
 }
 
 host_build_binary() {
@@ -411,7 +611,11 @@ host_write_unit_override() {
     if [[ "$need_execstart" == false ]] && [[ "$need_env" == false ]]; then
         # Clean up any stale override left from a previous from-source install.
         local stale="$override_dir/override.conf"
-        [[ -f "$stale" ]] && rm -f "$stale" && log "Removed stale unit override"
+        if [[ -f "$stale" ]]; then
+            rm -f "$stale"
+            log "Removed stale unit override"
+            _systemctl daemon-reload
+        fi
         return 0
     fi
 
@@ -430,6 +634,10 @@ host_write_unit_override() {
     } > "$override_file"
 
     log "Wrote unit override: $override_file"
+    # systemd needs a reload to pick up override.conf changes; without this,
+    # the next service_restart re-runs the previously cached ExecStart and
+    # ignores our new binary path.
+    _systemctl daemon-reload
 }
 
 host_install() {
@@ -585,6 +793,46 @@ host_uninstall() {
     fi
 
     ok "Host uninstall complete."
+}
+
+# Returns 0 if a host install is present (binary on disk, either the
+# packaged /usr/bin path or a from-source path under host_bin_dir).
+# Used by setup.sh's auto-routing for up/down/logs to decide whether
+# to call into the host or container path.
+host_is_installed() {
+    [[ -x /usr/bin/llama-toolchest ]] || [[ -x "$(host_binary_path)" ]]
+}
+
+host_up() {
+    if ! host_is_installed; then
+        err "No host install found. Run './setup.sh install --host' first."
+        return 1
+    fi
+    if service_is_active; then
+        ok "llama-toolchest is already running"
+        return 0
+    fi
+    log "Starting llama-toolchest service..."
+    service_start
+    ok "llama-toolchest started"
+}
+
+host_down() {
+    if ! service_is_active; then
+        ok "llama-toolchest is already stopped"
+        return 0
+    fi
+    log "Stopping llama-toolchest service..."
+    service_stop
+    ok "llama-toolchest stopped"
+}
+
+host_logs() {
+    if [[ "$(service_scope)" == "user" ]]; then
+        journalctl --user -u "$SERVICE_NAME" -f
+    else
+        journalctl -u "$SERVICE_NAME" -f
+    fi
 }
 
 # Whether a backend is applicable to this host. Used by deps/status to

--- a/scripts/lib/service.sh
+++ b/scripts/lib/service.sh
@@ -16,6 +16,9 @@
 #   service_uninstall             → stop, disable, remove unit file, daemon-reload
 #   service_enable                → enable + start
 #   service_disable               → stop + disable (leaves unit file in place)
+#   service_start                 → start (without changing enabled state)
+#   service_stop                  → stop (without changing enabled state)
+#   service_restart               → restart
 #   service_status                → show status (multi-line)
 #   service_is_active             → returns 0 if active, 1 otherwise
 #
@@ -95,6 +98,16 @@ service_disable() {
 
 service_restart() {
     _systemctl restart "$SERVICE_NAME"
+}
+
+# Plain start/stop — used by `setup.sh up`/`down` to toggle the running
+# state without touching whether the unit is enabled at boot.
+service_start() {
+    _systemctl start "$SERVICE_NAME"
+}
+
+service_stop() {
+    _systemctl stop "$SERVICE_NAME"
 }
 
 service_status() {

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,13 @@ COMPOSE_CMD=""          # "docker compose" or "podman-compose" or "podman compos
 CONTAINER_VERSION=""
 COMPOSE_VERSION=""
 
+# Tracks whether the user explicitly picked a mode this run (via --host /
+# --container / --cuda / etc. or the INSTALL_MODE env var). Stateful
+# commands (up/down/logs) auto-detect from disk only when the user did NOT
+# pick — otherwise the explicit choice wins. Set BEFORE the default so an
+# inherited INSTALL_MODE env var still counts as explicit.
+INSTALL_MODE_EXPLICIT="${INSTALL_MODE:+true}"
+INSTALL_MODE_EXPLICIT="${INSTALL_MODE_EXPLICIT:-false}"
 INSTALL_MODE="${INSTALL_MODE:-container}"  # host or container; default container preserves existing behavior
 HOST_INSTALL_MODE="${HOST_INSTALL_MODE:-package}"  # for --host: "package" (download released .deb/.rpm) or "source" (go build locally)
 HOST_SDK_BACKENDS=()    # backends to install host SDKs for (--cuda/--rocm/--vulkan); empty means autodetect+prompt
@@ -1336,6 +1343,36 @@ source "${SCRIPT_DIR}/scripts/lib/host.sh"
 # shellcheck source=scripts/lib/migrate.sh
 source "${SCRIPT_DIR}/scripts/lib/migrate.sh"
 
+# Detect which install modes are present on this machine. Echoes one of:
+#   host       — only a host install (binary on disk + systemd unit)
+#   container  — only a container install (named llama-toolchest exists)
+#   both       — both are present (e.g. mid-migration); caller must disambiguate
+#   none       — nothing installed
+# Used by up/down/logs/status to route to the right backend without forcing
+# the user to remember which install they have.
+detect_install_mode() {
+    local has_host=false has_container=false
+    host_is_installed && has_host=true
+
+    # Container detection needs $CONTAINER_CMD; populate it if not set yet.
+    if [[ -z "${CONTAINER_CMD:-}" ]]; then
+        detect_container_runtime 2>/dev/null || true
+    fi
+    if [[ -n "${CONTAINER_CMD:-}" ]] && container_exists llama-toolchest; then
+        has_container=true
+    fi
+
+    if [[ "$has_host" == true && "$has_container" == true ]]; then
+        echo "both"
+    elif [[ "$has_host" == true ]]; then
+        echo "host"
+    elif [[ "$has_container" == true ]]; then
+        echo "container"
+    else
+        echo "none"
+    fi
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 usage() {
@@ -1390,12 +1427,12 @@ Lifecycle:
               Use this when you've changed the Dockerfile or want to
               refresh the GPU SDK layers as well.
 
-Runtime (container only):
-  up          Start a stopped container
-  down        Stop the container
-  logs        Follow container logs (Ctrl-C to stop)
+Runtime (works for both host and container installs — auto-detected):
+  up          Start a stopped install (container or host service)
+  down        Stop a running install
+  logs        Follow logs (Ctrl-C to stop)
 
-Auto-start (container only):
+Auto-start (container only — for host installs use systemctl directly):
   enable      Enable auto-start on boot
   disable     Disable auto-start on boot
 
@@ -1452,17 +1489,17 @@ main() {
     # ── Parse flags after the command ──
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --host)         INSTALL_MODE="host" ;;
-            --container)    INSTALL_MODE="container" ;;
-            --from-source)  INSTALL_MODE="host"; HOST_INSTALL_MODE="source" ;;
-            --from-package) INSTALL_MODE="host"; HOST_INSTALL_MODE="package" ;;
+            --host)         INSTALL_MODE="host"; INSTALL_MODE_EXPLICIT=true ;;
+            --container)    INSTALL_MODE="container"; INSTALL_MODE_EXPLICIT=true ;;
+            --from-source)  INSTALL_MODE="host"; HOST_INSTALL_MODE="source"; INSTALL_MODE_EXPLICIT=true ;;
+            --from-package) INSTALL_MODE="host"; HOST_INSTALL_MODE="package"; INSTALL_MODE_EXPLICIT=true ;;
             # Backend flags are additive and host-mode-only (vulkan can't run
             # in containers without driver passthrough we don't manage; for
             # consistency cuda/rocm flags also imply --host). Stack them:
             # `./setup.sh install --rocm --vulkan` installs both SDKs.
-            --cuda)         INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("cuda") ;;
-            --rocm)         INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("rocm") ;;
-            --vulkan)       INSTALL_MODE="host"; HOST_SDK_BACKENDS+=("vulkan") ;;
+            --cuda)         INSTALL_MODE="host"; INSTALL_MODE_EXPLICIT=true; HOST_SDK_BACKENDS+=("cuda") ;;
+            --rocm)         INSTALL_MODE="host"; INSTALL_MODE_EXPLICIT=true; HOST_SDK_BACKENDS+=("rocm") ;;
+            --vulkan)       INSTALL_MODE="host"; INSTALL_MODE_EXPLICIT=true; HOST_SDK_BACKENDS+=("vulkan") ;;
             # Direction flags for the `migrate` command. Mutually exclusive
             # — passing both is an error. Each implies its target mode for
             # the purpose of post-flag dispatch.
@@ -1503,6 +1540,32 @@ main() {
             exit 1
             ;;
     esac
+
+    # ── Auto-route stateful commands by detecting which install is present ──
+    # up/down/logs are mode-agnostic from the user's POV: they want to start,
+    # stop, or tail logs for "the install that's there." Detect it instead of
+    # forcing the user to remember --host vs --container. install/migrate/etc.
+    # set up new state and don't auto-route.
+    if [[ "$INSTALL_MODE_EXPLICIT" != "true" ]]; then
+        case "$command" in
+            up|down|logs)
+                local detected
+                detected="$(detect_install_mode)"
+                case "$detected" in
+                    host)      INSTALL_MODE="host" ;;
+                    container) INSTALL_MODE="container" ;;
+                    both)
+                        err "Both host and container installs detected — pass --host or --container to disambiguate."
+                        exit 1
+                        ;;
+                    none)
+                        err "No llama-toolchest install detected. Run './setup.sh install' first."
+                        exit 1
+                        ;;
+                esac
+                ;;
+        esac
+    fi
 
     # ── migrate: hybrid command, needs both container and host context ──
     if [[ "$command" == "migrate" ]]; then
@@ -1593,15 +1656,16 @@ main() {
             status)    host_status ;;
             deps)      host_deps ;;
             detect)    echo "$GPU_VENDOR" ;;
-            up|down|logs|enable|disable|rebuild|quick)
+            up)        host_up ;;
+            down)      host_down ;;
+            logs)      host_logs ;;
+            enable|disable|rebuild|quick)
                 err "'$command' is not supported in --host mode."
-                log "For host installs, manage the service via systemd directly:"
+                log "For host installs, manage autostart via systemd directly:"
                 if [[ "$(host_scope 2>/dev/null)" == "system" ]]; then
-                    echo "    sudo systemctl start|stop|status|enable|disable llama-toolchest"
-                    echo "    sudo journalctl -u llama-toolchest -f      # logs"
+                    echo "    sudo systemctl enable|disable llama-toolchest"
                 else
-                    echo "    systemctl --user start|stop|status|enable|disable llama-toolchest"
-                    echo "    journalctl --user -u llama-toolchest -f    # logs"
+                    echo "    systemctl --user enable|disable llama-toolchest"
                 fi
                 exit 1
                 ;;


### PR DESCRIPTION
## Summary

- **`setup.sh up`/`down`/`logs` work for both install modes now.** Without an explicit `--host`/`--container` flag, they detect what's on disk and route accordingly. Errors clearly when both modes are present (ambiguous) or neither is (nothing to start). Explicit flags still win.
- **Host CUDA install is robust on Fedora 44 + RTX 5080.** Surfaced by upgrading from an AMD card to a 5080: nvcc not on PATH, gcc 16 too new for CUDA 12.6, no NVIDIA repo configured, daemon-reload missing after override.conf changes. All addressed.
- **`builder.go` plumbs nvcc + a compatible host compiler** into the cmake invocation for the cuda profile, so the systemd-managed service can build llama.cpp without inheriting a custom PATH.

## What's in here

### Auto-routing (`setup.sh`, `scripts/lib/{host,service}.sh`)
- New `detect_install_mode()` returns `host` / `container` / `both` / `none`.
- `INSTALL_MODE_EXPLICIT` flag tracks whether the user passed a mode flag (or set `INSTALL_MODE=` env). Auto-route only fires when no explicit choice is made.
- Host dispatch grew `host_up` / `host_down` / `host_logs` (thin wrappers over `service_start`/`service_stop`/`journalctl`); `service.sh` got plain `service_start`/`service_stop` so up/down don't toggle the enabled state.
- Usage text updated to reflect the new behavior.

### Host CUDA install (`scripts/lib/host.sh`)
- `host_find_nvcc` looks at PATH, `/usr/local/cuda/bin`, `/opt/cuda/bin` so detection isn't fooled when NVIDIA's RPM is installed but PATH isn't set.
- `host_find_cuda_host_compiler` probes `/usr/bin/g++-15`, `g++-14`, `g++-13`, `g++-12`.
- `host_install_nvidia_cuda_repo_fedora` adds NVIDIA's per-Fedora-release repo when cuda-toolkit is missing or stale (probes current Fedora version, falls back through 44/43/42/41).
- `host_warn_cuda_offpath` and `host_warn_cuda_version_for_gpu` surface PATH and version mismatches with concrete remediation.
- The cuda branch of `host_missing_gpu_sdk_packages` now adds `gcc15-c++` (Fedora) / `g++-13` (Debian) when no compatible side-by-side compiler is installed.
- `host_write_unit_override` runs `daemon-reload` after writing/removing `override.conf` — without this, `service_restart` re-runs the cached ExecStart and silently ignores the new binary path. (This is what was making `from-source` installs appear to do nothing.)

### Builder (`internal/builder/builder.go`)
- New `findNVCC` / `findCUDAHostCompiler` helpers.
- `runCmd` now accepts a per-build env slice (nil = inherit, used by git ops).
- For the cuda profile, cmake gets `-DCMAKE_CUDA_COMPILER=<nvcc>` and `-DCMAKE_CUDA_HOST_COMPILER=<g++-N>` when those exist, plus `/usr/local/cuda/bin` prepended to PATH for ninja's downstream tool calls.
- Build log emits `==> Using nvcc at ...` / `==> Using CUDA host compiler ...` so failures point at the right place.

## Test plan

- [x] `./setup.sh down` / `up` without flags routes to host service on a host-only install
- [x] `--host` / `--container` flags still force the explicit path
- [x] CUDA build on Fedora 44 + RTX 5080 (CUDA 13.2, gcc15-c++) compiles llama.cpp cleanly through the UI
- [x] `bash -n` syntax check on all touched shell files
- [x] `go build ./...` and `go vet ./...` pass
- [ ] Container path for `up`/`down` still works (smoke test: explicit `--container` invocation tried podman as expected; full container install not exercised in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)