### PR TITLE
fix(quant): re-derive persisted quant on registry load

### DIFF
--- a/internal/models/quant_test.go
+++ b/internal/models/quant_test.go
@@ -1,6 +1,10 @@
 package models
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParseQuant(t *testing.T) {
 	cases := []struct {
@@ -44,6 +48,43 @@ func TestParseQuant(t *testing.T) {
 	for _, c := range cases {
 		if got := ParseQuant(c.filename); got != c.want {
 			t.Errorf("ParseQuant(%q) = %q, want %q", c.filename, got, c.want)
+		}
+	}
+}
+
+// TestLoadBackfillsStaleQuant verifies that load() re-derives the persisted
+// Quant field from the filename. Models registered before a ParseQuant
+// improvement keep their stale value (ScanModels skips known paths), so load
+// must backfill it for the Models tab to match the live-parsed Search HF tab.
+func TestLoadBackfillsStaleQuant(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Persist a registry whose MXFP4 model was frozen as "unknown" by the old
+	// hand-maintained list, and a UD model truncated to its base quant.
+	const stale = `{
+  "models": {
+    "a": {"id": "a", "filename": "gpt-oss-20b-MXFP4.gguf", "quant": "unknown"},
+    "b": {"id": "b", "filename": "model-UD-Q2_K_XL.gguf", "quant": "Q2_K"},
+    "c": {"id": "c", "filename": "model-Q8_0.gguf", "quant": "Q8_0"}
+  }
+}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "models.json"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry(dir, filepath.Join(dir, "models"))
+
+	want := map[string]string{"a": "MXFP4", "b": "UD_Q2_K_XL", "c": "Q8_0"}
+	for id, q := range want {
+		m, err := r.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", id, err)
+		}
+		if m.Quant != q {
+			t.Errorf("model %q Quant = %q, want %q", id, m.Quant, q)
 		}
 	}
 }

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -1073,6 +1073,21 @@ func (r *Registry) load() {
 	if r.data.Configs == nil {
 		r.data.Configs = make(map[string]*ModelConfig)
 	}
+
+	// Re-derive Quant from the filename for every registered model. The field
+	// is persisted, but ScanModels skips already-known paths, so entries added
+	// before a ParseQuant improvement keep their stale value (e.g. MXFP4 frozen
+	// as "unknown", or UD-Q2_K_XL truncated to Q2_K). The Search HF tab parses
+	// live and stays correct; the Models tab reads this field, so backfill it
+	// on load to keep both tabs consistent and self-healing.
+	for _, m := range r.data.Models {
+		if m.Filename == "" {
+			continue
+		}
+		if q := ParseQuant(m.Filename); q != m.Quant {
+			m.Quant = q
+		}
+	}
 }
 
 func (r *Registry) save() {


### PR DESCRIPTION
## Problem

The last merge (#62, `3df08ab`) fixed `ParseQuant` to recognize MXFP4 and preserve UD prefixes/suffixes, but MXFP4 quants still showed as **"unknown" in the Models tab** while displaying correctly in the **Search HF tab**.

## Root cause

The two tabs get the quant differently:

- **Search HF tab** parses live — `hf.go:275` calls `ParseQuant(filename)` on every request, so it immediately reflects the fix. ✅
- **Models tab** reads the persisted `Model.Quant` field from `models.json`. That field is computed once when a model is registered, and `ScanModels` skips already-registered file paths (`registry.go:686`). So any model registered *before* the fix keeps its frozen value forever — MXFP4 stuck as `"unknown"`, or `UD-Q2_K_XL` truncated to `Q2_K`. ❌

It's not really MXFP4-specific: stale persisted quants are simply never re-derived.

## Fix

Re-derive `Quant` from the filename for every model in `load()`. The field is fully derived from the filename and has no manual-override UI, so this safely backfills stale values and keeps the registry self-healing against future `ParseQuant` improvements. The display corrects itself on the next restart — no need to remove and re-add the model.

Adds `TestLoadBackfillsStaleQuant` covering the MXFP4-as-unknown and UD-truncation cases.

## Testing

- `go build ./...`
- `go test ./internal/models/` (new and existing tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)