### PR TITLE
feat(hf): mark downloaded models and gate downloads by free disk space

### DIFF
--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -6,12 +6,32 @@ import (
 	"log/slog"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/tmlabonte/llamactl/internal/huggingface"
 	"github.com/tmlabonte/llamactl/internal/models"
 )
+
+// hfFileView decorates a HuggingFace ModelFile with local-state flags used
+// by the templates: whether we already have it on disk, and whether it would
+// fit given current free space minus the safety margin and in-flight downloads.
+type hfFileView struct {
+	huggingface.ModelFile
+	AlreadyDownloaded bool
+	FitsOnDisk        bool
+}
+
+// hfModelView is the template payload for the HF file-list partial.
+type hfModelView struct {
+	ID             string
+	Files          []hfFileView
+	AvailableBytes int64 // free - margin - in-flight
+	FreeBytes      int64
+	SafetyMargin   int64
+}
 
 func (s *Server) handleHFSearch(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("q")
@@ -49,19 +69,41 @@ func (s *Server) handleHFModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	available := s.downloader.AvailableForDownload()
+	view := hfModelView{
+		ID:             detail.ID,
+		Files:          make([]hfFileView, 0, len(detail.Files)),
+		AvailableBytes: available,
+		FreeBytes:      s.downloader.FreeBytes(),
+		SafetyMargin:   huggingface.DiskSafetyMarginBytes,
+	}
+	for _, f := range detail.Files {
+		fv := hfFileView{ModelFile: f}
+		if _, ok := s.registry.HasFile(detail.ID, f.Filename); ok {
+			fv.AlreadyDownloaded = true
+		} else {
+			// available < 0 means "free space unknown" (statfs failed) — don't
+			// ghost, let the user try. f.Size <= 0 means "size unknown" (HF
+			// tree API didn't return it) — don't ghost for the same reason.
+			fv.FitsOnDisk = available < 0 || f.Size <= 0 || f.Size <= available
+		}
+		view.Files = append(view.Files, fv)
+	}
+
 	if isHTMX(r) {
 		respondHTML(w)
-		s.renderPartial(w, "hf_files", detail)
+		s.renderPartial(w, "hf_files", view)
 		return
 	}
 
-	respondJSON(w, detail)
+	respondJSON(w, view)
 }
 
 func (s *Server) handleHFDownload(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ModelID  string `json:"model_id"`
 		Filename string `json:"filename"`
+		Size     int64  `json:"size"`
 	}
 
 	if r.Header.Get("Content-Type") == "application/json" {
@@ -73,9 +115,25 @@ func (s *Server) handleHFDownload(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 		req.ModelID = r.FormValue("model_id")
 		req.Filename = r.FormValue("filename")
+		req.Size, _ = strconv.ParseInt(r.FormValue("size"), 10, 64)
 	}
 
-	downloadID, err := s.downloader.Start(r.Context(), req.ModelID, req.Filename)
+	// Defense-in-depth disk-space guard. The browse UI also disables the
+	// button when a file won't fit, but a stale page or direct API call
+	// could still POST here.
+	if req.Size > 0 {
+		avail := s.downloader.AvailableForDownload()
+		if avail >= 0 && req.Size > avail {
+			needGB := float64(req.Size) / (1024 * 1024 * 1024)
+			haveGB := float64(avail) / (1024 * 1024 * 1024)
+			http.Error(w,
+				fmt.Sprintf("insufficient disk space: need %.1f GB, only %.1f GB available after reserving the 2 GB safety margin and any in-flight downloads", needGB, haveGB),
+				http.StatusInsufficientStorage)
+			return
+		}
+	}
+
+	downloadID, err := s.downloader.Start(r.Context(), req.ModelID, req.Filename, req.Size)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -118,7 +118,7 @@ func (s *Server) handleDownloadEmbeddingPreset(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	downloadID, err := s.downloader.Start(r.Context(), repo, filename)
+	downloadID, err := s.downloader.Start(r.Context(), repo, filename, 0)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/internal/huggingface/disk.go
+++ b/internal/huggingface/disk.go
@@ -1,0 +1,20 @@
+package huggingface
+
+import (
+	"github.com/shirou/gopsutil/v4/disk"
+)
+
+// DiskSafetyMarginBytes is reserved free space we never let downloads consume,
+// so a finished download doesn't leave the filesystem at 100% and break the OS.
+const DiskSafetyMarginBytes int64 = 2 * 1024 * 1024 * 1024 // 2 GB
+
+// freeBytesAt returns the number of free bytes on the filesystem hosting path,
+// or -1 if it can't be determined. Callers treat -1 as "unknown" rather than
+// "zero" — otherwise a failed statfs would falsely block every download.
+func freeBytesAt(path string) int64 {
+	usage, err := disk.Usage(path)
+	if err != nil || usage == nil {
+		return -1
+	}
+	return int64(usage.Free)
+}

--- a/internal/huggingface/downloader.go
+++ b/internal/huggingface/downloader.go
@@ -96,7 +96,11 @@ func (d *Downloader) SetOnComplete(fn CompletionFunc) {
 }
 
 // Start begins a download in the background. Returns the download ID.
-func (d *Downloader) Start(ctx context.Context, modelID, filename string) (string, error) {
+// expectedBytes is a caller-provided size hint (from the HF tree API) so the
+// in-flight reservation in AvailableForDownload is accurate from the moment
+// Start returns, before the download goroutine has done its own HEAD. Pass 0
+// when the size is unknown.
+func (d *Downloader) Start(ctx context.Context, modelID, filename string, expectedBytes int64) (string, error) {
 	// Create a stable download ID — replace all slashes to keep it URL-safe
 	safeName := strings.ReplaceAll(modelID, "/", "--")
 	safeFilename := strings.ReplaceAll(strings.TrimSuffix(filename, ".gguf"), "/", "--")
@@ -112,6 +116,15 @@ func (d *Downloader) Start(ctx context.Context, modelID, filename string) (strin
 	dl := &download{
 		cancel: cancel,
 		subs:   make(map[chan DownloadStatus]struct{}),
+		// Seed lastStatus so PendingBytes counts this download immediately,
+		// before run() reports its first progress tick.
+		lastStatus: DownloadStatus{
+			ID:         downloadID,
+			ModelID:    modelID,
+			Filename:   filename,
+			TotalBytes: expectedBytes,
+			Status:     "downloading",
+		},
 	}
 	d.active[downloadID] = dl
 	d.mu.Unlock()
@@ -156,6 +169,52 @@ func (d *Downloader) ListActive() []DownloadStatus {
 		dl.subMu.Unlock()
 	}
 	return out
+}
+
+// PendingBytes returns the sum of remaining bytes across all active downloads.
+// Used by AvailableForDownload to reserve space for in-flight downloads so a
+// second download started while a first is still running sees the correct
+// post-completion free space, not the current free space.
+func (d *Downloader) PendingBytes() int64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var pending int64
+	for _, dl := range d.active {
+		dl.subMu.Lock()
+		s := dl.lastStatus
+		dl.subMu.Unlock()
+		if s.Status != "downloading" {
+			continue
+		}
+		remaining := s.TotalBytes - s.BytesDownloaded
+		if remaining > 0 {
+			pending += remaining
+		}
+	}
+	return pending
+}
+
+// FreeBytes returns the free space on the filesystem hosting modelsDir.
+func (d *Downloader) FreeBytes() int64 {
+	return freeBytesAt(d.modelsDir)
+}
+
+// AvailableForDownload returns how many bytes a new download is allowed to
+// consume: free disk minus the safety margin minus the bytes already reserved
+// by in-flight downloads. Returns -1 when free space can't be determined, so
+// callers can distinguish "unknown" from "actually full" — we don't want a
+// failed statfs to falsely ghost every download button. A non-negative result
+// is clamped to zero (genuinely no room).
+func (d *Downloader) AvailableForDownload() int64 {
+	free := d.FreeBytes()
+	if free < 0 {
+		return -1
+	}
+	avail := free - DiskSafetyMarginBytes - d.PendingBytes()
+	if avail < 0 {
+		return 0
+	}
+	return avail
 }
 
 // Cancel stops an active download.

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -298,6 +298,20 @@ func (r *Registry) List() []*Model {
 	return out
 }
 
+// HasFile reports whether the registry already contains a model matching the
+// given HuggingFace repo + filename. Used to mark "already downloaded" in the
+// HF browse UI so we don't show a Download button for files we already have.
+func (r *Registry) HasFile(modelID, filename string) (*Model, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, m := range r.data.Models {
+		if m.ModelID == modelID && m.Filename == filename {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
 // Get returns a model by ID.
 func (r *Registry) Get(id string) (*Model, error) {
 	r.mu.RLock()

--- a/web/templates/partials/hf_files.html
+++ b/web/templates/partials/hf_files.html
@@ -1,5 +1,13 @@
 {{define "hf_files"}}
 <hr>
+<p style="font-size: 0.85rem; color: var(--pico-muted-color);">
+    {{if lt $.AvailableBytes 0}}
+        <small>Disk space unavailable — downloads not gated by free space.</small>
+    {{else}}
+        <strong>{{printf "%.1f" (divGB $.AvailableBytes)}} GB</strong> available for new downloads
+        <small>(free: {{printf "%.1f" (divGB $.FreeBytes)}} GB · reserved: {{printf "%.1f" (divGB $.SafetyMargin)}} GB safety + in-flight downloads)</small>
+    {{end}}
+</p>
 <table role="grid">
     <thead>
         <tr><th>File</th><th>Quant</th><th>Size</th><th>VRAM Est.</th><th>Fit</th><th></th></tr>
@@ -24,13 +32,24 @@
                 {{end}}
             </td>
             <td>
-                <button type="button"
-                        hx-post="/api/hf/download"
-                        hx-vals='{"model_id":"{{$.ID}}","filename":"{{$f.Filename}}"}'
-                        hx-target="#dl-{{cssID $.ID}}-{{$i}}"
-                        hx-swap="innerHTML">
-                    Download
-                </button>
+                {{if $f.AlreadyDownloaded}}
+                    <ins title="Already in your local model registry">Downloaded</ins>
+                    <a href="/models" style="margin-left: 0.4rem; font-size: 0.85rem;">View</a>
+                {{else if not $f.FitsOnDisk}}
+                    <button type="button" disabled
+                            style="opacity: 0.5; cursor: not-allowed;"
+                            title="Not enough free disk space — needs {{printf "%.1f" (divGB $f.Size)}} GB, only {{printf "%.1f" (divGB $.AvailableBytes)}} GB available after the 2 GB safety margin and in-flight downloads. Free space and try again.">
+                        Won't Fit
+                    </button>
+                {{else}}
+                    <button type="button"
+                            hx-post="/api/hf/download"
+                            hx-vals='{"model_id":"{{$.ID}}","filename":"{{$f.Filename}}","size":"{{$f.Size}}"}'
+                            hx-target="#dl-{{cssID $.ID}}-{{$i}}"
+                            hx-swap="innerHTML">
+                        Download
+                    </button>
+                {{end}}
             </td>
         </tr>
         <tr id="dl-{{cssID $.ID}}-{{$i}}"></tr>


### PR DESCRIPTION
## Summary
- HuggingFace browse: files already in the local registry render as a `Downloaded` badge with a link to `/models` instead of a redundant Download button (matched by `model_id` + `filename`).
- Hard-block downloads that won't fit: Download button is disabled with a tooltip explaining the deficit. Calculation is `free − 2 GB safety margin − Σ remaining bytes across in-flight downloads`.
- `Downloader.Start` now takes an `expectedBytes` hint and seeds `lastStatus.TotalBytes` synchronously, so a second click sees the first download's reservation immediately rather than after the first progress tick.
- `handleHFDownload` re-checks the gate server-side (defense-in-depth) and returns `507 Insufficient Storage` if a stale page or direct API call would overflow.
- Failed `statfs` and missing HF size return `-1` so callers can distinguish "unknown" from "actually full" — we never ghost everything on a transient failure.

## Test plan
- [ ] Browse a HF repo where one quant is already on disk → it shows as `Downloaded`, others show `Download`.
- [ ] Browse a repo with a file larger than free space → that row's button is disabled and the tooltip names the deficit.
- [ ] Start a large download, then browse the same repo → the disk-space header reflects the reservation and a similar-sized second file ghosts.
- [ ] POST `/api/hf/download` with a `size` larger than available → 507 with a readable message.
- [ ] Browse on a path where statfs fails (or with no internet so HF size is missing) → buttons are not blanket-disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)