### PR TITLE
fix(api): resolve default context_size in model info endpoint

### DIFF
--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -199,10 +199,14 @@ func (s *Server) handleModelInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if cfg != nil {
+		ctxSize := cfg.ContextSize
+		if ctxSize == 0 {
+			ctxSize = m.ContextLength
+		}
 		configMap := map[string]any{
 			"enabled":         cfg.Enabled,
 			"gpu_layers":      cfg.GPULayers,
-			"context_size":    cfg.ContextSize,
+			"context_size":    ctxSize,
 			"threads":         cfg.Threads,
 			"flash_attention": cfg.FlashAttention,
 		}


### PR DESCRIPTION
## Summary
- `/api/models/{id}/info` returned the raw config value for `context_size`, so models configured to "Model Default" (stored as `0`) were reported as `context_size: 0`.
- Resolve `0` to `m.ContextLength` before serializing, matching `/v1/models`, the `--ctx-size` runtime flag handling, and VRAM estimation.

## Test plan
- [ ] `GET /api/models/{id}/info` on a model with context_size set to "Model Default" returns the model's trained context length instead of 0.
- [ ] Same endpoint on a model with an explicit non-zero context_size still returns that explicit value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)