### PR TITLE
feat(cuda): install NCCL so tensor parallelism uses the optimized AllReduce

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -20,10 +20,15 @@ ARG TARGETARCH=amd64
 
 # curl + ca-certificates for the package download; libssl-dev for OpenSSL-
 # enabled llama.cpp builds. Build toolchain comes via the .deb's Depends.
+# libnccl-dev wires up llama.cpp's optimized AllReduce path for tensor
+# parallelism (-sm tensor) — without it GGML_CUDA_NCCL still defaults ON
+# but the build silently falls back to a slower shfl_tensor_async path.
+# The CUDA devel base image usually ships NCCL already; installing
+# explicitly is a no-op there and guarantees it's present otherwise.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates libssl-dev
+    curl ca-certificates libssl-dev libnccl-dev
 
 # uv is required by the llama-benchy benchmark integration — the
 # benchmark runner shells out to `uvx llama-benchy`. Install

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Two modes:
 
 GPU selection: pick "All GPUs" (tensor mode), specific GPUs ("GPU 0", "GPUs 0–1"), or a custom tensor-split string like `1,1,0,0`.
 
+**Tensor parallelism on CUDA — NCCL.** llama.cpp's `-sm tensor` path uses NCCL for the AllReduce that fires after attention and the FFN in every transformer block. NCCL is the optimized GPU-to-GPU collective communications library; without it the build silently falls back to a slower generic path. The CUDA container image installs `libnccl-dev` automatically, and `setup.sh install --cuda` does the same on host installs. At runtime, pair tensor parallelism with **Flash Attention on** and **KV cache at `f16`** (no quant) — those are hard constraints in the current implementation. Note that the per-tensor split requires the model's attention head count to divide cleanly by the number of GPUs, so 3-way splits crash on many architectures (most pick power-of-2 head counts). 2 or 4 GPUs split far more reliably.
+
 ## Architecture
 
 A single Go binary serves the web UI and manages llama-server subprocesses. Server-rendered HTML with [htmx](https://htmx.org/) and [Pico CSS](https://picocss.com/) — no JS build step.

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -178,6 +178,13 @@ host_missing_gpu_sdk_packages() {
                             fi
                         done
                     fi
+                    # libnccl-devel enables llama.cpp's GGML_CUDA_NCCL path
+                    # (optimized AllReduce for -sm tensor across multiple
+                    # GPUs). The cmake option defaults ON; without the
+                    # headers the build silently falls back to the slower
+                    # shfl_tensor_async path. NVIDIA ships this in their
+                    # cuda-fedoraN repo as libnccl-devel.
+                    rpm -q libnccl-devel >/dev/null 2>&1 || need+=("libnccl-devel")
                     ;;
                 debian)
                     if ! host_find_cuda_host_compiler >/dev/null 2>&1; then
@@ -188,6 +195,9 @@ host_missing_gpu_sdk_packages() {
                             fi
                         done
                     fi
+                    # See fedora branch above — libnccl-dev is what
+                    # llama.cpp's find_package(NCCL) needs at build time.
+                    dpkg -s libnccl-dev >/dev/null 2>&1 || need+=("libnccl-dev")
                     ;;
             esac
             ;;

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -175,7 +175,7 @@
         <dt>GPU <em>N</em></dt><dd>Pin to a single GPU.</dd>
         <dt>GPUs <em>i-j</em></dt><dd>Contiguous range, layer split — each GPU holds a sequential slice of layers.</dd>
         <dt>All GPUs (layer split)</dt><dd>Layer split across every GPU.</dd>
-        <dt>Tensor Parallelism (<em>N</em> GPUs)</dt><dd>Experimental. Splits individual tensors across N GPUs simultaneously — needs a fast GPU interconnect. Upstream support is still rough for some architectures.</dd>
+        <dt>Tensor Parallelism (<em>N</em> GPUs)</dt><dd>Experimental. Splits individual tensors across N GPUs simultaneously — needs a fast GPU interconnect. On CUDA, NCCL (libnccl-dev) must be present at build time for the optimized AllReduce path; without it the build falls back to a slower path. Pair with Flash Attention <em>on</em> and KV cache at <code>f16</code> (no quant). Upstream support is still rough for some architectures, and N must divide the model's attention head count — many models pick head counts that don't split by 3.</dd>
         <dt>Custom</dt><dd>You provide a raw <code>--tensor-split</code> ratio string.</dd>
     </dl>
 


### PR DESCRIPTION
## Summary

- Install `libnccl-dev` in `Dockerfile.cuda` and add it to the host-mode CUDA SDK package list (`scripts/lib/host.sh`) so llama.cpp's `find_package(NCCL)` succeeds at build time. `GGML_CUDA_NCCL` defaults `ON` upstream but silently falls back to a slower `shfl_tensor_async` path when the NCCL headers aren't on disk.
- Document the NCCL requirement, the FA-on / KV-f16 runtime constraints, and the attention-head divisibility gotcha that makes 3-way tensor splits crash on most architectures (most models pick power-of-2 head counts). Updates land in the README's Multi-GPU section and the in-app help (`web/templates/help.html`).

No code change to the build profile — `GGML_CUDA_NCCL` is already ON by default in current llama.cpp master, so once NCCL is present cmake picks it up on the next build.

## Test plan

- [ ] `./setup.sh rebuild` (or `quick`) on a CUDA host and confirm `libnccl-dev` lands in the image.
- [ ] Trigger a fresh `cuda` profile build from the Builds tab; confirm cmake output does **not** contain `Warning: NCCL not found, performance for multiple CUDA GPUs will be suboptimal`.
- [ ] On a host install (`./setup.sh install --cuda`), confirm `libnccl-dev` / `libnccl-devel` shows up in the missing-packages prompt when not already installed.
- [ ] Configure a model with Tensor Parallelism (2 GPUs), Flash Attention on, KV cache at f16 — confirm llama-server starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)