### PR TITLE
fix(tensor-split): pass --fit off so model load doesn't abort

### DIFF
--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -172,6 +172,15 @@ func (c *ModelConfig) EffectiveFlagsFor(isEmbedding bool) string {
 	}
 	if c.SplitMode != "" {
 		parts = append(parts, "--split-mode", c.SplitMode)
+		// Upstream auto-fit (common_fit_params) is not implemented for
+		// SPLIT_MODE_TENSOR and aborts model load with "llama_params_fit
+		// is not implemented for SPLIT_MODE_TENSOR". Disable it so the
+		// user's explicit --n-gpu-layers / --tensor-split values are
+		// honored verbatim. Drop this when llama.cpp adds the fitter for
+		// tensor mode.
+		if c.SplitMode == "tensor" {
+			parts = append(parts, "--fit", "off")
+		}
 	}
 	if c.MainGPU > 0 {
 		parts = append(parts, "--main-gpu", strconv.Itoa(c.MainGPU))


### PR DESCRIPTION
## Summary

llama-server's auto-fit-to-VRAM path (\`common_fit_params\`) is not implemented for \`SPLIT_MODE_TENSOR\` in upstream. When a model is loaded with \`--split-mode tensor\`, it aborts at load with:

\`\`\`
W common_fit_params: failed to fit params to free device memory: llama_params_fit is not implemented for SPLIT_MODE_TENSOR, abort
\`\`\`

The hint in upstream's log message — \`(for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)\` — points to the workaround. Inject \`--fit off\` automatically whenever split-mode is tensor so the user's explicit \`--n-gpu-layers\` and \`--tensor-split\` values are honored verbatim. Drop the workaround when upstream implements the fitter for tensor mode.

Repro from #45's follow-up: 3×A4000 box, Qwen3.6-27B Q6_K_XL, Tensor Parallelism (3 GPUs) → llama-server exits status 1 at load.

## Test plan

- [ ] Load a model with Tensor Parallelism on the 3×A4000 box and confirm load completes
- [ ] Load a model with layer split and confirm \`--fit off\` is NOT injected (\`internal/models/registry.go\` — only fires when split-mode == "tensor")

🤖 Generated with [Claude Code](https://claude.com/claude-code)