### PR TITLE
fix(ui): unique download progress slot IDs per HF model

### DIFF
--- a/web/templates/partials/hf_files.html
+++ b/web/templates/partials/hf_files.html
@@ -27,13 +27,13 @@
                 <button type="button"
                         hx-post="/api/hf/download"
                         hx-vals='{"model_id":"{{$.ID}}","filename":"{{$f.Filename}}"}'
-                        hx-target="#dl-{{$i}}"
+                        hx-target="#dl-{{cssID $.ID}}-{{$i}}"
                         hx-swap="innerHTML">
                     Download
                 </button>
             </td>
         </tr>
-        <tr id="dl-{{$i}}"></tr>
+        <tr id="dl-{{cssID $.ID}}-{{$i}}"></tr>
         {{end}}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary

When two models are expanded in the HF search tab, only the first one's download surfaces a progress bar. The second model's Download button silently overwrites the first's progress row instead of populating its own.

## Root cause

`web/templates/partials/hf_files.html` rendered each download slot as `id="dl-{$i}"`, where `$i` is the loop index over **one model's** file list. Expanding a second model puts a second copy of `dl-0`, `dl-1`, ... into the DOM. htmx's `hx-target="#dl-0"` resolves to the *first* matching element, so model B's progress lands in model A's row, and B looks like nothing happened.

## Fix

Prefix the IDs with the sanitized model ID using the existing `cssID` template helper — `dl-{cssID $.ID}-{$i}` — so each row has a unique target like `dl-Qwen_Qwen3-235B-A22B-GGUF-0`. One-line template change.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] HF Search → expand Model A files → start download (progress shows)
- [ ] Expand Model B files → start download (B's progress should now show, A's should still update)
- [ ] Same model, multiple files: each file's progress in its own row

🤖 Generated with [Claude Code](https://claude.com/claude-code)