### PR TITLE
fix(quant): parse UD prefix and suffixes consistently, recognize MXFP4

### DIFF
--- a/internal/models/quant_test.go
+++ b/internal/models/quant_test.go
@@ -1,0 +1,49 @@
+package models
+
+import "testing"
+
+func TestParseQuant(t *testing.T) {
+	cases := []struct {
+		filename string
+		want     string
+	}{
+		// UD ultra-dynamic quants — prefix must be preserved consistently.
+		{"UD-IQ1_M/MiniMax-M2.5-UD-IQ1_M-00001-of-00003.gguf", "UD_IQ1_M"},
+		{"UD-IQ1_S/MiniMax-M2.5-UD-IQ1_S-00001-of-00003.gguf", "UD_IQ1_S"},
+		{"UD-IQ2_M/MiniMax-M2.5-UD-IQ2_M-00001-of-00003.gguf", "UD_IQ2_M"},
+		{"UD-IQ2_XXS/MiniMax-M2.5-UD-IQ2_XXS-00001-of-00003.gguf", "UD_IQ2_XXS"},
+		{"UD-IQ3_XXS/MiniMax-M2.5-UD-IQ3_XXS-00001-of-00003.gguf", "UD_IQ3_XXS"},
+		// Previously dropped the XL suffix and reported a bare Q2_K.
+		{"UD-Q2_K_XL/MiniMax-M2.5-UD-Q2_K_XL-00001-of-00003.gguf", "UD_Q2_K_XL"},
+		{"UD-Q3_K_XL/MiniMax-M2.5-UD-Q3_K_XL-00001-of-00004.gguf", "UD_Q3_K_XL"},
+		{"UD-Q4_K_XL/MiniMax-M2.5-UD-Q4_K_XL-00001-of-00004.gguf", "UD_Q4_K_XL"},
+		{"UD-Q5_K_XL/MiniMax-M2.5-UD-Q5_K_XL-00001-of-00005.gguf", "UD_Q5_K_XL"},
+		{"UD-Q6_K_XL/MiniMax-M2.5-UD-Q6_K_XL-00001-of-00005.gguf", "UD_Q6_K_XL"},
+
+		// MXFP4 — previously reported "unknown".
+		{"gpt-oss-20b-MXFP4.gguf", "MXFP4"},
+		{"openai-gpt-oss-120b-UD-MXFP4.gguf", "UD_MXFP4"},
+
+		// Plain (non-UD) quants.
+		{"model-Q4_K_M.gguf", "Q4_K_M"},
+		{"model-Q2_K.gguf", "Q2_K"},
+		{"model-Q2_K_S.gguf", "Q2_K_S"},
+		{"model-Q8_0.gguf", "Q8_0"},
+		{"model-Q4_0.gguf", "Q4_0"},
+		{"model-IQ4_NL.gguf", "IQ4_NL"},
+		{"model-IQ2_XS.gguf", "IQ2_XS"},
+		{"model-TQ1_0.gguf", "TQ1_0"},
+		{"model-F16.gguf", "F16"},
+		{"model-BF16.gguf", "BF16"},
+		{"model-F32.gguf", "F32"},
+
+		// No recognizable quant.
+		{"some-random-model.gguf", "unknown"},
+	}
+
+	for _, c := range cases {
+		if got := ParseQuant(c.filename); got != c.want {
+			t.Errorf("ParseQuant(%q) = %q, want %q", c.filename, got, c.want)
+		}
+	}
+}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -1024,8 +1024,18 @@ func findShards(dir, filename string) []string {
 	return shards
 }
 
-// ParseQuant extracts quantization type from a GGUF filename.
-// Exported so it can be shared across packages.
+// quantRe matches a quantization token in a normalized (uppercased,
+// dashes->underscores) GGUF filename, with an optional "UD_" ultra-dynamic
+// prefix captured separately. The body alternatives are written so the greedy
+// optional suffix groups absorb variants generically (e.g. Q2_K_XL, Q3_K_L),
+// which the previous hand-maintained list dropped. Ordering keeps longer
+// tokens ahead of their prefixes where alternation could otherwise short-cut
+// (e.g. BF16 before F16).
+var quantRe = regexp.MustCompile(`(UD_)?(MXFP4|BF16|F16|F32|TQ[1-4]_[01]|IQ[1-4]_(?:XXS|XS|NL|S|M|L)|Q[2-8]_K(?:_(?:XL|XS|S|M|L))?|Q[2-8]_[01])`)
+
+// ParseQuant extracts the quantization type from a GGUF filename. It preserves
+// the "UD_" (Unsloth ultra-dynamic) prefix when present so UD quants are
+// labelled consistently. Exported so it can be shared across packages.
 func ParseQuant(filename string) string {
 	name := strings.TrimSuffix(filepath.Base(filename), ".gguf")
 	name = strings.TrimSuffix(name, ".GGUF")
@@ -1038,32 +1048,11 @@ func ParseQuant(filename string) string {
 	// Normalize dashes to underscores so "UD-Q8_K_XL" matches "UD_Q8_K_XL"
 	upper := strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 
-	// Longest match first to avoid partial matches (e.g., Q8_K_XL before Q8_K)
-	quants := []string{
-		// Ultra-dynamic
-		"UD_Q8_K_XL", "UD_Q6_K_XL", "UD_Q4_K_XL",
-		// Ternary / ultra-low bit
-		"TQ1_0", "TQ2_0",
-		// Importance-weighted quants
-		"IQ1_S", "IQ1_M", "IQ2_XXS", "IQ2_XS", "IQ2_S", "IQ2_M",
-		"IQ3_XXS", "IQ3_XS", "IQ3_S", "IQ3_M", "IQ4_XS", "IQ4_NL",
-		// K-quants (longest suffixes first)
-		"Q2_K_S", "Q2_K",
-		"Q3_K_S", "Q3_K_M", "Q3_K_L", "Q3_K_XL", "Q3_K",
-		"Q4_K_S", "Q4_K_M", "Q4_K_L", "Q4_K_XL", "Q4_K", "Q4_0", "Q4_1",
-		"Q5_K_S", "Q5_K_M", "Q5_K_L", "Q5_K_XL", "Q5_K", "Q5_0", "Q5_1",
-		"Q6_K_L", "Q6_K_XL", "Q6_K",
-		"Q8_K_XL", "Q8_K_L", "Q8_K", "Q8_0", "Q8_1",
-		// Full precision
-		"F16", "F32", "BF16",
+	m := quantRe.FindStringSubmatch(upper)
+	if m == nil {
+		return "unknown"
 	}
-
-	for _, q := range quants {
-		if strings.Contains(upper, q) {
-			return q
-		}
-	}
-	return "unknown"
+	return m[1] + m[2] // m[1] is "UD_" or "", m[2] is the quant body
 }
 
 func (r *Registry) registryPath() string {


### PR DESCRIPTION
## Problem

In the **Search HF** tab (and the **Models** tab — both share `ParseQuant`), the quant column mis-parsed several filenames:

- `UD-Q2_K_XL` was reported as `Q2_K` — the `_XL` suffix was dropped.
- UD quants other than `UD_Q4/Q6/Q8_K_XL` lost their `UD` prefix entirely (e.g. `UD-IQ1_M` showed as `IQ1_M`).
- `MXFP4` quants showed as `unknown`.

## Root cause

`ParseQuant` (`internal/models/registry.go`) used a hand-maintained slice of quant strings and returned the **first** substring match in slice order. Missing entries silently fell through to a shorter prefix, the `UD_` variants were only enumerated for a few quants, and `MXFP4` was absent.

## Fix

Replace the list with a single regex whose greedy optional suffix groups absorb variants (`_XL`, `_S`, `_M`, `_L`, …) generically, and capture the `UD_` prefix separately so it is **preserved consistently** across all quants. Adds `MXFP4` support. Because both tabs call the same function, this fixes the column everywhere.

Adds `internal/models/quant_test.go` covering every row from the reported screenshot plus edge cases.

## Test

```
go test ./internal/models/ -run TestParseQuant
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)