### PR TITLE
fix(api): report live vs. pending values for restart-requiring config fields

### DIFF
--- a/cmd/llama-toolchest/main.go
+++ b/cmd/llama-toolchest/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/tmlabonte/llamactl/internal/api"
 	"github.com/tmlabonte/llamactl/internal/config"
@@ -64,7 +65,22 @@ func main() {
 
 	<-ctx.Done()
 	slog.Info("shutting down")
-	httpSrv.Shutdown(context.Background())
+
+	// Stop the child llama-server in parallel with draining HTTP connections.
+	// The HTTP deadline keeps us well under systemd's TimeoutStopSec (90s) even
+	// when slow handlers (benchmark warmup, /api/monitor polls) are in flight.
+	done := make(chan struct{})
+	go func() {
+		srv.Shutdown()
+		close(done)
+	}()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+		slog.Warn("http shutdown", "error", err)
+	}
+	<-done
 }
 
 func initDataDir(cfg *config.Config) error {

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -199,25 +199,78 @@ func (s *Server) handleModelInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if cfg != nil {
-		ctxSize := cfg.ContextSize
-		if ctxSize == 0 {
-			ctxSize = m.ContextLength
+		// The router reads preset.ini only at startup, so any field that's
+		// baked into the launch command line is "what will be live after
+		// the next restart" — not necessarily what's live now. When we have
+		// a snapshot from the last router start, prefer it as the primary
+		// value and add a `<field>_pending` key whenever the configured
+		// value differs. Sampling params and aliases are not snapshotted
+		// because the proxy applies them per-request.
+		live := cfg
+		hasSnapshot := false
+		if snap, ok := s.runningConfigs[id]; ok && s.process.IsRunning() {
+			live = snap
+			hasSnapshot = true
 		}
+
+		// context_size resolves 0 → model's trained context length in every
+		// other surface (see f6be200). Do the same on both sides so we don't
+		// flag a spurious "pending" diff between e.g. configured=0 and
+		// live=131072 when they mean the same thing.
+		resolveCtx := func(v int) int {
+			if v == 0 {
+				return m.ContextLength
+			}
+			return v
+		}
+		liveCtx := resolveCtx(live.ContextSize)
+		configuredCtx := resolveCtx(cfg.ContextSize)
+
 		configMap := map[string]any{
-			"enabled":         cfg.Enabled,
-			"gpu_layers":      cfg.GPULayers,
-			"context_size":    ctxSize,
-			"threads":         cfg.Threads,
-			"flash_attention": cfg.FlashAttention,
+			"enabled":         live.Enabled,
+			"gpu_layers":      live.GPULayers,
+			"context_size":    liveCtx,
+			"threads":         live.Threads,
+			"flash_attention": live.FlashAttention,
 		}
-		if cfg.TensorSplit != "" {
-			configMap["tensor_split"] = cfg.TensorSplit
+		// Optional string fields: include the key when either side has a
+		// value, so an edit that *clears* the field still shows up as a
+		// pending change rather than silently disappearing.
+		if live.TensorSplit != "" || cfg.TensorSplit != "" {
+			configMap["tensor_split"] = live.TensorSplit
 		}
-		if cfg.KVCacheQuant != "" {
-			configMap["kv_cache_quant"] = cfg.KVCacheQuant
+		if live.KVCacheQuant != "" || cfg.KVCacheQuant != "" {
+			configMap["kv_cache_quant"] = live.KVCacheQuant
 		}
-		if cfg.MmprojPath != "" {
-			configMap["mmproj_path"] = cfg.MmprojPath
+		if live.MmprojPath != "" || cfg.MmprojPath != "" {
+			configMap["mmproj_path"] = live.MmprojPath
+		}
+
+		if hasSnapshot {
+			if cfg.Enabled != live.Enabled {
+				configMap["enabled_pending"] = cfg.Enabled
+			}
+			if cfg.GPULayers != live.GPULayers {
+				configMap["gpu_layers_pending"] = cfg.GPULayers
+			}
+			if liveCtx != configuredCtx {
+				configMap["context_size_pending"] = configuredCtx
+			}
+			if cfg.Threads != live.Threads {
+				configMap["threads_pending"] = cfg.Threads
+			}
+			if cfg.FlashAttention != live.FlashAttention {
+				configMap["flash_attention_pending"] = cfg.FlashAttention
+			}
+			if cfg.TensorSplit != live.TensorSplit {
+				configMap["tensor_split_pending"] = cfg.TensorSplit
+			}
+			if cfg.KVCacheQuant != live.KVCacheQuant {
+				configMap["kv_cache_quant_pending"] = cfg.KVCacheQuant
+			}
+			if cfg.MmprojPath != live.MmprojPath {
+				configMap["mmproj_path_pending"] = cfg.MmprojPath
+			}
 		}
 		info["config"] = configMap
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -48,6 +48,16 @@ type Server struct {
 // the first page render.
 func (s *Server) SetVersion(v string) { s.version = v }
 
+// Shutdown releases server-owned resources that outlive the HTTP listener.
+// Today that's the child llama-server router: without this, the cgroup keeps
+// it alive until systemd's TimeoutStopSec fires SIGKILL.
+func (s *Server) Shutdown() {
+	if err := s.process.Stop(); err != nil {
+		// "router not running" is the expected case when nothing was started.
+		slog.Debug("router stop during shutdown", "error", err)
+	}
+}
+
 func NewServer(cfg *config.Config, configPath string) *Server {
 	mon := monitor.New(3 * time.Second)
 	mon.Start()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -40,6 +40,12 @@ type Server struct {
 	bench *benchmark.Store
 	jobs  *benchmark.JobQueue
 	dirtyModels     map[string]bool // models whose config changed since last load
+	// runningConfigs holds a value-copy of each model's launch config at the
+	// time the router last started, so /api/models/{id}/info can report the
+	// live value of any restart-requiring field separately from a config
+	// edit that hasn't been picked up yet (the router reads preset.ini only
+	// at startup). Populated by startRouter, cleared by Stop.
+	runningConfigs map[string]*models.ModelConfig
 }
 
 // SetVersion records the build's version string. main.go calls this with
@@ -73,7 +79,8 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 		process:       process.NewManager(),
 		monitor:       mon,
 		bench:         benchmark.NewStore(cfg.DataDir, builderResolver(bld)),
-		dirtyModels:   make(map[string]bool),
+		dirtyModels:    make(map[string]bool),
+		runningConfigs: make(map[string]*models.ModelConfig),
 	}
 	s.jobs = benchmark.NewJobQueue(s.bench, newJobEnv(s))
 	s.downloader.SetOnComplete(s.onDownloadComplete)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -168,8 +168,6 @@ func (s *Server) handleServiceStart(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// Clear dirty flags — fresh start uses the latest preset.ini
-		s.dirtyModels = make(map[string]bool)
 	}
 	s.handleServiceStatus(w, r)
 }
@@ -179,6 +177,9 @@ func (s *Server) handleServiceStop(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	// Nothing is live anymore — drop the snapshot so /info falls back to
+	// reporting just the configured value.
+	s.runningConfigs = make(map[string]*models.ModelConfig)
 	s.handleServiceStatus(w, r)
 }
 
@@ -197,8 +198,6 @@ func (s *Server) handleServiceRestart(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	// Clear dirty flags — the router just reloaded with the latest preset.ini
-	s.dirtyModels = make(map[string]bool)
 	s.handleServiceStatus(w, r)
 }
 
@@ -410,12 +409,32 @@ func (s *Server) startRouter() error {
 		slog.Warn("failed to write preset INI", "error", err)
 	}
 
-	return s.process.Start(process.RouterConfig{
+	if err := s.process.Start(process.RouterConfig{
 		BinaryPath: binaryPath,
 		PresetPath: presetPath,
 		ModelsMax:  s.cfg.ModelsMax,
 		Port:       s.cfg.LlamaPort,
-	})
+	}); err != nil {
+		return err
+	}
+
+	// The router has just (re)read preset.ini. Snapshot each model's launch
+	// config so /api/models/{id}/info can report live values for
+	// restart-requiring fields vs. a subsequent edit. Value-copy (not a
+	// shared pointer) because handleUpdateModelConfig mutates the registry's
+	// config struct in place.
+	snapshot := make(map[string]*models.ModelConfig)
+	for _, m := range s.registry.List() {
+		cfg, err := s.registry.GetConfig(m.ID)
+		if err != nil {
+			continue
+		}
+		cp := *cfg
+		snapshot[m.ID] = &cp
+	}
+	s.runningConfigs = snapshot
+	s.dirtyModels = make(map[string]bool)
+	return nil
 }
 
 // handleModelEnable toggles a model's enabled state and updates the preset.


### PR DESCRIPTION
## Summary

- `/api/models/{id}/info` was reading `cfg.ContextSize` (and other launch-time fields) straight from the registry, so editing context_size made the endpoint report the new value before the router had restarted — even though llama-server was still running with the old one. The endpoint now reports the **live** value (snapshotted at router start) as the primary key and adds `<field>_pending` only when the configured value diverges, covering `enabled`, `gpu_layers`, `context_size`, `threads`, `flash_attention`, `tensor_split`, `kv_cache_quant`, `mmproj_path`.
- Bundles in a separate, pre-existing shutdown fix: `httpSrv.Shutdown` could block on in-flight handlers (benchmark warmup, `/api/monitor` polls) long enough for systemd's `TimeoutStopSec` to SIGKILL the child llama-server. The child is now stopped in parallel with the HTTP drain, with a 15s deadline.

## Behavior

Sampling params (`temperature`, `top_p`, etc.) and `aliases` are intentionally not snapshotted — the proxy applies them per request, so they don't need a restart.

`context_size` resolves `0 → m.ContextLength` on both the configured and live sides (matching f6be200), so a configured=0 vs. live=131072 doesn't show up as a spurious pending diff.

Example response after editing `context_size` and `kv_cache_quant` without restarting:

```json
"config": {
  "context_size": 4096,
  "context_size_pending": 8192,
  "kv_cache_quant": "",
  "kv_cache_quant_pending": "q8_0",
  ...
}
```

When the router is stopped, or for a model that wasn't in preset.ini at startup, behavior is unchanged — the primary key holds the configured value, no `_pending` keys.

The `dirtyModels` reset moved into `startRouter` so every start path (`handleServiceStart`, `handleServiceRestart`, `AutoStart`, the activate-induced start in `handleActivateModel`) clears it consistently with the new snapshot.

## Test plan

- [ ] `go build ./...` and `go vet ./...` clean (verified locally).
- [ ] With the router running, edit a model's `context_size`; `GET /api/models/{id}/info` shows `context_size` unchanged and a new `context_size_pending` key with the configured value.
- [ ] Restart the router; `context_size_pending` disappears and `context_size` shows the new value.
- [ ] With the router stopped, `context_size_pending` never appears.
- [ ] Repeat with `flash_attention`, `gpu_layers`, `kv_cache_quant` (set then cleared) to exercise bool / int / "cleared optional string" cases.
- [ ] Trigger a shutdown while a long `/api/monitor` poll is in flight; service stops within 15s and the child llama-server doesn't get SIGKILLed by systemd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)