### PR TITLE
feat(benchmark): add fp16 and MTP overrides to batch job options

### DIFF
--- a/web/templates/partials/job_form.html
+++ b/web/templates/partials/job_form.html
@@ -69,6 +69,7 @@
             <label>KV cache quant
                 <select name="ov_kv_cache_quant">
                     <option value="">inherit</option>
+                    <option value="f16">f16 (no quant)</option>
                     <option value="q8_0">q8_0</option>
                     <option value="q4_0">q4_0</option>
                 </select>
@@ -95,6 +96,7 @@
                 <select name="ov_spec_type">
                     <option value="">inherit</option>
                     <option value="draft">Draft Model</option>
+                    <option value="draft-mtp">MTP (self-speculation)</option>
                     <option value="ngram-simple">N-gram Simple</option>
                     <option value="ngram-cache">N-gram Cache</option>
                     <option value="ngram-map-k">N-gram Map-K</option>


### PR DESCRIPTION
## Summary

The benchmark batch job override options were missing two settings that already exist in the models tab:

- **KV cache quant — added `f16 (no quant)`.** Previously the override only offered `inherit`, `q8_0`, `q4_0`, so there was no way to *force* no quantization (inherit just uses each model's saved value). The new option emits an explicit `--cache-type-k/v f16` via the existing registry logic, and VRAM estimation already treats `f16` as the 2.0 bytes/elem default — so the math is correct.
- **Spec type — added `MTP (self-speculation)` (`draft-mtp`).** Matches the value and label used in the models tab after MTP speculative decoding support was added there.

## Notes

Template-only change in `web/templates/partials/job_form.html`. No JS or Go changes were needed — the `readOverrides`/`setField` helpers and the `ConfigOverrides` pass-through already handle both as generic string fields.

## Test plan

- [x] `go build ./...` passes
- [ ] Open the benchmark job form and confirm both new options appear and persist on edit/re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)