### PR TITLE
feat(mtp): support gemma-4 separate MTP drafter heads

### DIFF
--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -256,6 +256,17 @@ func (s *Server) onDownloadComplete(downloadID, modelID, filename string, sizeBy
 		return
 	}
 
+	meta, _ := models.ParseGGUFMeta(filePath)
+
+	// MTP drafter heads (e.g. gemma-4's gemma4-assistant) aren't runnable
+	// models — they load via --model-draft. Don't register; auto-associate
+	// with sibling main models like we do for mmproj.
+	if meta != nil && models.IsMTPHeadArch(meta.Architecture) {
+		slog.Info("MTP drafter head downloaded, associating with sibling models", "file", filePath)
+		s.registry.AutoDetectMTP()
+		return
+	}
+
 	safeFilename := strings.ReplaceAll(strings.TrimSuffix(filename, ".gguf"), "/", "--")
 	m := &models.Model{
 		ID:           fmt.Sprintf("%s--%s", safeName, safeFilename),
@@ -268,8 +279,8 @@ func (s *Server) onDownloadComplete(downloadID, modelID, filename string, sizeBy
 		DownloadedAt: time.Now(),
 	}
 
-	// Parse GGUF metadata for architecture-aware VRAM estimation
-	if meta, err := models.ParseGGUFMeta(filePath); err == nil {
+	// Architecture-aware VRAM estimation from the GGUF header parsed above.
+	if meta != nil {
 		m.Arch = meta.Architecture
 		m.NLayers = meta.NLayers
 		m.NEmbd = meta.NEmbd
@@ -290,5 +301,13 @@ func (s *Server) onDownloadComplete(downloadID, modelID, filename string, sizeBy
 			slog.Info("auto-associated mmproj", "model", m.ID, "mmproj", mmproj)
 		}
 	}
-}
 
+	// Check if a separate MTP drafter head already exists nearby
+	if mtp := models.FindMTP(filePath); mtp != "" {
+		if cfg, err := s.registry.GetConfig(m.ID); err == nil && cfg.MtpPath == "" {
+			cfg.MtpPath = mtp
+			s.registry.SetConfig(m.ID, cfg)
+			slog.Info("auto-associated MTP head", "model", m.ID, "mtp", mtp)
+		}
+	}
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -555,11 +555,13 @@ func (s *Server) handleGetModelConfig(w http.ResponseWriter, r *http.Request) {
 
 		maxContext := 0
 		detectedMMProj := ""
+		detectedMTP := ""
 		isEmbedding := false
 		var draftCandidates []models.DraftCandidate
 		if model != nil {
 			maxContext = model.ContextLength
 			detectedMMProj = models.FindMMProj(model.FilePath)
+			detectedMTP = models.FindMTP(model.FilePath)
 			isEmbedding = models.IsEmbeddingModel(model.ModelID) || models.IsEmbeddingModel(model.ID)
 			if !isEmbedding {
 				draftCandidates = s.registry.FindDraftCandidates(id)
@@ -632,6 +634,7 @@ func (s *Server) handleGetModelConfig(w http.ResponseWriter, r *http.Request) {
 			EffectiveFlags      string
 			MaxContext          int
 			HasMMProj           bool
+			HasMTP              bool
 			HasBuiltinVision    bool
 			IsEmbedding         bool
 			DraftCandidates     []models.DraftCandidate
@@ -645,6 +648,7 @@ func (s *Server) handleGetModelConfig(w http.ResponseWriter, r *http.Request) {
 			EffectiveFlags:      cfg.EffectiveFlagsFor(isEmbedding),
 			MaxContext:          maxContext,
 			HasMMProj:           cfg.MmprojPath != "" || detectedMMProj != "",
+			HasMTP:              cfg.MtpPath != "" || detectedMTP != "",
 			HasBuiltinVision:    hasBuiltinVision,
 			IsEmbedding:         isEmbedding,
 			DraftCandidates:     draftCandidates,
@@ -717,6 +721,12 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 			// Default-false on a missing checkbox means "disabled", which is
 			// exactly the unchecked state.
 			cfg.MmprojDisabled = r.FormValue("mmproj_enabled") != "on"
+		}
+		if r.Form.Has("mtp_path") {
+			cfg.MtpPath = r.FormValue("mtp_path")
+			// Inverted storage, same as mmproj: form sends mtp_enabled=on when
+			// checked; a missing checkbox means disabled.
+			cfg.MtpDisabled = r.FormValue("mtp_enabled") != "on"
 		}
 		// Parse aliases (comma-separated, trimmed)
 		if aliasStr := strings.TrimSpace(r.FormValue("aliases")); aliasStr != "" {

--- a/internal/models/preset.go
+++ b/internal/models/preset.go
@@ -175,6 +175,26 @@ func writeConfigParams(b *strings.Builder, cfg *ModelConfig, isEmbedding bool) {
 			}
 		case "draft-mtp":
 			b.WriteString("spec-type = draft-mtp\n")
+			// Separate drafter head (gemma-4); empty for self-speculation MTP.
+			if cfg.MtpPath != "" && !cfg.MtpDisabled {
+				b.WriteString(fmt.Sprintf("model-draft = %s\n", cfg.MtpPath))
+				if cfg.DraftCtxSize > 0 {
+					b.WriteString(fmt.Sprintf("ctx-size-draft = %d\n", cfg.DraftCtxSize))
+				}
+				if cfg.DraftGPULayers > 0 {
+					b.WriteString(fmt.Sprintf("gpu-layers-draft = %d\n", cfg.DraftGPULayers))
+				}
+				if cfg.DraftDevice != "" {
+					b.WriteString(fmt.Sprintf("device-draft = %s\n", cfg.DraftDevice))
+				}
+				if cfg.DraftCPUMoE > 0 {
+					b.WriteString(fmt.Sprintf("n-cpu-moe-draft = %d\n", cfg.DraftCPUMoE))
+				}
+				if cfg.DraftKVCacheQuant != "" {
+					b.WriteString(fmt.Sprintf("cache-type-k-draft = %s\n", cfg.DraftKVCacheQuant))
+					b.WriteString(fmt.Sprintf("cache-type-v-draft = %s\n", cfg.DraftKVCacheQuant))
+				}
+			}
 			if cfg.DraftMax > 0 {
 				b.WriteString(fmt.Sprintf("spec-draft-n-max = %d\n", cfg.DraftMax))
 			}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -81,21 +81,23 @@ type Model struct {
 
 // ModelConfig holds per-model launch configuration for llama-server.
 type ModelConfig struct {
-	Enabled          bool   `json:"enabled"`
-	GPULayers        int    `json:"gpu_layers"`
-	TensorSplit      string `json:"tensor_split"`
-	SplitMode        string `json:"split_mode,omitempty"` // "layer", "tensor", or ""
-	MainGPU          int    `json:"main_gpu,omitempty"`
-	GPUAssign        string `json:"gpu_assign,omitempty"` // "all", "0", "0-1", "custom", etc.
-	ContextSize      int    `json:"context_size"`
-	Parallel         int    `json:"parallel,omitempty"` // n parallel sequence slots; 0/1 = no extra slots, >1 divides ctx_size across slots
-	Threads          int    `json:"threads"`
-	FlashAttention   bool   `json:"flash_attention"`
-	Jinja            bool   `json:"jinja"`
-	KVCacheQuant     string `json:"kv_cache_quant"`        // "", "q8_0", "q4_0"
-	DirectIO         bool   `json:"direct_io"`             // bypass page cache, load straight to VRAM
-	MmprojPath       string `json:"mmproj_path,omitempty"`     // path to mmproj GGUF for vision models
-	MmprojDisabled   bool   `json:"mmproj_disabled,omitempty"` // skip --mmproj at launch even when MmprojPath is set; preserves the path so it can be re-enabled without retyping
+	Enabled        bool   `json:"enabled"`
+	GPULayers      int    `json:"gpu_layers"`
+	TensorSplit    string `json:"tensor_split"`
+	SplitMode      string `json:"split_mode,omitempty"` // "layer", "tensor", or ""
+	MainGPU        int    `json:"main_gpu,omitempty"`
+	GPUAssign      string `json:"gpu_assign,omitempty"` // "all", "0", "0-1", "custom", etc.
+	ContextSize    int    `json:"context_size"`
+	Parallel       int    `json:"parallel,omitempty"` // n parallel sequence slots; 0/1 = no extra slots, >1 divides ctx_size across slots
+	Threads        int    `json:"threads"`
+	FlashAttention bool   `json:"flash_attention"`
+	Jinja          bool   `json:"jinja"`
+	KVCacheQuant   string `json:"kv_cache_quant"`            // "", "q8_0", "q4_0"
+	DirectIO       bool   `json:"direct_io"`                 // bypass page cache, load straight to VRAM
+	MmprojPath     string `json:"mmproj_path,omitempty"`     // path to mmproj GGUF for vision models
+	MmprojDisabled bool   `json:"mmproj_disabled,omitempty"` // skip --mmproj at launch even when MmprojPath is set; preserves the path so it can be re-enabled without retyping
+	MtpPath        string `json:"mtp_path,omitempty"`        // path to a separate MTP drafter-head GGUF (gemma-4 style); loaded via --model-draft under spec_type=draft-mtp. Empty for self-speculation MTP (Qwen3.6/DeepSeek-V3) where the head is baked into the main GGUF.
+	MtpDisabled    bool   `json:"mtp_disabled,omitempty"`    // skip the separate --model-draft MTP head at launch even when MtpPath is set; preserves the path so it can be re-enabled
 
 	// Speculative decoding
 	SpecType       string `json:"spec_type,omitempty"`        // "", "draft", "draft-mtp", "ngram-simple", "ngram-cache", etc.
@@ -106,8 +108,9 @@ type ModelConfig struct {
 	NgramSizeN     int    `json:"ngram_size_n,omitempty"`     // n-gram lookup length
 	NgramSizeM     int    `json:"ngram_size_m,omitempty"`     // n-gram draft length
 
-	// Draft model resource overrides (only meaningful when spec_type="draft" —
-	// not used by MTP self-speculation since the draft *is* the main model).
+	// Draft model resource overrides. Apply to spec_type="draft" and to
+	// gemma-4-style draft-mtp (separate head loaded via --model-draft). Not
+	// used by self-speculation MTP, where the draft *is* the main model.
 	DraftCtxSize      int    `json:"draft_ctx_size,omitempty"`       // --ctx-size-draft
 	DraftGPULayers    int    `json:"draft_gpu_layers,omitempty"`     // --gpu-layers-draft
 	DraftDevice       string `json:"draft_device,omitempty"`         // --device-draft
@@ -244,10 +247,32 @@ func (c *ModelConfig) EffectiveFlagsFor(isEmbedding bool) string {
 				parts = append(parts, "--cache-type-k-draft", c.DraftKVCacheQuant, "--cache-type-v-draft", c.DraftKVCacheQuant)
 			}
 		case "draft-mtp":
-			// MTP is self-speculation: the main GGUF carries the draft
-			// head, so no --model-draft is set and the draft-resource
-			// flags above don't apply. Only the draft sampling knobs do.
+			// Two MTP flavors share this spec-type:
+			//   • Self-speculation (Qwen3.6, DeepSeek-V3): the MTP head is baked
+			//     into the main GGUF, so MtpPath is empty — no --model-draft and
+			//     the draft-resource flags don't apply. Only the sampling knobs do.
+			//   • Separate drafter (gemma-4's "gemma4-assistant" head): the head
+			//     ships as its own GGUF in MtpPath, loaded via --model-draft just
+			//     like a draft-simple model, including the draft-resource overrides.
 			parts = append(parts, "--spec-type", "draft-mtp")
+			if c.MtpPath != "" && !c.MtpDisabled {
+				parts = append(parts, "--model-draft", c.MtpPath)
+				if c.DraftCtxSize > 0 {
+					parts = append(parts, "--ctx-size-draft", strconv.Itoa(c.DraftCtxSize))
+				}
+				if c.DraftGPULayers > 0 {
+					parts = append(parts, "--gpu-layers-draft", strconv.Itoa(c.DraftGPULayers))
+				}
+				if c.DraftDevice != "" {
+					parts = append(parts, "--device-draft", c.DraftDevice)
+				}
+				if c.DraftCPUMoE > 0 {
+					parts = append(parts, "--n-cpu-moe-draft", strconv.Itoa(c.DraftCPUMoE))
+				}
+				if c.DraftKVCacheQuant != "" {
+					parts = append(parts, "--cache-type-k-draft", c.DraftKVCacheQuant, "--cache-type-v-draft", c.DraftKVCacheQuant)
+				}
+			}
 			if c.DraftMax > 0 {
 				parts = append(parts, "--spec-draft-n-max", strconv.Itoa(c.DraftMax))
 			}
@@ -709,6 +734,13 @@ func (r *Registry) ScanModels() int {
 			m.HasBuiltinVision = meta.HasVision
 		}
 
+		// Skip standalone MTP / drafter "assistant" heads (e.g. gemma-4's
+		// gemma4-assistant). They're loaded via --model-draft alongside a main
+		// model, not served on their own — auto-associated by AutoDetectMTP below.
+		if IsMTPHeadArch(m.Arch) {
+			return nil
+		}
+
 		found = append(found, m)
 		return nil
 	})
@@ -720,9 +752,10 @@ func (r *Registry) ScanModels() int {
 			"arch", m.Arch)
 	}
 
-	// Auto-associate mmproj files with newly scanned models
+	// Auto-associate mmproj files and separate MTP drafter heads with models
 	if len(found) > 0 {
 		r.AutoDetectMMProj()
+		r.AutoDetectMTP()
 	}
 
 	return len(found)
@@ -792,6 +825,100 @@ func (r *Registry) AutoDetectMMProj() int {
 		}
 		if mmproj := FindMMProj(m.FilePath); mmproj != "" {
 			cfg.MmprojPath = mmproj
+			found++
+		}
+	}
+	if found > 0 {
+		r.save()
+	}
+	return found
+}
+
+// IsMTPHeadArch reports whether a GGUF architecture identifies a standalone
+// MTP / speculative "assistant" drafter head (e.g. gemma-4's "gemma4-assistant")
+// rather than a runnable model. Such files load via --model-draft under
+// spec_type=draft-mtp, not served on their own.
+//
+// Detection is by architecture, not filename: Qwen's self-speculation MTP
+// models also carry "MTP" in their name but ARE runnable (the head is baked
+// into a normal qwen3 arch), so they must keep registering as ordinary models.
+func IsMTPHeadArch(arch string) bool {
+	return strings.Contains(strings.ToLower(arch), "assistant")
+}
+
+// FindMTP looks for a separate MTP drafter-head GGUF associated with the given
+// model: the same directory, an "MTP/" subdirectory (unsloth's gemma-4 layout),
+// or the parent directory and its "MTP/" subdir (for quant-in-subdir repos).
+// Returns the path to the first one found, or empty string.
+func FindMTP(modelFilePath string) string {
+	dir := filepath.Dir(modelFilePath)
+	for _, d := range []string{dir, filepath.Join(dir, "MTP")} {
+		if p := findMTPInDir(d); p != "" {
+			return p
+		}
+	}
+	parent := filepath.Dir(dir)
+	if parent != dir {
+		for _, d := range []string{parent, filepath.Join(parent, "MTP")} {
+			if p := findMTPInDir(d); p != "" {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+// findMTPInDir scans a single directory for a GGUF whose architecture marks it
+// as an MTP drafter head.
+func findMTPInDir(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	// unsloth ships heads in an "MTP/" subdirectory; arch is authoritative but
+	// reading every GGUF header is the expensive part, so use location/name as
+	// a cheap pre-filter.
+	inMTPDir := strings.EqualFold(filepath.Base(dir), "MTP")
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		lname := strings.ToLower(name)
+		if !strings.HasSuffix(lname, ".gguf") {
+			continue
+		}
+		// Only crack open headers for files that plausibly *are* a drafter head.
+		// Skips parsing every multi-GB main quant on each config open / scan.
+		// The IsMTPHeadArch check below stays authoritative — e.g. a Qwen
+		// self-speculation model named "...-MTP-..." passes this pre-filter but
+		// is correctly rejected by its runnable (non-assistant) architecture.
+		if !inMTPDir && !strings.Contains(lname, "mtp") && !strings.Contains(lname, "assistant") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if meta, err := ParseGGUFMeta(path); err == nil && IsMTPHeadArch(meta.Architecture) {
+			return path
+		}
+	}
+	return ""
+}
+
+// AutoDetectMTP scans all registered models and sets MtpPath on configs where a
+// separate MTP drafter head exists in or near the model directory but isn't
+// configured yet.
+func (r *Registry) AutoDetectMTP() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	found := 0
+	for id, m := range r.data.Models {
+		cfg := r.data.Configs[id]
+		if cfg == nil || cfg.MtpPath != "" {
+			continue
+		}
+		if mtp := FindMTP(m.FilePath); mtp != "" {
+			cfg.MtpPath = mtp
 			found++
 		}
 	}

--- a/internal/models/spec_smoke_test.go
+++ b/internal/models/spec_smoke_test.go
@@ -24,6 +24,66 @@ func TestSpecMTPEffectiveFlags(t *testing.T) {
 	}
 }
 
+func TestSpecMTPSeparateDrafterFlags(t *testing.T) {
+	// gemma-4 style: MTP head ships as its own GGUF, loaded via --model-draft
+	// under spec-type draft-mtp, including draft-resource overrides.
+	cfg := &ModelConfig{
+		GPULayers:   99,
+		ContextSize: 8192,
+		Threads:     8,
+		SpecType:    "draft-mtp",
+		MtpPath:     "/models/gemma-4-12B-it-MTP-Q8_0.gguf",
+		DraftMax:    4,
+		DraftDevice: "CUDA0",
+	}
+	got := cfg.EffectiveFlags()
+	for _, want := range []string{
+		"--spec-type draft-mtp",
+		"--model-draft /models/gemma-4-12B-it-MTP-Q8_0.gguf",
+		"--spec-draft-n-max 4",
+		"--device-draft CUDA0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("gemma MTP flags missing %q in: %s", want, got)
+		}
+	}
+}
+
+func TestSpecMTPSeparateDrafterDisabled(t *testing.T) {
+	// MtpDisabled suppresses --model-draft while keeping self-speculation flags.
+	cfg := &ModelConfig{
+		GPULayers:   99,
+		ContextSize: 8192,
+		Threads:     8,
+		SpecType:    "draft-mtp",
+		MtpPath:     "/models/gemma-4-12B-it-MTP-Q8_0.gguf",
+		MtpDisabled: true,
+		DraftMax:    4,
+	}
+	got := cfg.EffectiveFlags()
+	if strings.Contains(got, "--model-draft") {
+		t.Errorf("disabled MTP head should not emit --model-draft, got: %s", got)
+	}
+	if !strings.Contains(got, "--spec-type draft-mtp") {
+		t.Errorf("MTP flags missing --spec-type draft-mtp in: %s", got)
+	}
+}
+
+func TestIsMTPHeadArch(t *testing.T) {
+	for _, arch := range []string{"gemma4-assistant", "gemma4_assistant"} {
+		if !IsMTPHeadArch(arch) {
+			t.Errorf("IsMTPHeadArch(%q) = false, want true", arch)
+		}
+	}
+	// Qwen self-speculation MTP models use a normal runnable arch — must NOT
+	// be classified as a standalone drafter head.
+	for _, arch := range []string{"qwen3", "qwen3moe", "gemma3", "llama"} {
+		if IsMTPHeadArch(arch) {
+			t.Errorf("IsMTPHeadArch(%q) = true, want false", arch)
+		}
+	}
+}
+
 func TestSpecDraftResourceFlags(t *testing.T) {
 	cfg := &ModelConfig{
 		GPULayers:         99,

--- a/web/templates/partials/model_config.html
+++ b/web/templates/partials/model_config.html
@@ -179,7 +179,7 @@
                 <dd>Uses a separate smaller model of the same architecture to propose tokens. Highest and most consistent speedups (1.5-2.5x typical). Requires a compatible model — download one with the same architecture but smaller size (e.g., 0.5B-1B) and it will appear in the dropdown. Uses extra VRAM for the draft model.</dd>
 
                 <dt><strong>MTP (Multi-Token Prediction)</strong></dt>
-                <dd>Self-speculation built into the model — the same GGUF carries an MTP head that drafts tokens for itself, so no separate draft model is needed. Used by Qwen3.6-MTP and DeepSeek-V3-MTP releases. Typical speedup 1.5-2x with zero extra VRAM. <strong>Limitations:</strong> requires the main model to be MTP-enabled (look for "MTP" in the filename), is incompatible with <em>parallel &gt; 1</em>, and does not work with <code>--mmproj</code> vision projectors.</dd>
+                <dd>Multi-token prediction comes in two flavors, both selected here. <strong>Self-speculation</strong> (Qwen3.6-MTP, DeepSeek-V3-MTP): the same GGUF carries an MTP head that drafts tokens for itself — no separate file needed. <strong>Separate drafter</strong> (gemma-4): ships an "assistant" head as its own GGUF (in an <code>MTP/</code> subfolder); llama-toolchest auto-detects it and loads it via <code>--model-draft</code>. Typical speedup 1.5-3x with little or no extra VRAM. <strong>Notes:</strong> typically needs <em>parallel = 1</em>; gemma-4's <code>gemma4-assistant</code> arch requires a llama.cpp build of <strong>b9549 or newer</strong> (Gemma-4 MTP merged 2026-06-07) — build the latest from the Builds tab if an older one is in use.</dd>
 
                 <dt><strong>N-gram Simple</strong></dt>
                 <dd>Searches the generation history for matching token patterns and reuses what followed. Zero overhead, no extra VRAM. Works best when the model repeats patterns (code refactoring, structured output). No benefit for entirely novel text.</dd>
@@ -257,6 +257,18 @@
             </select>
         </label>
         {{end}}
+        {{if and (eq .Config.SpecType "draft-mtp") .HasMTP}}
+        <label title="A separate MTP drafter-head GGUF (e.g. gemma-4's gemma4-assistant), loaded via --model-draft. Auto-detected from the model's MTP/ subdirectory. Leave blank for self-speculation MTP models (Qwen3.6, DeepSeek-V3) whose head is baked into the main GGUF.">
+            MTP Drafter Head
+            <input type="text" name="mtp_path" value="{{.Config.MtpPath}}"
+                   placeholder="Auto-detected, or blank for self-speculation MTP">
+        </label>
+        <label title="Uncheck to launch without the separate MTP head while keeping the path saved.">
+            Load MTP Head
+            <input type="checkbox" name="mtp_enabled" role="switch"
+                   {{if not .Config.MtpDisabled}}checked{{end}}>
+        </label>
+        {{end}}
     </div>
     {{if ne .Config.SpecType ""}}
     <div class="grid">
@@ -278,8 +290,8 @@
         </label>
     </div>
     {{end}}
-    {{if eq .Config.SpecType "draft"}}
-    <small><strong>Draft model resources</strong> — leave blank to inherit llama-server defaults. Set these when the draft model needs its own GPU offload, context, or cache type.</small>
+    {{if or (eq .Config.SpecType "draft") (and (eq .Config.SpecType "draft-mtp") .HasMTP)}}
+    <small><strong>Draft model resources</strong> — leave blank to inherit llama-server defaults. Set these when the draft/MTP head needs its own GPU offload, context, or cache type (e.g. <code>--device-draft CUDA0</code> on multi-GPU).</small>
     <div class="grid">
         <label title="Context size for the draft model. Default: inherits from main ctx-size.">
             Draft Ctx Size
@@ -315,12 +327,13 @@
     </div>
     {{end}}
     {{if eq .Config.SpecType "draft-mtp"}}
-    {{if or (gt .Config.Parallel 1) (and (ne .Config.MmprojPath "") (not .Config.MmprojDisabled))}}
-    <small style="color:var(--pico-del-color)"><strong>⚠ MTP incompatibility:</strong>
-        {{if gt .Config.Parallel 1}}MTP requires parallel = 1 (currently {{.Config.Parallel}}). {{end}}
-        {{if and (ne .Config.MmprojPath "") (not .Config.MmprojDisabled)}}MTP does not work with an mmproj vision projector. {{end}}
-        The server may fail to start until this is resolved.
+    {{if gt .Config.Parallel 1}}
+    <small style="color:var(--pico-del-color)"><strong>⚠ MTP + parallel:</strong>
+        MTP typically requires parallel = 1 (currently {{.Config.Parallel}}). If the server fails to start, set parallel to 1.
     </small>
+    {{end}}
+    {{if .HasMTP}}
+    <small>gemma-4's separate <code>gemma4-assistant</code> head needs a llama.cpp build of <strong>b9549 or newer</strong>. Older builds report <em>"model type gemma4_assistant not supported"</em> — rebuild from the Builds tab if needed.</small>
     {{end}}
     {{end}}
     {{if and (ne .Config.SpecType "") (ne .Config.SpecType "draft") (ne .Config.SpecType "draft-mtp")}}


### PR DESCRIPTION
## Summary

Adds support for **gemma-4 multi-token prediction (MTP)**, which ships its draft head as a *separate* `gemma4-assistant` GGUF (in an `MTP/` subfolder) — unlike the Qwen3.6 / DeepSeek-V3 self-speculation MTP we already support, where the head is baked into the main GGUF.

Both flavors use `--spec-type draft-mtp`, but the separate head must be loaded via `--model-draft`. Previously the `draft-mtp` path hard-coded the self-speculation assumption and never emitted `--model-draft`, so gemma-4 MTP couldn't work.

## What changed

- **Config:** `ModelConfig` gains `MtpPath` / `MtpDisabled` (mirrors the existing mmproj pair).
- **Flag emission** (`registry.go` + `preset.go`): `draft-mtp` now emits `--model-draft <head>` plus draft-resource overrides (`--device-draft`, `--gpu-layers-draft`, …) when a head path is set; behavior is unchanged (self-speculation, no `--model-draft`) when empty.
- **Detection:** `IsMTPHeadArch` identifies heads by **architecture** (`gemma4-assistant`), not filename — so Qwen self-spec models named `…-MTP-…` keep registering as ordinary runnable models.
- **Association:** `FindMTP` / `AutoDetectMTP` auto-attach a head found in the model dir, an `MTP/` subdir, or the parent. Scan and download skip registering heads as standalone models (same treatment as mmproj).
- **UI:** exposes the head path + load toggle + draft-resource fields under MTP, notes the **b9549+** llama.cpp requirement, and **drops the incorrect "MTP is incompatible with mmproj" warning** — they coexist (confirmed in testing).
- **Perf:** `findMTPInDir` uses a cheap name/location pre-filter so it doesn't parse multi-GB main quants on every config open; arch remains the authoritative confirmation.

## llama.cpp support

Gemma-4 MTP merged upstream in [PR #23398](https://github.com/ggml-org/llama.cpp/pull/23398) and is present in release **b9549** and newer. Since the project builds the latest llama.cpp, a fresh build picks it up automatically.

## Testing

- New unit tests cover the separate-drafter flags, the disabled case, and `IsMTPHeadArch` classification (incl. that `qwen3`/`gemma3`/`llama` are *not* flagged).
- **Verified end-to-end on b9553-rocm:** `unsloth/gemma-4-12b-it-GGUF` loads with `--model-draft .../MTP/gemma-4-12B-it-MTP-Q8_0.gguf --spec-type draft-mtp` **and** `--mmproj`, and the `draft-mtp` drafter initializes (`speculative decoding context initialized`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)