### PR TITLE
fix(bench): preserve cell-check selection across running-job polls

### DIFF
--- a/web/templates/partials/job_detail.html
+++ b/web/templates/partials/job_detail.html
@@ -36,7 +36,7 @@
     <table role="grid" style="font-size:0.85rem;margin-top:0.5rem;">
         <thead>
             <tr>
-                <th style="width:2rem;"><input type="checkbox" style="margin:0;"
+                <th style="width:2rem;"><input type="checkbox" id="cell-check-all-{{$j.ID}}" hx-preserve="true" style="margin:0;"
                     onchange="this.closest('table').querySelectorAll('.cell-check').forEach(function(c){c.checked=this.checked}.bind(this));"></th>
                 <th>Model</th>
                 <th>Quant</th>
@@ -52,7 +52,7 @@
         <tbody>
         {{range .Rows}}
         <tr id="cell-row-{{$j.ID}}-{{.Idx}}">
-            <td>{{if .Cell.BenchmarkRunID}}<input type="checkbox" class="cell-check" value="{{.Cell.BenchmarkRunID}}" style="margin:0;">{{end}}</td>
+            <td>{{if .Cell.BenchmarkRunID}}<input type="checkbox" id="cell-check-{{.Cell.BenchmarkRunID}}" hx-preserve="true" class="cell-check" value="{{.Cell.BenchmarkRunID}}" style="margin:0;">{{end}}</td>
             <td>{{.ModelName}}</td>
             <td>{{if .Quant}}<kbd>{{.Quant}}</kbd>{{else}}—{{end}}</td>
             <td><kbd>{{.BuildLbl}}</kbd></td>


### PR DESCRIPTION
## Summary
- Running batch jobs poll their detail view every 2s with `hx-swap="outerHTML"`, which re-renders the whole table and wipes any cell-checkbox selection the user just made (same for the "select all" header checkbox).
- Give each per-row `.cell-check` and the header checkbox a stable `id` and mark them `hx-preserve="true"` so htmx keeps the existing DOM nodes — and their checked state — across the polled swaps.
- Once the job reaches a terminal state the 2s poll stops, so this only affects the running-job view.

## Test plan
- [ ] Start a batch job with multiple cells; while it's running, expand the job and tick a few `.cell-check` boxes — they stay checked across the 2s refresh.
- [ ] Click the "select all" header checkbox during the running poll — it stays checked and rows stay checked.
- [ ] Let the job finish; checkboxes still work normally (no poll active).
- [ ] Compare/Export/Delete buttons still pick up the selected runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)