### PR TITLE
fix(compose): pin image name so Quadlet unit can find the built image

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -8,6 +8,12 @@ services:
         # quick path uses this to invalidate just the package-install
         # layer when a newer release is available.
         LLAMA_TOOLCHEST_VERSION: "${LLAMA_TOOLCHEST_VERSION:-latest}"
+    # Pin the built image name so it matches the Quadlet unit (generate_quadlet
+    # in setup.sh). Without this, compose tags the build as
+    # <project>_<service> (localhost/llama-toolchest_llama-toolchest) and the
+    # systemd service tries to pull localhost/llama-toolchest:latest from a
+    # registry, failing with exit 125.
+    image: localhost/llama-toolchest:latest
     container_name: llama-toolchest
     ports:
       - "${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI

--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -8,6 +8,12 @@ services:
         # quick path uses this to invalidate just the package-install
         # layer when a newer release is available.
         LLAMA_TOOLCHEST_VERSION: "${LLAMA_TOOLCHEST_VERSION:-latest}"
+    # Pin the built image name so it matches the Quadlet unit (generate_quadlet
+    # in setup.sh). Without this, compose tags the build as
+    # <project>_<service> (localhost/llama-toolchest_llama-toolchest) and the
+    # systemd service tries to pull localhost/llama-toolchest:latest from a
+    # registry, failing with exit 125.
+    image: localhost/llama-toolchest:latest
     container_name: llama-toolchest
     ports:
       - "${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI

--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -11,6 +11,12 @@ services:
         # layers stay cached. Falls back to "latest" if unset, in which
         # case the Dockerfile resolves it at build time itself.
         LLAMA_TOOLCHEST_VERSION: "${LLAMA_TOOLCHEST_VERSION:-latest}"
+    # Pin the built image name so it matches the Quadlet unit (generate_quadlet
+    # in setup.sh). Without this, compose tags the build as
+    # <project>_<service> (localhost/llama-toolchest_llama-toolchest) and the
+    # systemd service tries to pull localhost/llama-toolchest:latest from a
+    # registry, failing with exit 125.
+    image: localhost/llama-toolchest:latest
     container_name: llama-toolchest
     ports:
       - "${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@ services:
       args:
         # See docker-compose.rocm.yml for the rationale.
         LLAMA_TOOLCHEST_VERSION: "${LLAMA_TOOLCHEST_VERSION:-latest}"
+    # Pin the built image name so it matches the Quadlet unit (generate_quadlet
+    # in setup.sh). Without this, compose tags the build as
+    # <project>_<service> (localhost/llama-toolchest_llama-toolchest) and the
+    # systemd service tries to pull localhost/llama-toolchest:latest from a
+    # registry, failing with exit 125.
+    image: localhost/llama-toolchest:latest
     container_name: llama-toolchest
     ports:
       - "${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI


### PR DESCRIPTION
## Problem

On a rootless-podman host, `./setup.sh enable` installs a Quadlet unit that runs:

```
Image=localhost/llama-toolchest:latest
```

But the compose services declare a `build:` block with **no `image:` key**, so `podman-compose` tags the built image with the project_service default:

```
localhost/llama-toolchest_llama-toolchest:latest
```

The names don't match. `podman run` can't find `localhost/llama-toolchest:latest` locally, falls back to pulling it from a registry literally named `localhost`, and fails:

```
Error: unable to copy from source docker://localhost/llama-toolchest:latest:
  ... pinging container registry localhost ...
llama-toolchest.service: Main process exited, code=exited, status=125/n/a
```

systemd then loops on the failing pull (`Restart=on-failure`).

## Fix

Pin `image: localhost/llama-toolchest:latest` on every compose variant (base, cpu, cuda, rocm) so the built image is tagged with the exact name the Quadlet unit (`generate_quadlet` in `setup.sh`) expects. Both `docker compose` and `podman-compose` honor `image:` as the build tag.

## Notes

- For an already-broken host, the image can be re-tagged without a rebuild:
  `podman tag localhost/llama-toolchest_llama-toolchest:latest localhost/llama-toolchest:latest`
  then `systemctl --user reset-failed && restart`. After merging, a `./setup.sh quick` rebuild tags it correctly going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)