### PR TITLE
feat(rocm): add FP16 cuBLAS compute toggle and bump ROCm to 7.2.4

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -23,7 +23,7 @@ RUN <<'EOF'
 tee /etc/yum.repos.d/rocm.repo <<REPO
 [ROCm-7.2]
 name=ROCm7.2
-baseurl=https://repo.radeon.com/rocm/el9/7.2.2/main
+baseurl=https://repo.radeon.com/rocm/el9/7.2.4/main
 enabled=1
 priority=50
 gpgcheck=1

--- a/internal/builder/profiles.go
+++ b/internal/builder/profiles.go
@@ -53,6 +53,12 @@ func ProfileOptions(profile string) []BuildOption {
 				Description: "Allow models larger than VRAM to overflow into system RAM. Slower but lets you run bigger models.",
 				Default:     false,
 			},
+			{
+				Flag:        "GGML_CUDA_FORCE_CUBLAS_COMPUTE_16F",
+				Label:       "Force FP16 cuBLAS Compute Type",
+				Description: "Force cuBLAS GEMM to use FP16 accumulators instead of FP32 when inputs are FP16. Faster on FP16-throughput-bound GPUs at a small accuracy cost.",
+				Default:     false,
+			},
 		}...)
 	case "rocm":
 		return append(common, []BuildOption{
@@ -72,6 +78,12 @@ func ProfileOptions(profile string) []BuildOption {
 				Flag:        "GGML_HIP_ROCWMMA_FATTN",
 				Label:       "rocWMMA FlashAttention",
 				Description: "Build the FlashAttention kernel against rocWMMA so attention dispatches through the AI matrix accelerators (FP16 WMMA). Recommended for RDNA3+ (gfx1100/1101/1151) and RDNA4 (gfx1200/1201) on ROCm 7.x — speeds up prefill noticeably. Requires --flash-attn at runtime to take effect. Needs rocwmma-devel installed.",
+				Default:     false,
+			},
+			{
+				Flag:        "GGML_CUDA_FORCE_CUBLAS_COMPUTE_16F",
+				Label:       "Force FP16 hipBLAS Compute Type",
+				Description: "Force hipBLAS/cuBLAS GEMM to use FP16 accumulators instead of FP32 when inputs are FP16. Particularly useful on RDNA4 (gfx1200/1201) where the rocWMMA-FATTN path is flaky — this is the main tuning knob for FP16 matrix throughput. Small accuracy cost.",
 				Default:     false,
 			},
 		}...)


### PR DESCRIPTION
## Summary
- Expose `GGML_CUDA_FORCE_CUBLAS_COMPUTE_16F` as a build toggle on both the `cuda` and `rocm` profiles. Forces FP16 accumulators in cuBLAS/hipBLAS GEMM when inputs are FP16 — useful FP16-throughput knob, particularly on RDNA4 (gfx1200/1201) where the rocWMMA-FATTN path is currently flaky. Defaults off; small accuracy cost (largely swamped by quantization noise on Q8_0 and lower).
- Bump the ROCm runtime in `Dockerfile.rocm` from 7.2.2 → 7.2.4.

## Test plan
- [ ] Build llama.cpp with the rocm profile and the new toggle enabled; confirm cmake picks up the flag and the build succeeds.
- [ ] Run a prompt-processing benchmark on an RDNA4 GPU with the toggle off vs on, sanity-check throughput delta and PPL drift.
- [ ] Rebuild the ROCm Docker image and confirm `rocminfo` works and llama-server boots against an RDNA4 device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)