### PR TITLE
fix(vram): model GQA + sliding-window attention and auxiliary files

### DIFF
--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -281,14 +281,7 @@ func (s *Server) onDownloadComplete(downloadID, modelID, filename string, sizeBy
 
 	// Architecture-aware VRAM estimation from the GGUF header parsed above.
 	if meta != nil {
-		m.Arch = meta.Architecture
-		m.NLayers = meta.NLayers
-		m.NEmbd = meta.NEmbd
-		m.NHead = meta.NHead
-		m.NKVHead = meta.NKVHead
-		m.ContextLength = meta.ContextLength
-		m.SupportsTools = meta.SupportsTools
-		m.HasBuiltinVision = meta.HasVision
+		meta.ApplyTo(m)
 	}
 
 	s.registry.Add(m)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -515,26 +515,38 @@ func (s *Server) handleModelVRAMEstimate(w http.ResponseWriter, r *http.Request)
 	contextSize, _ := strconv.Atoi(r.FormValue("context_size"))
 	kvCacheQuant := r.FormValue("kv_cache_quant")
 
-	cfg := &models.ModelConfig{
-		ContextSize:  contextSize,
-		KVCacheQuant: kvCacheQuant,
+	// Start from the saved config so the estimate includes the model's
+	// activated auxiliary files (mmproj / MTP head / draft), then apply the
+	// context and cache-type the user is currently adjusting. Copy so we don't
+	// mutate the registry's live config.
+	cfg := &models.ModelConfig{}
+	if saved, err := s.registry.GetConfig(id); err == nil && saved != nil {
+		*cfg = *saved
 	}
+	cfg.ContextSize = contextSize
+	cfg.KVCacheQuant = kvCacheQuant
 
 	total := models.VRAMEstimateForConfig(model, cfg)
-	kvGB := models.EstimateKVCacheGB(model.NLayers, model.NKVHead, model.NHead, model.NEmbd, contextSize, kvCacheQuant)
+	kvGB := model.KVCacheGB(contextSize, kvCacheQuant)
 	weightsGB := models.BytesToGB(model.SizeBytes)
+	extraGB := models.AuxFilesVRAMGB(cfg)
 
 	if isHTMX(r) {
 		respondHTML(w)
-		fmt.Fprintf(w, `<strong>%.1f GB</strong> <small>(weights: %.1f GB + KV cache: %.1f GB + overhead)</small>`,
-			total, weightsGB, kvGB)
+		extra := ""
+		if extraGB > 0.05 {
+			extra = fmt.Sprintf(" + aux files: %.1f GB", extraGB)
+		}
+		fmt.Fprintf(w, `<strong>%.1f GB</strong> <small>(weights: %.1f GB + KV cache: %.1f GB%s + overhead)</small>`,
+			total, weightsGB, kvGB, extra)
 		return
 	}
 
 	respondJSON(w, map[string]any{
-		"total_gb":    total,
-		"weights_gb":  weightsGB,
-		"kv_cache_gb": kvGB,
+		"total_gb":     total,
+		"weights_gb":   weightsGB,
+		"kv_cache_gb":  kvGB,
+		"aux_files_gb": extraGB,
 	})
 }
 

--- a/internal/models/gguf.go
+++ b/internal/models/gguf.go
@@ -15,9 +15,33 @@ type GGUFMeta struct {
 	NEmbd         int    `json:"n_embd"`
 	NHead         int    `json:"n_head"`
 	NKVHead       int    `json:"n_kv_head"`
-	ContextLength int    `json:"context_length"`  // max trained context size
-	SupportsTools bool   `json:"supports_tools"`  // chat template references tools
-	HasVision     bool   `json:"has_vision"`       // model has a built-in vision encoder
+	ContextLength int    `json:"context_length"` // max trained context size
+	SupportsTools bool   `json:"supports_tools"` // chat template references tools
+	HasVision     bool   `json:"has_vision"`     // model has a built-in vision encoder
+
+	// KV-cache scaling factors, precomputed per-layer to capture grouped-query
+	// attention (which can vary per layer) and sliding-window attention. The KV
+	// cache at context C is: (C·KVFullPerTok + min(C,SlidingWindow)·KVSWAPerTok)
+	// × bytes_per_element. "PerTok" values are KV elements per token, already
+	// summed over the relevant layers and including both K and V.
+	KVFullPerTok  int `json:"kv_full_per_tok,omitempty"` // Σ full-attention layers of kv_heads·(k_dim+v_dim)
+	KVSWAPerTok   int `json:"kv_swa_per_tok,omitempty"`  // Σ sliding-window layers of kv_heads·(k_dim_swa+v_dim_swa)
+	SlidingWindow int `json:"sliding_window,omitempty"`  // sliding-window size; 0 if no local-attention layers
+}
+
+// ApplyTo copies parsed GGUF metadata onto a Model.
+func (meta *GGUFMeta) ApplyTo(m *Model) {
+	m.Arch = meta.Architecture
+	m.NLayers = meta.NLayers
+	m.NEmbd = meta.NEmbd
+	m.NHead = meta.NHead
+	m.NKVHead = meta.NKVHead
+	m.ContextLength = meta.ContextLength
+	m.SupportsTools = meta.SupportsTools
+	m.HasBuiltinVision = meta.HasVision
+	m.KVFullPerTok = meta.KVFullPerTok
+	m.KVSWAPerTok = meta.KVSWAPerTok
+	m.SlidingWindow = meta.SlidingWindow
 }
 
 // HeadDim returns the dimension per attention head.
@@ -65,86 +89,194 @@ func ParseGGUFMeta(path string) (*GGUFMeta, error) {
 	}
 
 	meta := &GGUFMeta{}
-	needed := 7 // architecture + 4 params + context_length + chat_template
-	found := 0
 
-	for i := uint64(0); i < kvCount && found < needed; i++ {
+	// Locals gathered across the metadata scan, reduced into the KV-cache
+	// scaling factors once architecture-prefixed keys are all read. The full
+	// scan (no early exit) is cheap: values we don't capture are seek-skipped.
+	var (
+		headCountKV   int   // scalar head_count_kv (0 if absent or array form)
+		kvHeadCounts  []int // per-layer head_count_kv (gemma stores this as an array)
+		keyLen        int   // attention.key_length (explicit head dim for K)
+		valLen        int   // attention.value_length
+		keyLenSWA     int   // attention.key_length_swa (sliding-window layers)
+		valLenSWA     int   // attention.value_length_swa
+		slidingWindow int   // attention.sliding_window size
+		swaPattern    []bool
+	)
+
+	for i := uint64(0); i < kvCount; i++ {
 		key, err := readGGUFString(f)
 		if err != nil {
-			return meta, nil
+			break
 		}
-
 		valueType, err := readUint32(f)
 		if err != nil {
-			return meta, nil
+			break
 		}
+		arch := meta.Architecture
 
 		// Detect built-in vision encoder from keys like "{arch}.vision.block_count"
 		if strings.Contains(key, ".vision.") {
 			meta.HasVision = true
 		}
 
-		// Check if this is a key we want
 		switch {
 		case key == "general.architecture" && valueType == ggufTypeString:
-			v, err := readGGUFString(f)
-			if err != nil {
-				return meta, nil
+			if v, err := readGGUFString(f); err == nil {
+				meta.Architecture = v
 			}
-			meta.Architecture = v
-			found++
 			continue
 
 		case key == "tokenizer.chat_template" && valueType == ggufTypeString:
-			v, err := readGGUFString(f)
-			if err != nil {
-				return meta, nil
+			if v, err := readGGUFString(f); err == nil {
+				meta.SupportsTools = strings.Contains(v, "tools")
 			}
-			meta.SupportsTools = strings.Contains(v, "tools")
-			found++
 			continue
 
-		case meta.Architecture != "" && key == meta.Architecture+".block_count":
-			if v, err := readGGUFUint32OrInt32(f, valueType); err == nil {
-				meta.NLayers = int(v)
-				found++
+		case arch != "" && key == arch+".block_count":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				meta.NLayers = v
 				continue
 			}
 
-		case meta.Architecture != "" && key == meta.Architecture+".embedding_length":
-			if v, err := readGGUFUint32OrInt32(f, valueType); err == nil {
-				meta.NEmbd = int(v)
-				found++
+		case arch != "" && key == arch+".embedding_length":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				meta.NEmbd = v
 				continue
 			}
 
-		case meta.Architecture != "" && key == meta.Architecture+".attention.head_count":
-			if v, err := readGGUFUint32OrInt32(f, valueType); err == nil {
-				meta.NHead = int(v)
-				found++
+		case arch != "" && key == arch+".attention.head_count":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				meta.NHead = v
 				continue
 			}
 
-		case meta.Architecture != "" && key == meta.Architecture+".attention.head_count_kv":
-			if v, err := readGGUFUint32OrInt32(f, valueType); err == nil {
-				meta.NKVHead = int(v)
-				found++
+		case arch != "" && key == arch+".attention.head_count_kv":
+			// Scalar for most models; a per-layer array for gemma-style models
+			// whose GQA grouping differs between local and global layers.
+			if valueType == ggufTypeArray {
+				kvHeadCounts = readGGUFArrayInts(f)
+				continue
+			}
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				headCountKV = v
+				meta.NKVHead = v
 				continue
 			}
 
-		case meta.Architecture != "" && key == meta.Architecture+".context_length":
-			if v, err := readGGUFUint32OrInt32(f, valueType); err == nil {
-				meta.ContextLength = int(v)
-				found++
+		case arch != "" && key == arch+".context_length":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				meta.ContextLength = v
+				continue
+			}
+
+		case arch != "" && key == arch+".attention.key_length":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				keyLen = v
+				continue
+			}
+		case arch != "" && key == arch+".attention.value_length":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				valLen = v
+				continue
+			}
+		case arch != "" && key == arch+".attention.key_length_swa":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				keyLenSWA = v
+				continue
+			}
+		case arch != "" && key == arch+".attention.value_length_swa":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				valLenSWA = v
+				continue
+			}
+		case arch != "" && key == arch+".attention.sliding_window":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				slidingWindow = v
+				continue
+			}
+		case arch != "" && key == arch+".attention.sliding_window_pattern":
+			// Per-layer bool array (gemma-3/4): true = local/sliding-window
+			// layer. Other layouts (scalar interval) are left unmodeled, which
+			// conservatively keeps those layers at full attention.
+			if valueType == ggufTypeArray {
+				for _, x := range readGGUFArrayInts(f) {
+					swaPattern = append(swaPattern, x != 0)
+				}
 				continue
 			}
 		}
 
-		// Skip values we don't care about
+		// Skip values we don't capture (also handles type-mismatched reads above).
 		skipGGUFValue(f, valueType)
 	}
 
+	computeKVScaling(meta, headCountKV, kvHeadCounts, keyLen, valLen, keyLenSWA, valLenSWA, slidingWindow, swaPattern)
 	return meta, nil
+}
+
+// computeKVScaling reduces the raw per-layer attention parameters into the
+// compact KV-cache scaling factors stored on GGUFMeta. Falls back to uniform
+// full attention with head_dim = n_embd/n_head when the richer keys are absent,
+// which reproduces the legacy estimate exactly for non-gemma architectures.
+func computeKVScaling(meta *GGUFMeta, headCountKV int, kvHeadCounts []int, keyLen, valLen, keyLenSWA, valLenSWA, slidingWindow int, swaPattern []bool) {
+	if meta.NLayers == 0 {
+		return
+	}
+
+	embHeadDim := 0
+	if meta.NHead > 0 {
+		embHeadDim = meta.NEmbd / meta.NHead
+	}
+	kDim, vDim := keyLen, valLen
+	if kDim == 0 {
+		kDim = embHeadDim
+	}
+	if vDim == 0 {
+		vDim = embHeadDim
+	}
+	kDimSWA, vDimSWA := keyLenSWA, valLenSWA
+	if kDimSWA == 0 {
+		kDimSWA = kDim
+	}
+	if vDimSWA == 0 {
+		vDimSWA = vDim
+	}
+	if kDim+vDim == 0 {
+		return // no head-dim info — leave KV factors zero, caller falls back
+	}
+
+	// Default per-layer KV head count: explicit scalar, else full attention.
+	defaultKV := headCountKV
+	if defaultKV == 0 {
+		defaultKV = meta.NHead
+	}
+
+	full, swa, maxKV := 0, 0, meta.NKVHead
+	for i := 0; i < meta.NLayers; i++ {
+		kv := defaultKV
+		if i < len(kvHeadCounts) {
+			kv = kvHeadCounts[i]
+		}
+		if kv > maxKV {
+			maxKV = kv
+		}
+		local := i < len(swaPattern) && swaPattern[i]
+		if local && slidingWindow > 0 {
+			swa += kv * (kDimSWA + vDimSWA)
+		} else {
+			full += kv * (kDim + vDim)
+		}
+	}
+	meta.KVFullPerTok = full
+	meta.KVSWAPerTok = swa
+	if swa > 0 {
+		meta.SlidingWindow = slidingWindow
+	}
+	// Representative scalar for display when head_count_kv was an array.
+	if meta.NKVHead == 0 {
+		meta.NKVHead = maxKV
+	}
 }
 
 // GGUF value type constants
@@ -185,17 +317,67 @@ func readUint32(r io.Reader) (uint32, error) {
 	return v, err
 }
 
-func readGGUFUint32OrInt32(r io.Reader, valueType uint32) (uint32, error) {
+// readGGUFScalarInt reads an integer-typed scalar value. It consumes bytes only
+// when valueType is a recognized integer type; on a type mismatch it reads
+// nothing and returns ok=false so the caller can fall back to skipGGUFValue
+// (keeping the parser aligned).
+func readGGUFScalarInt(r io.Reader, valueType uint32) (int, bool) {
 	switch valueType {
-	case ggufTypeUint32:
-		return readUint32(r)
-	case ggufTypeInt32:
-		var v int32
-		err := binary.Read(r, binary.LittleEndian, &v)
-		return uint32(v), err
-	default:
-		return 0, fmt.Errorf("expected uint32/int32, got type %d", valueType)
+	case ggufTypeUint8, ggufTypeInt8, ggufTypeBool:
+		var v uint8
+		if binary.Read(r, binary.LittleEndian, &v) == nil {
+			return int(int8(v)), true
+		}
+	case ggufTypeUint16, ggufTypeInt16:
+		var v uint16
+		if binary.Read(r, binary.LittleEndian, &v) == nil {
+			return int(int16(v)), true
+		}
+	case ggufTypeUint32, ggufTypeInt32:
+		var v uint32
+		if binary.Read(r, binary.LittleEndian, &v) == nil {
+			return int(int32(v)), true
+		}
+	case ggufTypeUint64, ggufTypeInt64:
+		var v uint64
+		if binary.Read(r, binary.LittleEndian, &v) == nil {
+			return int(int64(v)), true
+		}
 	}
+	return 0, false
+}
+
+// readGGUFArrayInts reads an array value (its element type, count, and elements;
+// the outer array type has already been consumed) and returns fixed-size
+// numeric/bool elements as ints. It always consumes the full value so the parser
+// stays aligned. Returns nil for unsupported element types.
+func readGGUFArrayInts(r io.ReadSeeker) []int {
+	elemType, err := readUint32(r)
+	if err != nil {
+		return nil
+	}
+	var count uint64
+	if binary.Read(r, binary.LittleEndian, &count) != nil {
+		return nil
+	}
+	if count > 1<<20 { // sanity bound
+		return nil
+	}
+	out := make([]int, 0, count)
+	for i := uint64(0); i < count; i++ {
+		v, ok := readGGUFScalarInt(r, elemType)
+		if !ok {
+			// Unsupported element type — consume the remainder generically so
+			// the stream stays aligned, then bail.
+			remaining := int64(count - i)
+			if sz := ggufFixedSize(elemType); sz > 0 {
+				r.Seek(remaining*sz, io.SeekCurrent)
+			}
+			return out
+		}
+		out = append(out, v)
+	}
+	return out
 }
 
 // ggufFixedSize returns the byte size of a fixed-size GGUF value type, or 0 for variable types.

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -77,6 +77,14 @@ type Model struct {
 	ContextLength    int    `json:"context_length,omitempty"`     // max trained context
 	SupportsTools    bool   `json:"supports_tools,omitempty"`     // chat template handles tools
 	HasBuiltinVision bool   `json:"has_builtin_vision,omitempty"` // vision encoder baked into model
+
+	// KV-cache scaling factors (see GGUFMeta). Persisted so VRAM estimates
+	// don't re-parse the GGUF on every render. Zero on records parsed before
+	// these existed — BackfillGGUFMeta repopulates them, and KVCacheGB falls
+	// back to the uniform estimate until then.
+	KVFullPerTok  int `json:"kv_full_per_tok,omitempty"`
+	KVSWAPerTok   int `json:"kv_swa_per_tok,omitempty"`
+	SlidingWindow int `json:"sliding_window,omitempty"`
 }
 
 // ModelConfig holds per-model launch configuration for llama-server.
@@ -531,8 +539,11 @@ func (r *Registry) BackfillGGUFMeta() {
 	for _, m := range r.data.Models {
 		needsFull := m.NLayers == 0
 		needsVision := m.NLayers > 0 && !m.HasBuiltinVision // re-check for vision field
+		// Records parsed before KV scaling factors existed have layers but no
+		// per-token factors — re-parse once to repopulate them.
+		needsKV := m.NLayers > 0 && m.KVFullPerTok == 0 && m.KVSWAPerTok == 0
 
-		if !needsFull && !needsVision {
+		if !needsFull && !needsVision && !needsKV {
 			continue
 		}
 		meta, err := ParseGGUFMeta(m.FilePath)
@@ -543,22 +554,29 @@ func (r *Registry) BackfillGGUFMeta() {
 			continue
 		}
 		if needsFull {
-			m.Arch = meta.Architecture
-			m.NLayers = meta.NLayers
-			m.NEmbd = meta.NEmbd
-			m.NHead = meta.NHead
-			m.NKVHead = meta.NKVHead
-			m.ContextLength = meta.ContextLength
-			m.SupportsTools = meta.SupportsTools
-			m.HasBuiltinVision = meta.HasVision
+			meta.ApplyTo(m)
 			changed = true
 			slog.Info("backfilled GGUF metadata", "model", m.ID, "arch", meta.Architecture,
 				"layers", meta.NLayers, "kv_heads", meta.NKVHead, "ctx", meta.ContextLength,
 				"vision", meta.HasVision)
-		} else if meta.HasVision {
-			m.HasBuiltinVision = true
-			changed = true
-			slog.Info("detected built-in vision", "model", m.ID)
+		} else {
+			if meta.HasVision && !m.HasBuiltinVision {
+				m.HasBuiltinVision = true
+				changed = true
+				slog.Info("detected built-in vision", "model", m.ID)
+			}
+			if needsKV && (meta.KVFullPerTok > 0 || meta.KVSWAPerTok > 0) {
+				m.KVFullPerTok = meta.KVFullPerTok
+				m.KVSWAPerTok = meta.KVSWAPerTok
+				m.SlidingWindow = meta.SlidingWindow
+				if m.NKVHead == 0 {
+					m.NKVHead = meta.NKVHead
+				}
+				changed = true
+				slog.Info("backfilled KV scaling", "model", m.ID,
+					"kv_full_per_tok", meta.KVFullPerTok, "kv_swa_per_tok", meta.KVSWAPerTok,
+					"sliding_window", meta.SlidingWindow)
+			}
 		}
 	}
 	if changed {
@@ -724,14 +742,7 @@ func (r *Registry) ScanModels() int {
 
 		// Parse GGUF metadata
 		if meta, err := ParseGGUFMeta(path); err == nil {
-			m.Arch = meta.Architecture
-			m.NLayers = meta.NLayers
-			m.NEmbd = meta.NEmbd
-			m.NHead = meta.NHead
-			m.NKVHead = meta.NKVHead
-			m.ContextLength = meta.ContextLength
-			m.SupportsTools = meta.SupportsTools
-			m.HasBuiltinVision = meta.HasVision
+			meta.ApplyTo(m)
 		}
 
 		// Skip standalone MTP / drafter "assistant" heads (e.g. gemma-4's

--- a/internal/models/vram.go
+++ b/internal/models/vram.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"math"
+	"os"
 )
 
 const vramOverheadGB = 0.2 // fixed overhead for compute buffers, scratch space, etc.
@@ -18,25 +19,53 @@ func EstimateVRAM(sizeBytes int64) float64 {
 	return float64(sizeBytes)*1.1/(1024*1024*1024) + vramOverheadGB
 }
 
-// EstimateVRAMDetailed returns an estimated VRAM usage in GB accounting for
-// model weights, KV cache at a given context size, and overhead.
-//
-// Parameters:
-//   - sizeBytes: model file size (approximates weight memory)
-//   - nLayers, nKVHead, nHead, nEmbd: architecture params from GGUF
-//   - contextSize: token context window (0 = model default, treated as 2048)
-//   - kvCacheQuant: "", "q8_0", "q4_0"
-func EstimateVRAMDetailed(sizeBytes int64, nLayers, nKVHead, nHead, nEmbd, contextSize int, kvCacheQuant string) float64 {
-	// Weight memory: file size is a good proxy for quantized weights in VRAM.
-	weightsGB := BytesToGB(sizeBytes)
-
-	// KV cache estimate
-	kvGB := EstimateKVCacheGB(nLayers, nKVHead, nHead, nEmbd, contextSize, kvCacheQuant)
-
-	return weightsGB + kvGB + vramOverheadGB
+// kvBytesPerElem returns the bytes consumed per KV-cache element for a given
+// cache quantization (quantized caches carry a small per-block scale).
+func kvBytesPerElem(kvCacheQuant string) float64 {
+	switch kvCacheQuant {
+	case "q4_0":
+		return 0.5625 // 4.5 bits = 0.5625 bytes (4 bits + 0.5 bit block scale)
+	case "q8_0":
+		return 1.0625 // 8.5 bits (8 bits + 0.5 bit block scale)
+	default:
+		return 2.0 // f16
+	}
 }
 
-// EstimateKVCacheGB returns the estimated KV cache size in GB.
+// KVCacheGB returns the estimated KV cache size in GB at the given context size.
+//
+// When the model carries precomputed per-token KV factors (KVFullPerTok /
+// KVSWAPerTok), it uses them — these capture per-layer grouped-query attention
+// and sliding-window attention, which matter enormously for architectures like
+// gemma-4 (most layers cache only the sliding window, and global layers use far
+// fewer KV heads). Otherwise it falls back to the uniform full-attention
+// estimate.
+func (m *Model) KVCacheGB(ctx int, kvCacheQuant string) float64 {
+	if ctx == 0 {
+		ctx = m.ContextLength
+	}
+	if ctx == 0 {
+		ctx = 2048
+	}
+	bpe := kvBytesPerElem(kvCacheQuant)
+
+	if m.KVFullPerTok > 0 || m.KVSWAPerTok > 0 {
+		swaTokens := ctx
+		if m.SlidingWindow > 0 && m.SlidingWindow < ctx {
+			swaTokens = m.SlidingWindow
+		}
+		// PerTok sums already include both K and V across their layers.
+		elems := float64(ctx)*float64(m.KVFullPerTok) + float64(swaTokens)*float64(m.KVSWAPerTok)
+		return elems * bpe / (1024 * 1024 * 1024)
+	}
+
+	// Legacy fallback for records parsed before per-token factors existed.
+	return EstimateKVCacheGB(m.NLayers, m.NKVHead, m.NHead, m.NEmbd, ctx, kvCacheQuant)
+}
+
+// EstimateKVCacheGB returns the estimated KV cache size in GB assuming uniform
+// full attention. Used as a fallback by Model.KVCacheGB when richer per-layer
+// metadata isn't available.
 //
 // Formula: 2 (K+V) × n_layers × n_kv_head × head_dim × ctx × bytes_per_element
 func EstimateKVCacheGB(nLayers, nKVHead, nHead, nEmbd, contextSize int, kvCacheQuant string) float64 {
@@ -65,19 +94,8 @@ func EstimateKVCacheGB(nLayers, nKVHead, nHead, nEmbd, contextSize int, kvCacheQ
 		ctx = 2048
 	}
 
-	// Bytes per element based on KV cache quantization
-	var bytesPerElem float64
-	switch kvCacheQuant {
-	case "q4_0":
-		bytesPerElem = 0.5625 // 4.5 bits = 0.5625 bytes (4 bits + 0.5 bit block scale)
-	case "q8_0":
-		bytesPerElem = 1.0625 // 8.5 bits (8 bits + 0.5 bit block scale)
-	default:
-		bytesPerElem = 2.0 // f16
-	}
-
 	// 2 (K + V) × layers × kv_heads × head_dim × context × bytes
-	totalBytes := 2.0 * float64(nLayers) * float64(kvHeads) * float64(headDim) * float64(ctx) * bytesPerElem
+	totalBytes := 2.0 * float64(nLayers) * float64(kvHeads) * float64(headDim) * float64(ctx) * kvBytesPerElem(kvCacheQuant)
 
 	return totalBytes / (1024 * 1024 * 1024)
 }
@@ -91,17 +109,42 @@ func VRAMEstimateForConfig(m *Model, cfg *ModelConfig) float64 {
 	}
 	// ContextSize 0 means "Model Default" in the UI; llama-server resolves
 	// that to the model's trained context length at load time, so estimate
-	// against that, not the bare 2048 fallback in EstimateKVCacheGB.
+	// against that, not the bare 2048 fallback in KVCacheGB.
 	ctx := cfg.ContextSize
 	if ctx == 0 {
 		ctx = m.ContextLength
 	}
-	return EstimateVRAMDetailed(
-		m.SizeBytes,
-		m.NLayers, m.NKVHead, m.NHead, m.NEmbd,
-		ctx,
-		cfg.KVCacheQuant,
-	)
+	// Weight memory: file size is a good proxy for quantized weights in VRAM.
+	return BytesToGB(m.SizeBytes) + m.KVCacheGB(ctx, cfg.KVCacheQuant) + AuxFilesVRAMGB(cfg) + vramOverheadGB
+}
+
+// AuxFilesVRAMGB sums the on-disk sizes of auxiliary GGUFs that load into VRAM
+// alongside the main model: the vision projector (mmproj), a separate MTP
+// drafter head, and a speculative draft model. Each is counted only when it is
+// both downloaded (file present) and activated (its enable toggle on, or, for a
+// draft model, draft mode selected). File size approximates the loaded weights;
+// a draft model's own small KV cache is not separately modeled.
+func AuxFilesVRAMGB(cfg *ModelConfig) float64 {
+	var gb float64
+	if cfg.MmprojPath != "" && !cfg.MmprojDisabled {
+		gb += fileSizeGB(cfg.MmprojPath)
+	}
+	if cfg.MtpPath != "" && !cfg.MtpDisabled {
+		gb += fileSizeGB(cfg.MtpPath)
+	}
+	if cfg.SpecType == "draft" && cfg.DraftModelPath != "" {
+		gb += fileSizeGB(cfg.DraftModelPath)
+	}
+	return gb
+}
+
+// fileSizeGB returns a file's size in GB, or 0 if it can't be stat'd (e.g. not
+// downloaded yet).
+func fileSizeGB(path string) float64 {
+	if fi, err := os.Stat(path); err == nil {
+		return BytesToGB(fi.Size())
+	}
+	return 0
 }
 
 // VRAMFitLabel returns a human-readable label for how a model fits

--- a/internal/models/vram_test.go
+++ b/internal/models/vram_test.go
@@ -1,0 +1,158 @@
+package models
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func approx(t *testing.T, label string, got, want, tol float64) {
+	t.Helper()
+	if math.Abs(got-want) > tol {
+		t.Errorf("%s: got %.4f, want %.4f (±%.4f)", label, got, want, tol)
+	}
+}
+
+// computeKVScaling should reduce uniform full-attention params to the same KV
+// scaling the legacy formula assumes: nLayers · nKVHead · (k_dim+v_dim) per tok.
+func TestComputeKVScalingUniform(t *testing.T) {
+	meta := &GGUFMeta{NLayers: 4, NEmbd: 512, NHead: 8} // headDim = 64
+	computeKVScaling(meta, 2 /*kv*/, nil, 0, 0, 0, 0, 0, nil)
+
+	if want := 4 * 2 * (64 + 64); meta.KVFullPerTok != want {
+		t.Errorf("KVFullPerTok = %d, want %d", meta.KVFullPerTok, want)
+	}
+	if meta.KVSWAPerTok != 0 {
+		t.Errorf("KVSWAPerTok = %d, want 0", meta.KVSWAPerTok)
+	}
+	if meta.SlidingWindow != 0 {
+		t.Errorf("SlidingWindow = %d, want 0", meta.SlidingWindow)
+	}
+}
+
+// Explicit key_length/value_length should override n_embd/n_head, which matters
+// when the latter isn't a whole number (e.g. Qwen3.6: 5120/24 = 213.3).
+func TestComputeKVScalingExplicitHeadDim(t *testing.T) {
+	meta := &GGUFMeta{NLayers: 64, NEmbd: 5120, NHead: 24}
+	computeKVScaling(meta, 4 /*kv*/, nil, 256 /*keyLen*/, 256 /*valLen*/, 0, 0, 0, nil)
+
+	if want := 64 * 4 * (256 + 256); meta.KVFullPerTok != want {
+		t.Errorf("KVFullPerTok = %d, want %d", meta.KVFullPerTok, want)
+	}
+}
+
+// gemma-style: per-layer GQA (head_count_kv array) plus sliding-window layers
+// with their own smaller head dims.
+func TestComputeKVScalingGemma(t *testing.T) {
+	meta := &GGUFMeta{NLayers: 6, NEmbd: 3840, NHead: 16}
+	kvHeads := []int{8, 8, 8, 8, 8, 1}
+	swa := []bool{true, true, true, true, true, false}
+	computeKVScaling(meta, 0, kvHeads, 512, 512, 256, 256, 1024, swa)
+
+	// 5 sliding-window layers: 8 kv heads × (256+256)
+	if want := 5 * 8 * (256 + 256); meta.KVSWAPerTok != want {
+		t.Errorf("KVSWAPerTok = %d, want %d", meta.KVSWAPerTok, want)
+	}
+	// 1 full-attention layer: 1 kv head × (512+512)
+	if want := 1 * 1 * (512 + 512); meta.KVFullPerTok != want {
+		t.Errorf("KVFullPerTok = %d, want %d", meta.KVFullPerTok, want)
+	}
+	if meta.SlidingWindow != 1024 {
+		t.Errorf("SlidingWindow = %d, want 1024", meta.SlidingWindow)
+	}
+	// Representative scalar for display = max per-layer kv head count.
+	if meta.NKVHead != 8 {
+		t.Errorf("NKVHead = %d, want 8", meta.NKVHead)
+	}
+}
+
+// When a model carries no per-token factors (old record), KVCacheGB must match
+// the legacy uniform estimate exactly.
+func TestKVCacheGBLegacyFallback(t *testing.T) {
+	m := &Model{NLayers: 48, NKVHead: 8, NHead: 40, NEmbd: 5120}
+	for _, ctx := range []int{8192, 32768, 131072} {
+		for _, q := range []string{"", "q8_0", "q4_0"} {
+			got := m.KVCacheGB(ctx, q)
+			want := EstimateKVCacheGB(m.NLayers, m.NKVHead, m.NHead, m.NEmbd, ctx, q)
+			approx(t, "KVCacheGB fallback", got, want, 1e-9)
+		}
+	}
+}
+
+// Real gemma-4-12b factors (parsed from the GGUF): 8 global layers @ 1 kv head,
+// 40 sliding-window layers @ 8 kv heads, window 1024. At 128K/q8_0 this is ~1.2
+// GB — versus the ~48 GB the old uniform formula produced.
+func TestKVCacheGBGemma4(t *testing.T) {
+	m := &Model{
+		NLayers:       48,
+		NEmbd:         3840,
+		NHead:         16,
+		NKVHead:       8,
+		ContextLength: 262144,
+		KVFullPerTok:  8192,
+		KVSWAPerTok:   163840,
+		SlidingWindow: 1024,
+	}
+	approx(t, "gemma4 KV @128K q8_0", m.KVCacheGB(131072, "q8_0"), 1.23, 0.05)
+
+	// Below the sliding window, local layers stop growing; KV is tiny.
+	small := m.KVCacheGB(512, "q8_0")
+	if small > 0.1 {
+		t.Errorf("KV @512 tokens = %.4f GB, expected < 0.1", small)
+	}
+
+	// Past the window, only the 8 global layers keep scaling with context, so
+	// doubling context from 128K to 256K should less-than-double total KV.
+	if kv256 := m.KVCacheGB(262144, "q8_0"); kv256 >= 2*m.KVCacheGB(131072, "q8_0") {
+		t.Errorf("sliding window not capping local layers: kv256=%.3f", kv256)
+	}
+}
+
+// Auxiliary files (mmproj / MTP head / draft) count toward VRAM only when both
+// downloaded (present on disk) and activated (toggle on / draft mode selected).
+func TestAuxFilesVRAMGB(t *testing.T) {
+	dir := t.TempDir()
+	const oneGiB = 1024 * 1024 * 1024
+	write := func(name string, gb int) string {
+		p := filepath.Join(dir, name)
+		if err := os.Truncate(p, 0); err != nil {
+			f, _ := os.Create(p)
+			f.Close()
+		}
+		if err := os.Truncate(p, int64(gb)*oneGiB); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	mmproj := write("mmproj.gguf", 1)
+	mtp := write("mtp.gguf", 2)
+	draft := write("draft.gguf", 3)
+
+	cases := []struct {
+		name string
+		cfg  ModelConfig
+		want float64
+	}{
+		{"all activated", ModelConfig{MmprojPath: mmproj, MtpPath: mtp, SpecType: "draft", DraftModelPath: draft}, 6},
+		{"mmproj disabled", ModelConfig{MmprojPath: mmproj, MmprojDisabled: true}, 0},
+		{"mtp disabled", ModelConfig{MtpPath: mtp, MtpDisabled: true}, 0},
+		{"draft path but not draft mode", ModelConfig{SpecType: "draft-mtp", DraftModelPath: draft}, 0},
+		{"mtp head under draft-mtp", ModelConfig{SpecType: "draft-mtp", MtpPath: mtp}, 2},
+		{"missing file counts zero", ModelConfig{MmprojPath: filepath.Join(dir, "nope.gguf")}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			approx(t, "AuxFilesVRAMGB", AuxFilesVRAMGB(&tc.cfg), tc.want, 1e-9)
+		})
+	}
+}
+
+// The sliding window caps the local-layer token count at min(ctx, window).
+func TestKVCacheGBSlidingWindowCap(t *testing.T) {
+	m := &Model{NLayers: 1, KVSWAPerTok: 1000, SlidingWindow: 1024}
+	// ctx well past the window — local contribution should use 1024, not ctx.
+	got := m.KVCacheGB(100000, "")
+	want := 1024.0 * 1000.0 * 2.0 / (1024 * 1024 * 1024)
+	approx(t, "SWA cap", got, want, 1e-9)
+}


### PR DESCRIPTION
## Problem

VRAM estimates on the models page were wildly high for gemma-4 — e.g. **58 GB** for gemma-4-12b at 128K/q8_0, a model that actually runs in **24 GB**. gemma-4-31B at 256K estimated 198 GB.

## Root cause

The estimator modeled every layer as uniform full attention with `head_dim = n_embd/n_head`. gemma-4 breaks all three assumptions:

- **Per-layer GQA** — `head_count_kv` is a *per-layer array* (`[8,8,8,8,8,1,…]`) stored as an array type the parser couldn't read, so it fell back to `n_head` (16 instead of the real 1–8).
- **Explicit head dims** — real dims are `key_length=512` (global) / `256` (local), not `n_embd/n_head=240`.
- **Sliding-window attention** — 40 of 48 layers cache only `sliding_window=1024` tokens, not the full 131072; only 8 global layers scale with context, and those use just 1 KV head.

Combined, the KV cache was overcounted ~40×.

## Fix

1. **Richer GGUF parsing** — read `key_length`/`value_length`(`_swa`), `sliding_window`, and the per-layer `head_count_kv` / `sliding_window_pattern` arrays. Reduce them at parse time into two compact, persisted factors — `KVFullPerTok` and `KVSWAPerTok` (KV elements/token for full vs. sliding-window layers) — plus `SlidingWindow`. KV at context C is `(C·KVFullPerTok + min(C,window)·KVSWAPerTok) · bytes_per_element`.
2. **Auxiliary files** — count mmproj, a separate MTP drafter head, and a draft model toward the total, but only when **downloaded** (file present → else 0) and **activated** (enable toggle on / draft mode selected).

This generalizes cleanly:
- Models without the richer keys reduce to the **exact** legacy number (zero regression).
- Models that declare explicit head dims get the dim llama.cpp actually allocates — e.g. **Qwen3.6**, whose `n_embd/n_head = 5120/24 = 213.3` was a non-integer guess, is corrected to its real `key_length=256`.

## Verified against the real gemma-4-12b GGUF (@128K / q8_0)

| Component | Before | After |
|---|---|---|
| KV cache | ~48 GB | **1.23 GB** |
| Aux (mmproj 0.16 + MTP head 0.43) | 0 (ignored) | **0.60 GB** |
| **Total** | **~58 GB** | **11.98 GB** (11.38 with aux toggled off) |

Matches real usage on a 24 GB card.

## Notes

- Existing model records have no KV factors yet; `BackfillGGUFMeta` repopulates them on the next server **restart** (fresh downloads get them immediately). I added a `needsKV` gate for this.
- Aux-file sizing is `stat`-based (cheap, reflects the toggles live). A draft model's own small KV cache is not separately modeled.

## Tests

New `vram_test.go` (8 cases): uniform-equals-legacy, explicit head-dim override, gemma per-layer reduction, sliding-window cap, legacy fallback, and the aux-file downloaded/activated toggle matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)