### PR TITLE
feat(spec): MTP + draft-resource flags, fix draft mode --spec-type

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -34,6 +34,15 @@ func applySpecDefaults(cfg *models.ModelConfig) {
 		cfg.DraftPMin = "0.75"
 		cfg.NgramSizeN = 0
 		cfg.NgramSizeM = 0
+	case "draft-mtp":
+		// unsloth's MTP cookbook uses --spec-draft-n-max 6 for Qwen3.6.
+		// Leave min/p-min at llama.cpp defaults — MTP heads have their
+		// own acceptance logic and the broader knobs rarely help.
+		cfg.DraftMax = 6
+		cfg.DraftMin = 0
+		cfg.DraftPMin = ""
+		cfg.NgramSizeN = 0
+		cfg.NgramSizeM = 0
 	case "ngram-simple", "ngram-cache", "ngram-map-k", "ngram-map-k4v":
 		cfg.DraftMax = 16
 		cfg.DraftMin = 0
@@ -734,6 +743,25 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		} else {
 			cfg.NgramSizeM = 0
 		}
+
+		// Draft model resource overrides (spec_type=draft only).
+		if v, err := strconv.Atoi(r.FormValue("draft_ctx_size")); err == nil && v > 0 {
+			cfg.DraftCtxSize = v
+		} else {
+			cfg.DraftCtxSize = 0
+		}
+		if v, err := strconv.Atoi(r.FormValue("draft_gpu_layers")); err == nil && v > 0 {
+			cfg.DraftGPULayers = v
+		} else {
+			cfg.DraftGPULayers = 0
+		}
+		cfg.DraftDevice = strings.TrimSpace(r.FormValue("draft_device"))
+		if v, err := strconv.Atoi(r.FormValue("draft_cpu_moe")); err == nil && v > 0 {
+			cfg.DraftCPUMoE = v
+		} else {
+			cfg.DraftCPUMoE = 0
+		}
+		cfg.DraftKVCacheQuant = r.FormValue("draft_kv_cache_quant")
 
 		// Populate recommended defaults only when the user actually switched
 		// modes — preserves any custom values they tuned within an existing

--- a/internal/models/preset.go
+++ b/internal/models/preset.go
@@ -144,9 +144,37 @@ func writeConfigParams(b *strings.Builder, cfg *ModelConfig, isEmbedding bool) {
 		// mode-specific flags. Emit the right name based on SpecType.
 		switch cfg.SpecType {
 		case "draft":
+			b.WriteString("spec-type = draft-simple\n")
 			if cfg.DraftModelPath != "" {
 				b.WriteString(fmt.Sprintf("model-draft = %s\n", cfg.DraftModelPath))
 			}
+			if cfg.DraftMax > 0 {
+				b.WriteString(fmt.Sprintf("spec-draft-n-max = %d\n", cfg.DraftMax))
+			}
+			if cfg.DraftMin > 0 {
+				b.WriteString(fmt.Sprintf("spec-draft-n-min = %d\n", cfg.DraftMin))
+			}
+			if cfg.DraftPMin != "" {
+				b.WriteString(fmt.Sprintf("spec-draft-p-min = %s\n", cfg.DraftPMin))
+			}
+			if cfg.DraftCtxSize > 0 {
+				b.WriteString(fmt.Sprintf("ctx-size-draft = %d\n", cfg.DraftCtxSize))
+			}
+			if cfg.DraftGPULayers > 0 {
+				b.WriteString(fmt.Sprintf("gpu-layers-draft = %d\n", cfg.DraftGPULayers))
+			}
+			if cfg.DraftDevice != "" {
+				b.WriteString(fmt.Sprintf("device-draft = %s\n", cfg.DraftDevice))
+			}
+			if cfg.DraftCPUMoE > 0 {
+				b.WriteString(fmt.Sprintf("n-cpu-moe-draft = %d\n", cfg.DraftCPUMoE))
+			}
+			if cfg.DraftKVCacheQuant != "" {
+				b.WriteString(fmt.Sprintf("cache-type-k-draft = %s\n", cfg.DraftKVCacheQuant))
+				b.WriteString(fmt.Sprintf("cache-type-v-draft = %s\n", cfg.DraftKVCacheQuant))
+			}
+		case "draft-mtp":
+			b.WriteString("spec-type = draft-mtp\n")
 			if cfg.DraftMax > 0 {
 				b.WriteString(fmt.Sprintf("spec-draft-n-max = %d\n", cfg.DraftMax))
 			}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -97,13 +97,21 @@ type ModelConfig struct {
 	MmprojPath       string `json:"mmproj_path,omitempty"` // path to mmproj GGUF for vision models
 
 	// Speculative decoding
-	SpecType       string `json:"spec_type,omitempty"`        // "", "draft", "ngram-simple", "ngram-cache", etc.
+	SpecType       string `json:"spec_type,omitempty"`        // "", "draft", "draft-mtp", "ngram-simple", "ngram-cache", etc.
 	DraftModelPath string `json:"draft_model_path,omitempty"` // path to draft model (when spec_type="draft")
 	DraftMax       int    `json:"draft_max,omitempty"`        // max draft tokens per step
 	DraftMin       int    `json:"draft_min,omitempty"`        // min draft tokens per step
 	DraftPMin      string `json:"draft_p_min,omitempty"`      // min probability threshold (string to allow empty=default)
 	NgramSizeN     int    `json:"ngram_size_n,omitempty"`     // n-gram lookup length
 	NgramSizeM     int    `json:"ngram_size_m,omitempty"`     // n-gram draft length
+
+	// Draft model resource overrides (only meaningful when spec_type="draft" —
+	// not used by MTP self-speculation since the draft *is* the main model).
+	DraftCtxSize      int    `json:"draft_ctx_size,omitempty"`       // --ctx-size-draft
+	DraftGPULayers    int    `json:"draft_gpu_layers,omitempty"`     // --gpu-layers-draft
+	DraftDevice       string `json:"draft_device,omitempty"`         // --device-draft
+	DraftCPUMoE       int    `json:"draft_cpu_moe,omitempty"`        // --n-cpu-moe-draft
+	DraftKVCacheQuant string `json:"draft_kv_cache_quant,omitempty"` // --cache-type-{k,v}-draft
 
 	Aliases    []string `json:"aliases,omitempty"` // user-defined friendly names
 	ExtraFlags string   `json:"extra_flags"`
@@ -189,9 +197,47 @@ func (c *ModelConfig) EffectiveFlagsFor(isEmbedding bool) string {
 		// mode-specific flags. Emit the right name based on SpecType.
 		switch c.SpecType {
 		case "draft":
+			// Internal value is still "draft" (legacy config compat) but
+			// llama.cpp renamed the spec-type enum value to "draft-simple"
+			// alongside the introduction of "draft-mtp" and "draft-eagle3".
+			// Without --spec-type, the draft model loads but isn't used —
+			// the default is "none".
+			parts = append(parts, "--spec-type", "draft-simple")
 			if c.DraftModelPath != "" {
 				parts = append(parts, "--model-draft", c.DraftModelPath)
 			}
+			if c.DraftMax > 0 {
+				parts = append(parts, "--spec-draft-n-max", strconv.Itoa(c.DraftMax))
+			}
+			if c.DraftMin > 0 {
+				parts = append(parts, "--spec-draft-n-min", strconv.Itoa(c.DraftMin))
+			}
+			if c.DraftPMin != "" {
+				parts = append(parts, "--spec-draft-p-min", c.DraftPMin)
+			}
+			// Draft model resource overrides. Without these, the draft model
+			// inherits llama-server defaults — which on a large MoE main
+			// model often means no GPU offload for the draft.
+			if c.DraftCtxSize > 0 {
+				parts = append(parts, "--ctx-size-draft", strconv.Itoa(c.DraftCtxSize))
+			}
+			if c.DraftGPULayers > 0 {
+				parts = append(parts, "--gpu-layers-draft", strconv.Itoa(c.DraftGPULayers))
+			}
+			if c.DraftDevice != "" {
+				parts = append(parts, "--device-draft", c.DraftDevice)
+			}
+			if c.DraftCPUMoE > 0 {
+				parts = append(parts, "--n-cpu-moe-draft", strconv.Itoa(c.DraftCPUMoE))
+			}
+			if c.DraftKVCacheQuant != "" {
+				parts = append(parts, "--cache-type-k-draft", c.DraftKVCacheQuant, "--cache-type-v-draft", c.DraftKVCacheQuant)
+			}
+		case "draft-mtp":
+			// MTP is self-speculation: the main GGUF carries the draft
+			// head, so no --model-draft is set and the draft-resource
+			// flags above don't apply. Only the draft sampling knobs do.
+			parts = append(parts, "--spec-type", "draft-mtp")
 			if c.DraftMax > 0 {
 				parts = append(parts, "--spec-draft-n-max", strconv.Itoa(c.DraftMax))
 			}

--- a/internal/models/spec_smoke_test.go
+++ b/internal/models/spec_smoke_test.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSpecMTPEffectiveFlags(t *testing.T) {
+	cfg := &ModelConfig{
+		GPULayers:   99,
+		ContextSize: 8192,
+		Threads:     8,
+		SpecType:    "draft-mtp",
+		DraftMax:    6,
+	}
+	got := cfg.EffectiveFlags()
+	for _, want := range []string{"--spec-type draft-mtp", "--spec-draft-n-max 6"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("MTP flags missing %q in: %s", want, got)
+		}
+	}
+	if strings.Contains(got, "--model-draft") {
+		t.Errorf("MTP should not emit --model-draft, got: %s", got)
+	}
+}
+
+func TestSpecDraftResourceFlags(t *testing.T) {
+	cfg := &ModelConfig{
+		GPULayers:         99,
+		ContextSize:       16384,
+		Threads:           8,
+		SpecType:          "draft",
+		DraftModelPath:    "/models/qwen-0.5b.gguf",
+		DraftMax:          16,
+		DraftPMin:         "0.75",
+		DraftCtxSize:      4096,
+		DraftGPULayers:    99,
+		DraftDevice:       "CUDA1",
+		DraftCPUMoE:       2,
+		DraftKVCacheQuant: "q8_0",
+	}
+	got := cfg.EffectiveFlags()
+	for _, want := range []string{
+		"--spec-type draft-simple",
+		"--model-draft /models/qwen-0.5b.gguf",
+		"--spec-draft-n-max 16",
+		"--spec-draft-p-min 0.75",
+		"--ctx-size-draft 4096",
+		"--gpu-layers-draft 99",
+		"--device-draft CUDA1",
+		"--n-cpu-moe-draft 2",
+		"--cache-type-k-draft q8_0",
+		"--cache-type-v-draft q8_0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Draft flags missing %q in: %s", want, got)
+		}
+	}
+}
+
+func TestSpecMTPPresetINI(t *testing.T) {
+	cfg := &ModelConfig{
+		Enabled:     true,
+		GPULayers:   99,
+		ContextSize: 8192,
+		Threads:     8,
+		SpecType:    "draft-mtp",
+		DraftMax:    6,
+	}
+	var b strings.Builder
+	writeConfigParams(&b, cfg, false)
+	out := b.String()
+	for _, want := range []string{"spec-type = draft-mtp", "spec-draft-n-max = 6"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("MTP preset missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "model-draft") {
+		t.Errorf("MTP preset should not emit model-draft, got:\n%s", out)
+	}
+}

--- a/web/templates/partials/model_config.html
+++ b/web/templates/partials/model_config.html
@@ -173,6 +173,9 @@
                 <dt><strong>Draft Model</strong></dt>
                 <dd>Uses a separate smaller model of the same architecture to propose tokens. Highest and most consistent speedups (1.5-2.5x typical). Requires a compatible model — download one with the same architecture but smaller size (e.g., 0.5B-1B) and it will appear in the dropdown. Uses extra VRAM for the draft model.</dd>
 
+                <dt><strong>MTP (Multi-Token Prediction)</strong></dt>
+                <dd>Self-speculation built into the model — the same GGUF carries an MTP head that drafts tokens for itself, so no separate draft model is needed. Used by Qwen3.6-MTP and DeepSeek-V3-MTP releases. Typical speedup 1.5-2x with zero extra VRAM. <strong>Limitations:</strong> requires the main model to be MTP-enabled (look for "MTP" in the filename), is incompatible with <em>parallel &gt; 1</em>, and does not work with <code>--mmproj</code> vision projectors.</dd>
+
                 <dt><strong>N-gram Simple</strong></dt>
                 <dd>Searches the generation history for matching token patterns and reuses what followed. Zero overhead, no extra VRAM. Works best when the model repeats patterns (code refactoring, structured output). No benefit for entirely novel text.</dd>
 
@@ -228,6 +231,7 @@
             <select name="spec_type">
                 <option value="" {{if eq .Config.SpecType ""}}selected{{end}}>Disabled</option>
                 <option value="draft" {{if eq .Config.SpecType "draft"}}selected{{end}}>Draft Model{{if not .DraftCandidates}} (no compatible models){{end}}</option>
+                <option value="draft-mtp" {{if eq .Config.SpecType "draft-mtp"}}selected{{end}}>MTP (self-speculation)</option>
                 <option value="ngram-simple" {{if eq .Config.SpecType "ngram-simple"}}selected{{end}}>N-gram Simple</option>
                 <option value="ngram-cache" {{if eq .Config.SpecType "ngram-cache"}}selected{{end}}>N-gram Cache</option>
                 <option value="ngram-map-k" {{if eq .Config.SpecType "ngram-map-k"}}selected{{end}}>N-gram Map-K</option>
@@ -269,7 +273,52 @@
         </label>
     </div>
     {{end}}
-    {{if and (ne .Config.SpecType "") (ne .Config.SpecType "draft")}}
+    {{if eq .Config.SpecType "draft"}}
+    <small><strong>Draft model resources</strong> — leave blank to inherit llama-server defaults. Set these when the draft model needs its own GPU offload, context, or cache type.</small>
+    <div class="grid">
+        <label title="Context size for the draft model. Default: inherits from main ctx-size.">
+            Draft Ctx Size
+            <input type="number" name="draft_ctx_size" value="{{if gt .Config.DraftCtxSize 0}}{{.Config.DraftCtxSize}}{{end}}"
+                   min="0" placeholder="Inherit">
+        </label>
+        <label title="Number of draft-model layers to offload to GPU. Default: 0 (CPU only).">
+            Draft GPU Layers
+            <input type="number" name="draft_gpu_layers" value="{{if gt .Config.DraftGPULayers 0}}{{.Config.DraftGPULayers}}{{end}}"
+                   min="0" max="999" placeholder="0">
+        </label>
+        <label title="Comma-separated device list for the draft model (e.g. CUDA0 or CUDA1). Default: same as main model.">
+            Draft Device
+            <input type="text" name="draft_device" value="{{.Config.DraftDevice}}"
+                   placeholder="e.g. CUDA0">
+        </label>
+    </div>
+    <div class="grid">
+        <label title="Keep MoE weights of the first N draft-model layers in CPU memory. Saves draft-model VRAM at the cost of speed.">
+            Draft CPU MoE Layers
+            <input type="number" name="draft_cpu_moe" value="{{if gt .Config.DraftCPUMoE 0}}{{.Config.DraftCPUMoE}}{{end}}"
+                   min="0" placeholder="0">
+        </label>
+        <label title="KV cache quantization for the draft model. Default: inherits from main cache type.">
+            Draft KV Cache Quant
+            <select name="draft_kv_cache_quant">
+                <option value="" {{if eq .Config.DraftKVCacheQuant ""}}selected{{end}}>Inherit</option>
+                <option value="f16" {{if eq .Config.DraftKVCacheQuant "f16"}}selected{{end}}>f16</option>
+                <option value="q8_0" {{if eq .Config.DraftKVCacheQuant "q8_0"}}selected{{end}}>q8_0</option>
+                <option value="q4_0" {{if eq .Config.DraftKVCacheQuant "q4_0"}}selected{{end}}>q4_0</option>
+            </select>
+        </label>
+    </div>
+    {{end}}
+    {{if eq .Config.SpecType "draft-mtp"}}
+    {{if or (gt .Config.Parallel 1) (ne .Config.MmprojPath "")}}
+    <small style="color:var(--pico-del-color)"><strong>⚠ MTP incompatibility:</strong>
+        {{if gt .Config.Parallel 1}}MTP requires parallel = 1 (currently {{.Config.Parallel}}). {{end}}
+        {{if ne .Config.MmprojPath ""}}MTP does not work with an mmproj vision projector. {{end}}
+        The server may fail to start until this is resolved.
+    </small>
+    {{end}}
+    {{end}}
+    {{if and (ne .Config.SpecType "") (ne .Config.SpecType "draft") (ne .Config.SpecType "draft-mtp")}}
     <div class="grid">
         <label title="Length of the n-gram used for lookup in generation history. Default: 12">
             N-gram Lookup Size


### PR DESCRIPTION
## Summary
- Adds **MTP (Multi-Token Prediction)** as a new speculative decoding mode, emitting `--spec-type draft-mtp`. Enables running models like `unsloth/Qwen3.6-27B-MTP-GGUF` from the UI without dropping into `extra_flags`.
- Adds **draft-model resource overrides** for the existing Draft Model mode: `--ctx-size-draft`, `--gpu-layers-draft`, `--device-draft`, `--n-cpu-moe-draft`, `--cache-type-{k,v}-draft`. Previously the draft inherited llama-server defaults, which on a large MoE main model often meant no GPU offload for the draft at all.
- **Fixes a latent bug:** Draft Model mode emitted `--model-draft` but never `--spec-type`. llama.cpp's default is `--spec-type none`, so the draft GGUF was loading but speculation never engaged. Now emits `--spec-type draft-simple` (the new canonical name) alongside `--model-draft`.
- Adds `spec_smoke_test.go` to pin the canonical flag names — llama.cpp has renamed these twice already; next time it should break the build instead of silently disabling speculation.

## Context
llama.cpp PR [ggml-org/llama.cpp#22673](https://github.com/ggml-org/llama.cpp/pull/22673) merged 2026-05-16 added MTP and renamed the legacy `draft` spec-type to `draft-simple`. The toolchest's spec-decoding switch hadn't been touched since the prior rename, so users picking Draft Model were getting no speedup.

MTP requires a llama.cpp build that includes commit `2555826` — the b9174 release tag was cut ~10 hours before the merge, so the next b-tag (or a `master` build) is needed at runtime. UI shows inline warnings for the two known MTP incompatibilities: `parallel > 1` and `--mmproj`.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — new `TestSpecMTPEffectiveFlags`, `TestSpecDraftResourceFlags`, `TestSpecMTPPresetINI` pass
- [ ] Manual: pick MTP model in UI → restart router → verify `--spec-type draft-mtp` in spawned-process args (requires a llama.cpp build with commit `2555826`)
- [ ] Manual: pick Draft Model mode → restart router → verify `--spec-type draft-simple --model-draft <path>` in spawned-process args and confirm draft acceptance log lines appear
- [ ] Manual: set MTP + parallel=2 → UI shows red incompatibility warning
- [ ] Manual: set Draft Model + draft-resource fields → verify all `*-draft` flags appear in spawned-process args

🤖 Generated with [Claude Code](https://claude.com/claude-code)