### PR TITLE
feat(bench): edit and re-run batch benchmark jobs

### DIFF
--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -125,6 +125,54 @@ func (s *Server) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, job)
 }
 
+// handleUpdateJob edits a job's definition (name/description/matrix/
+// overrides) and re-submits it. Completed cells survive any matrix
+// change that still includes their (model, build, preset) point; runs
+// behind cells that no longer exist are reassigned to Ad-Hoc.
+func (s *Server) handleUpdateJob(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if id == benchmark.AdhocJobID {
+		http.Error(w, "the Ad-Hoc job cannot be edited", http.StatusBadRequest)
+		return
+	}
+	var req jobCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	if len(req.ModelIDs) == 0 || len(req.BuildIDs) == 0 || len(req.Presets) == 0 {
+		http.Error(w, "model_ids, build_ids, and presets are all required", http.StatusBadRequest)
+		return
+	}
+
+	updated, err := s.bench.UpdateJobDefinition(id, req.Name, req.Description, req.ModelIDs, req.BuildIDs, req.Presets, req.Overrides)
+	if err != nil {
+		// "synthetic" is the adhoc-edit refusal; anything else means the
+		// job wasn't found.
+		if strings.Contains(err.Error(), "synthetic") {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if err := s.jobs.Submit(*updated); err != nil {
+		if errors.Is(err, benchmark.ErrJobAlreadyRunning) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	respondJSON(w, updated)
+}
+
 // handleGetJob returns one job (with its cells).
 func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -276,6 +276,7 @@ func (s *Server) buildRouter() chi.Router {
 			r.Post("/", s.handleCreateJob)
 			r.Get("/form", s.handleJobForm)
 			r.Get("/{id}", s.handleGetJob)
+			r.Put("/{id}", s.handleUpdateJob)
 			r.Delete("/{id}", s.handleDeleteJob)
 			r.Post("/{id}/cancel", s.handleCancelJob)
 			r.Post("/{id}/retry-failed", s.handleRetryFailedCells)

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -473,6 +473,93 @@ func (s *Store) DeleteJob(id string, disposition DeleteDisposition) error {
 	return nil
 }
 
+// UpdateJobDefinition replaces a job's editable fields (name/description/
+// matrix/overrides) and rebuilds its cell list. Cells whose (model, build,
+// preset) coordinate still exists in the new matrix AND were already
+// completed are carried over with their run intact; everything else
+// starts fresh as pending. Runs no longer reachable from any cell are
+// orphaned to the Ad-Hoc job so the user keeps the history. The caller
+// must Submit the returned job to actually re-run it.
+//
+// Refuses to edit the synthetic adhoc job. Does not check whether the
+// queue is busy — that's the JobQueue's responsibility on Submit.
+func (s *Store) UpdateJobDefinition(id, name, description string, modelIDs, buildIDs, presets []string, overrides *ConfigOverrides) (*BenchmarkJob, error) {
+	if id == AdhocJobID {
+		return nil, fmt.Errorf("cannot edit the synthetic %q job", AdhocJobID)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx := -1
+	for i := range s.jobs {
+		if s.jobs[i].ID == id {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return nil, fmt.Errorf("job not found: %s", id)
+	}
+	job := s.jobs[idx]
+
+	type cellKey struct{ Model, Build, Preset string }
+	prev := make(map[cellKey]JobCell, len(job.Cells))
+	for _, c := range job.Cells {
+		prev[cellKey{c.ModelID, c.BuildID, c.Preset}] = c
+	}
+
+	newCells := ExpandCells(modelIDs, buildIDs, presets)
+	keptRuns := make(map[string]bool)
+	for i := range newCells {
+		k := cellKey{newCells[i].ModelID, newCells[i].BuildID, newCells[i].Preset}
+		if old, ok := prev[k]; ok && old.Status == CellStatusCompleted {
+			newCells[i] = old
+			if old.BenchmarkRunID != "" {
+				keptRuns[old.BenchmarkRunID] = true
+			}
+		}
+	}
+
+	// Anything previously linked to this job that didn't survive into a
+	// kept cell becomes adhoc, preserving the run history.
+	orphaned := false
+	for i := range s.runs {
+		if s.runs[i].JobID != id || keptRuns[s.runs[i].ID] {
+			continue
+		}
+		s.runs[i].JobID = AdhocJobID
+		orphaned = true
+	}
+	if orphaned && !s.hasJobLocked(AdhocJobID) {
+		s.jobs = append(s.jobs, newAdhocJob(time.Now()))
+		// hasJobLocked failed because the slice didn't contain an adhoc
+		// entry; appending it can move the backing array, so re-find the
+		// index of the job we're editing.
+		for i := range s.jobs {
+			if s.jobs[i].ID == id {
+				idx = i
+				break
+			}
+		}
+	}
+
+	job.Name = name
+	job.Description = description
+	job.ModelIDs = modelIDs
+	job.BuildIDs = buildIDs
+	job.Presets = presets
+	job.Overrides = overrides
+	job.Cells = newCells
+	job.Status = JobStatusPending
+	job.StartedAt = time.Time{}
+	job.FinishedAt = time.Time{}
+	s.jobs[idx] = job
+
+	s.persist()
+	out := job
+	return &out, nil
+}
+
 // RunsForJob returns all runs belonging to the given job, newest first.
 func (s *Store) RunsForJob(jobID string) []BenchmarkRun {
 	s.mu.RLock()

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -46,7 +46,7 @@
     <article>
         <header>
             <button type="button" aria-label="Close" rel="prev" onclick="closeJobForm();"></button>
-            New Batch Job
+            <span id="job-form-title">New Batch Job</span>
         </header>
         <div id="job-form-slot">Loading…</div>
     </article>
@@ -233,7 +233,13 @@ function openBenchHelp() {
 }
 
 // --- Job form modal ---
+// editingJobID is empty for a new job; set to a job ID when the modal
+// was opened via "Edit & Re-run" so submit chooses PUT over POST.
+var editingJobID = '';
+
 function openJobForm() {
+    editingJobID = '';
+    document.getElementById('job-form-title').textContent = 'New Batch Job';
     var modal = document.getElementById('job-form-modal');
     var slot = document.getElementById('job-form-slot');
     slot.innerHTML = 'Loading…';
@@ -245,6 +251,69 @@ function openJobForm() {
             updateMatrixCount();
         });
     modal.showModal();
+}
+function openJobEditForm(id) {
+    editingJobID = id;
+    document.getElementById('job-form-title').textContent = 'Edit Batch Job';
+    var modal = document.getElementById('job-form-modal');
+    var slot = document.getElementById('job-form-slot');
+    slot.innerHTML = 'Loading…';
+    // Fetch the job JSON and the form HTML in parallel, then pre-fill.
+    Promise.all([
+        fetch('/api/benchmark-jobs/'+encodeURIComponent(id), {headers:{'Accept':'application/json'}}).then(function(r){
+            if (!r.ok) throw new Error('failed to load job: HTTP '+r.status);
+            return r.json();
+        }),
+        fetch('/api/benchmark-jobs/form', {headers:{'HX-Request':'true'}}).then(function(r){return r.text();}),
+    ]).then(function(arr) {
+        var job = arr[0], html = arr[1];
+        slot.innerHTML = html;
+        htmx.process(slot);
+        prefillJobForm(job);
+        updateMatrixCount();
+    }).catch(function(e){
+        slot.textContent = e.message;
+    });
+    modal.showModal();
+}
+function prefillJobForm(job) {
+    var form = document.getElementById('new-job-form');
+    if (!form) return;
+    form.elements.name.value = job.name || '';
+    form.elements.description.value = job.description || '';
+    var setChecked = function(name, values) {
+        var set = {};
+        (values || []).forEach(function(v){ set[v] = true; });
+        form.querySelectorAll('input[name='+name+']').forEach(function(c){ c.checked = !!set[c.value]; });
+    };
+    setChecked('model', job.model_ids);
+    setChecked('build', job.build_ids);
+    setChecked('preset', job.presets);
+    var ov = job.overrides || {};
+    var setField = function(name, val) {
+        var el = form.elements[name];
+        if (!el) return;
+        if (val === null || val === undefined) { el.value = ''; return; }
+        el.value = String(val);
+    };
+    setField('ov_gpu_layers',      ov.gpu_layers);
+    setField('ov_context_size',    ov.context_size);
+    setField('ov_threads',         ov.threads);
+    setField('ov_flash_attention', ov.flash_attention === undefined || ov.flash_attention === null ? null : (ov.flash_attention ? 'true' : 'false'));
+    setField('ov_kv_cache_quant',  ov.kv_cache_quant);
+    setField('ov_direct_io',       ov.direct_io === undefined || ov.direct_io === null ? null : (ov.direct_io ? 'true' : 'false'));
+    setField('ov_gpu_assign',      ov.gpu_assign);
+    setField('ov_tensor_split',    ov.tensor_split);
+    setField('ov_spec_type',       ov.spec_type);
+    // Reveal the overrides <details> if any override is set so the user
+    // can see what they're editing without an extra click.
+    if (Object.keys(ov).length > 0) {
+        var det = form.querySelector('details');
+        if (det) det.open = true;
+    }
+    // Tweak submit button label so it reads natural in edit mode.
+    var btn = document.getElementById('job-submit-btn');
+    if (btn) btn.textContent = 'Save & Re-run';
 }
 function closeJobForm() {
     document.getElementById('job-form-modal').close();
@@ -294,9 +363,12 @@ function submitNewJob() {
         presets: picked('preset'),
         overrides: readOverrides(form),
     };
-    fetch('/api/benchmark-jobs', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)})
+    var isEdit = !!editingJobID;
+    var url = isEdit ? '/api/benchmark-jobs/'+encodeURIComponent(editingJobID) : '/api/benchmark-jobs';
+    var method = isEdit ? 'PUT' : 'POST';
+    fetch(url, {method:method, headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)})
         .then(function(r){
-            if (r.status === 201) {
+            if (r.ok) {
                 closeJobForm();
                 document.body.dispatchEvent(new CustomEvent('jobChanged'));
                 return;

--- a/web/templates/partials/job_detail.html
+++ b/web/templates/partials/job_detail.html
@@ -90,6 +90,8 @@
         {{else}}
         <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
                 onclick="retryFailed('{{$j.ID}}')">Retry failed</button>
+        <button type="button" class="outline secondary" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;"
+                onclick="openJobEditForm('{{$j.ID}}')">Edit &amp; Re-run</button>
         {{end}}
         <a class="outline secondary" role="button" style="margin:0;padding:0.2rem 0.6rem;font-size:0.8rem;width:auto;text-decoration:none;"
            href="/api/benchmark-jobs/{{$j.ID}}/export?format=csv&scope=cells" download>CSV (cells)</a>


### PR DESCRIPTION
## Summary
- Adds an **Edit & Re-run** button to non-running batch jobs (next to *Retry failed*). Reuses the existing create-job modal, pre-filled with the job's current name, description, matrix selections, and overrides.
- Submitting from edit mode hits a new `PUT /api/benchmark-jobs/{id}` which updates the job in place and re-queues it.
- Completed cells whose `(model, build, preset)` coordinate still exists in the edited matrix are preserved with their run; only changed/new cells re-run. Runs no longer reachable from any cell get reassigned to **Ad-Hoc** so history isn't lost.
- The Ad-Hoc pseudo-job is rejected (400) and editing while another job is running surfaces 409 from the queue.

## Test plan
- [ ] Open a finished batch job, click **Edit & Re-run**, verify modal title says "Edit Batch Job", inputs/checkboxes/overrides reflect the existing job, and the submit button reads "Save & Re-run".
- [ ] Edit just the name → save → job keeps its cells/runs and ends up completed (nothing to re-run).
- [ ] Add a new preset → save → only the new cells re-run; previously completed cells keep their TG/PP numbers.
- [ ] Remove a model from the matrix → save → the removed cells' runs show up under **Ad-Hoc Runs**.
- [ ] Verify the button is hidden on running jobs and on the Ad-Hoc pseudo-job.
- [ ] PUT on `/api/benchmark-jobs/adhoc` returns 400; PUT with missing `name`/`model_ids`/`build_ids`/`presets` returns 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)