### PR TITLE
feat(mmproj): add toggle to skip vision projector without clearing path

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -713,6 +713,10 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 
 		if r.Form.Has("mmproj_path") {
 			cfg.MmprojPath = r.FormValue("mmproj_path")
+			// Inverted storage: form sends mmproj_enabled=on when checked.
+			// Default-false on a missing checkbox means "disabled", which is
+			// exactly the unchecked state.
+			cfg.MmprojDisabled = r.FormValue("mmproj_enabled") != "on"
 		}
 		// Parse aliases (comma-separated, trimmed)
 		if aliasStr := strings.TrimSpace(r.FormValue("aliases")); aliasStr != "" {

--- a/internal/models/preset.go
+++ b/internal/models/preset.go
@@ -136,7 +136,7 @@ func writeConfigParams(b *strings.Builder, cfg *ModelConfig, isEmbedding bool) {
 		if cfg.DirectIO {
 			b.WriteString("direct-io = true\n")
 		}
-		if cfg.MmprojPath != "" {
+		if cfg.MmprojPath != "" && !cfg.MmprojDisabled {
 			b.WriteString(fmt.Sprintf("mmproj = %s\n", cfg.MmprojPath))
 		}
 		// Speculative decoding. llama.cpp split the legacy mode-agnostic

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -94,7 +94,8 @@ type ModelConfig struct {
 	Jinja            bool   `json:"jinja"`
 	KVCacheQuant     string `json:"kv_cache_quant"`        // "", "q8_0", "q4_0"
 	DirectIO         bool   `json:"direct_io"`             // bypass page cache, load straight to VRAM
-	MmprojPath       string `json:"mmproj_path,omitempty"` // path to mmproj GGUF for vision models
+	MmprojPath       string `json:"mmproj_path,omitempty"`     // path to mmproj GGUF for vision models
+	MmprojDisabled   bool   `json:"mmproj_disabled,omitempty"` // skip --mmproj at launch even when MmprojPath is set; preserves the path so it can be re-enabled without retyping
 
 	// Speculative decoding
 	SpecType       string `json:"spec_type,omitempty"`        // "", "draft", "draft-mtp", "ngram-simple", "ngram-cache", etc.
@@ -198,7 +199,7 @@ func (c *ModelConfig) EffectiveFlagsFor(isEmbedding bool) string {
 		if c.DirectIO {
 			parts = append(parts, "--direct-io")
 		}
-		if c.MmprojPath != "" {
+		if c.MmprojPath != "" && !c.MmprojDisabled {
 			parts = append(parts, "--mmproj", c.MmprojPath)
 		}
 		// Speculative decoding. llama.cpp split the legacy mode-agnostic

--- a/web/templates/partials/model_config.html
+++ b/web/templates/partials/model_config.html
@@ -148,6 +148,11 @@
             <input type="text" name="mmproj_path" value="{{.Config.MmprojPath}}"
                    placeholder="Auto-detected or enter path to mmproj GGUF">
         </label>
+        <label title="Uncheck to launch without the vision projector while keeping the path saved. Useful when the projector pushes a tight VRAM budget over the edge.">
+            Load Projector
+            <input type="checkbox" name="mmproj_enabled" role="switch"
+                   {{if not .Config.MmprojDisabled}}checked{{end}}>
+        </label>
     </div>
     {{end}}
 
@@ -310,10 +315,10 @@
     </div>
     {{end}}
     {{if eq .Config.SpecType "draft-mtp"}}
-    {{if or (gt .Config.Parallel 1) (ne .Config.MmprojPath "")}}
+    {{if or (gt .Config.Parallel 1) (and (ne .Config.MmprojPath "") (not .Config.MmprojDisabled))}}
     <small style="color:var(--pico-del-color)"><strong>⚠ MTP incompatibility:</strong>
         {{if gt .Config.Parallel 1}}MTP requires parallel = 1 (currently {{.Config.Parallel}}). {{end}}
-        {{if ne .Config.MmprojPath ""}}MTP does not work with an mmproj vision projector. {{end}}
+        {{if and (ne .Config.MmprojPath "") (not .Config.MmprojDisabled)}}MTP does not work with an mmproj vision projector. {{end}}
         The server may fail to start until this is resolved.
     </small>
     {{end}}


### PR DESCRIPTION
## Summary
- Adds a **Load Projector** switch in the model config next to the mmproj path input. Unchecking it skips `--mmproj` at launch while keeping the path saved.
- Motivation: when a model just barely fits with full context, the projector pushes VRAM over the edge. Previously the only way to launch without it was to wipe the path — which then had to be retyped to re-enable vision.
- Backed by an inverted `MmprojDisabled` bool so existing configs keep their projector enabled with zero migration.

## Test plan
- [ ] Open a vision model's config — the "Load Projector" switch shows checked.
- [ ] Uncheck the switch, save, restart — server launches without `--mmproj` and the path remains in the field.
- [ ] Re-check the switch, save, restart — `--mmproj` is back, vision works.
- [ ] MTP incompatibility warning no longer fires when the projector is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)