### PR TITLE
Surface incomplete model downloads with in-place resume

### DIFF
--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -232,6 +233,104 @@ func (s *Server) handleHFActiveDownloads(w http.ResponseWriter, r *http.Request)
 	}
 
 	respondJSON(w, active)
+}
+
+// domID sanitizes a string for use as an HTML id / CSS selector fragment.
+func domID(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+}
+
+// handleIncompleteDownloads renders the "Incomplete downloads" panel: failed or
+// partial downloads that left `.part` files on disk but never registered as
+// models, each offering Resume (reuses the normal download path, which picks up
+// from the existing partial) and Discard. Mirrors handleHFActiveDownloads.
+func (s *Server) handleIncompleteDownloads(w http.ResponseWriter, r *http.Request) {
+	parts := s.registry.OrphanParts()
+
+	if isHTMX(r) {
+		respondHTML(w)
+		if len(parts) == 0 {
+			return // empty response — nothing to show
+		}
+		fmt.Fprint(w, `<article style="padding: 0.5rem 0.75rem; margin: 0.5rem 0;">
+			<strong style="font-size: 0.9rem;">Incomplete downloads</strong>`)
+		for _, p := range parts {
+			id := domID(p.ModelID + "--" + p.Filename)
+			onDiskGB := models.BytesToGB(p.BytesOnDisk)
+			fmt.Fprintf(w, `<div style="padding: 0.25rem 0; font-size: 0.85rem; border-top: 1px solid var(--pico-muted-border-color);">
+				<div style="display:flex; justify-content:space-between; align-items:center; gap:0.5rem;">
+					<span><strong>%s</strong> — <small>%s</small> <small>(%.1f GB on disk, %d partial file(s))</small></span>
+					<span role="group" style="margin:0; flex:0 0 auto;">
+						<button type="button" class="outline"
+								style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem;"
+								hx-post="/api/hf/download"
+								hx-vals='{"model_id":"%s","filename":"%s","size":"0"}'
+								hx-target="#incdl-%s"
+								hx-swap="innerHTML">Resume</button>
+						<button type="button" class="outline secondary"
+								style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem;"
+								hx-delete="/api/hf/incomplete"
+								hx-vals='{"model_id":"%s","filename":"%s"}'
+								hx-confirm="Delete the partial files for %s? This cannot be undone."
+								hx-target="#incdl-%s"
+								hx-swap="innerHTML">Discard</button>
+					</span>
+				</div>
+				<div id="incdl-%s"></div>
+			</div>`,
+				p.ModelID, p.Filename, onDiskGB, p.PartCount,
+				p.ModelID, p.Filename, id,
+				p.ModelID, p.Filename, p.ModelID, id,
+				id)
+		}
+		fmt.Fprint(w, `</article>`)
+		return
+	}
+
+	respondJSON(w, parts)
+}
+
+// handleIncompleteDiscard deletes the on-disk files (completed shards and
+// `.part` fragments) for an orphan partial download identified by model_id +
+// filename. Paths are constrained to the models directory.
+func (s *Server) handleIncompleteDiscard(w http.ResponseWriter, r *http.Request) {
+	r.ParseForm()
+	modelID := r.FormValue("model_id")
+	filename := r.FormValue("filename")
+	if modelID == "" || filename == "" {
+		http.Error(w, "model_id and filename required", http.StatusBadRequest)
+		return
+	}
+
+	root := s.cfg.ModelsPath()
+	safeName := strings.ReplaceAll(modelID, "/", "--")
+	modelDir := filepath.Join(root, safeName)
+
+	removed := 0
+	for _, fn := range huggingface.ExpandShards(filename) {
+		final := filepath.Join(modelDir, fn)
+		// Containment guard: never touch anything outside the models dir.
+		if rel, err := filepath.Rel(root, final); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		for _, path := range []string{final, final + ".part"} {
+			if err := os.Remove(path); err == nil {
+				removed++
+			}
+		}
+	}
+	slog.Info("discarded incomplete download", "model", modelID, "filename", filename, "files_removed", removed)
+
+	// Empty response so the per-row target clears; the panel re-polls and drops
+	// the row on its next refresh.
+	respondHTML(w)
 }
 
 func (s *Server) handleHFDownloadCancel(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/model_card_render_test.go
+++ b/internal/api/model_card_render_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmlabonte/llamactl/web"
+)
+
+// modelCardData mirrors the anonymous struct renderModelCard builds, so the
+// partial can be exercised standalone.
+type modelCardData struct {
+	models.Model
+	IsActive       bool
+	IsEnabled      bool
+	PendingEnable  bool
+	PendingDisable bool
+	NeedsReload    bool
+	HasVision      bool
+	GPULabel       string
+	ServiceState   string
+	VRAMGB         float64
+	IsOrphan       bool
+	IsIncomplete   bool
+	ResumeFilename string
+	SearchText     string
+}
+
+func renderModelCardPartial(t *testing.T, data modelCardData) string {
+	t.Helper()
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, "model_card", data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return buf.String()
+}
+
+// TestModelCardIncomplete verifies an incomplete model renders the badge, a
+// Resume button posting to the download endpoint, and a disabled enable toggle.
+func TestModelCardIncomplete(t *testing.T) {
+	out := renderModelCardPartial(t, modelCardData{
+		Model:          models.Model{ID: "org--repo--model", ModelID: "org/repo", Filename: "model-00001-of-00003.gguf", Quant: "Q4_K_M"},
+		IsIncomplete:   true,
+		ResumeFilename: "model-00001-of-00003.gguf",
+	})
+
+	if !strings.Contains(out, ">incomplete<") {
+		t.Errorf("expected incomplete badge; output=\n%s", out)
+	}
+	if !strings.Contains(out, "Resume") {
+		t.Errorf("expected Resume button; output=\n%s", out)
+	}
+	if !strings.Contains(out, `hx-post="/api/hf/download"`) {
+		t.Errorf("expected Resume to post to download endpoint; output=\n%s", out)
+	}
+	if !strings.Contains(out, `"filename":"model-00001-of-00003.gguf"`) {
+		t.Errorf("expected resume filename in hx-vals; output=\n%s", out)
+	}
+	if !strings.Contains(out, "disabled") {
+		t.Errorf("expected enable toggle disabled; output=\n%s", out)
+	}
+}
+
+// TestModelCardHealthy verifies a normal model shows neither orphan nor
+// incomplete indicators and keeps its enable toggle active.
+func TestModelCardHealthy(t *testing.T) {
+	out := renderModelCardPartial(t, modelCardData{
+		Model:     models.Model{ID: "org--repo--model", ModelID: "org/repo", Filename: "model.gguf", Quant: "Q4_K_M"},
+		IsEnabled: true,
+	})
+	if strings.Contains(out, ">incomplete<") {
+		t.Errorf("healthy model should not show incomplete badge; output=\n%s", out)
+	}
+	if strings.Contains(out, "Resume") {
+		t.Errorf("healthy model should not show Resume button; output=\n%s", out)
+	}
+	if !strings.Contains(out, "Configure") {
+		t.Errorf("healthy model should show Configure; output=\n%s", out)
+	}
+}

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -327,7 +327,7 @@ func (s *Server) routerKnownStates() map[string]string {
 }
 
 // renderModelCard writes one model_card partial.
-func (s *Server) renderModelCard(w http.ResponseWriter, m *models.Model, routerKnown map[string]string, isOrphan bool) {
+func (s *Server) renderModelCard(w http.ResponseWriter, m *models.Model, routerKnown map[string]string, isOrphan, isIncomplete bool) {
 	// Look up router state under any of the names the router might know this
 	// model by. The router's primary ID is the auto-discovery section name
 	// (RouterName), but it may also surface m.ID or PublicName via aliases.
@@ -381,6 +381,8 @@ func (s *Server) renderModelCard(w http.ResponseWriter, m *models.Model, routerK
 		ServiceState   string
 		VRAMGB         float64
 		IsOrphan       bool
+		IsIncomplete   bool
+		ResumeFilename string
 		SearchText     string
 	}{
 		Model:          *m,
@@ -394,6 +396,8 @@ func (s *Server) renderModelCard(w http.ResponseWriter, m *models.Model, routerK
 		ServiceState:   state,
 		VRAMGB:         vramGB,
 		IsOrphan:       isOrphan,
+		IsIncomplete:   isIncomplete,
+		ResumeFilename: m.Filename,
 		SearchText:     searchText,
 	}
 	s.renderPartial(w, "model_card", data)
@@ -408,6 +412,11 @@ func (s *Server) renderModelList(w http.ResponseWriter, r *http.Request, modelLi
 	orphanSet := make(map[string]bool)
 	for _, m := range s.registry.FindOrphans() {
 		orphanSet[m.ID] = true
+	}
+
+	incompleteSet := make(map[string]bool)
+	for _, m := range s.registry.IncompleteRegistered() {
+		incompleteSet[m.ID] = true
 	}
 
 	sorted := make([]*models.Model, len(modelList))
@@ -429,7 +438,7 @@ func (s *Server) renderModelList(w http.ResponseWriter, r *http.Request, modelLi
 	w.Write([]byte(`<div class="model-card-list">`))
 	w.Write([]byte(`<div class="model-card-header"><span></span><span>Model</span><span>Quant</span><span title="Estimated VRAM at the configured context size">VRAM Est.</span><span>Size</span><span></span></div>`))
 	for _, m := range sorted {
-		s.renderModelCard(w, m, routerKnown, orphanSet[m.ID])
+		s.renderModelCard(w, m, routerKnown, orphanSet[m.ID], incompleteSet[m.ID])
 	}
 	w.Write([]byte(`</div>`))
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -317,6 +317,8 @@ func (s *Server) buildRouter() chi.Router {
 			r.Get("/model", s.handleHFModel)
 			r.Post("/download", s.handleHFDownload)
 			r.Get("/downloads", s.handleHFActiveDownloads)
+			r.Get("/incomplete", s.handleIncompleteDownloads)
+			r.Delete("/incomplete", s.handleIncompleteDiscard)
 			r.Get("/download/{id}/progress", s.handleHFDownloadProgress)
 			r.Delete("/download/{id}", s.handleHFDownloadCancel)
 		})

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -492,9 +492,16 @@ func (s *Server) handleModelEnable(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
+		isIncomplete := false
+		for _, im := range s.registry.IncompleteRegistered() {
+			if im.ID == id {
+				isIncomplete = true
+				break
+			}
+		}
 		w.Header().Set("HX-Trigger-After-Swap", `{"gpuMapChanged":true}`)
 		respondHTML(w)
-		s.renderModelCard(w, m, s.routerKnownStates(), isOrphan)
+		s.renderModelCard(w, m, s.routerKnownStates(), isOrphan, isIncomplete)
 		return
 	}
 

--- a/internal/models/incomplete_test.go
+++ b/internal/models/incomplete_test.go
@@ -1,0 +1,119 @@
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// touch creates a file with the given size (bytes of zero content) under dir,
+// making any parent directories as needed.
+func touch(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// register adds a model whose primary file is filename inside modelsDir/<safeName>.
+func register(t *testing.T, r *Registry, modelsDir, modelID, filename string) {
+	t.Helper()
+	safe := filepath.Join(modelsDir, sanitizeDir(modelID))
+	m := &Model{
+		ID:       modelID + "--" + filename,
+		ModelID:  modelID,
+		Filename: filename,
+		FilePath: filepath.Join(safe, filename),
+	}
+	if err := r.Add(m); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sanitizeDir(modelID string) string {
+	out := ""
+	for _, c := range modelID {
+		if c == '/' {
+			out += "--"
+		} else {
+			out += string(c)
+		}
+	}
+	return out
+}
+
+func TestIncompleteRegistered(t *testing.T) {
+	dir := t.TempDir()
+	modelsDir := filepath.Join(dir, "models")
+	r := NewRegistry(dir, modelsDir)
+
+	// (a) registered sharded model missing shard 2 of 3 → incomplete.
+	aDir := filepath.Join(modelsDir, "org--repoA")
+	touch(t, filepath.Join(aDir, "modelA-00001-of-00003.gguf"), 10)
+	touch(t, filepath.Join(aDir, "modelA-00003-of-00003.gguf"), 10)
+	register(t, r, modelsDir, "org/repoA", "modelA-00001-of-00003.gguf")
+
+	// (c) registered sharded model with all shards present → complete.
+	cDir := filepath.Join(modelsDir, "org--repoC")
+	touch(t, filepath.Join(cDir, "modelC-00001-of-00002.gguf"), 10)
+	touch(t, filepath.Join(cDir, "modelC-00002-of-00002.gguf"), 10)
+	register(t, r, modelsDir, "org/repoC", "modelC-00001-of-00002.gguf")
+
+	// (d) registered single-file model, present → complete.
+	dDir := filepath.Join(modelsDir, "org--repoD")
+	touch(t, filepath.Join(dDir, "modelD.gguf"), 10)
+	register(t, r, modelsDir, "org/repoD", "modelD.gguf")
+
+	got := r.IncompleteRegistered()
+	if len(got) != 1 {
+		t.Fatalf("IncompleteRegistered returned %d models, want 1: %+v", len(got), got)
+	}
+	if got[0].ModelID != "org/repoA" {
+		t.Errorf("incomplete model = %q, want org/repoA", got[0].ModelID)
+	}
+}
+
+func TestOrphanParts(t *testing.T) {
+	dir := t.TempDir()
+	modelsDir := filepath.Join(dir, "models")
+	r := NewRegistry(dir, modelsDir)
+
+	// (b) unregistered partial: two .part shards, no registry entry.
+	bDir := filepath.Join(modelsDir, "org--repoB")
+	touch(t, filepath.Join(bDir, "modelB-00001-of-00002.gguf.part"), 100)
+	touch(t, filepath.Join(bDir, "modelB-00002-of-00002.gguf.part"), 50)
+
+	// A registered-but-incomplete model whose shard 2 is a .part — must NOT
+	// appear in OrphanParts (it surfaces via IncompleteRegistered instead).
+	eDir := filepath.Join(modelsDir, "org--repoE")
+	touch(t, filepath.Join(eDir, "modelE-00001-of-00002.gguf"), 10)
+	touch(t, filepath.Join(eDir, "modelE-00002-of-00002.gguf.part"), 5)
+	register(t, r, modelsDir, "org/repoE", "modelE-00001-of-00002.gguf")
+
+	got := r.OrphanParts()
+	if len(got) != 1 {
+		t.Fatalf("OrphanParts returned %d entries, want 1: %+v", len(got), got)
+	}
+	p := got[0]
+	if p.ModelID != "org/repoB" {
+		t.Errorf("orphan ModelID = %q, want org/repoB", p.ModelID)
+	}
+	if p.Filename != "modelB-00001-of-00002.gguf" {
+		t.Errorf("orphan resume Filename = %q, want first shard", p.Filename)
+	}
+	if p.PartCount != 2 {
+		t.Errorf("orphan PartCount = %d, want 2", p.PartCount)
+	}
+	if p.BytesOnDisk != 150 {
+		t.Errorf("orphan BytesOnDisk = %d, want 150", p.BytesOnDisk)
+	}
+
+	// Sanity: repoE is reported incomplete, not as an orphan part.
+	inc := r.IncompleteRegistered()
+	if len(inc) != 1 || inc[0].ModelID != "org/repoE" {
+		t.Errorf("IncompleteRegistered = %+v, want only org/repoE", inc)
+	}
+}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -635,6 +635,143 @@ func (r *Registry) FindOrphans() []*Model {
 	return orphans
 }
 
+// IncompleteRegistered returns registered multi-shard models whose primary file
+// exists but whose shard set is incomplete (one or more shard files missing).
+// These are the silently-broken downloads: ScanModels registers a model off its
+// first shard, and FindOrphans only stats that first shard, so a model missing
+// later shards looks healthy until it fails to load. Single-file models, and
+// models whose primary file is entirely missing (those are orphans — see
+// FindOrphans), are not reported here.
+func (r *Registry) IncompleteRegistered() []*Model {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var incomplete []*Model
+	for _, m := range r.data.Models {
+		// Primary file missing → orphan, not incomplete.
+		if _, err := os.Stat(m.FilePath); err != nil {
+			continue
+		}
+		shards := findShards(filepath.Dir(m.FilePath), filepath.Base(m.FilePath))
+		if len(shards) < 2 {
+			continue // single-file model with its file present → complete
+		}
+		for _, shard := range shards {
+			if _, err := os.Stat(shard); os.IsNotExist(err) {
+				incomplete = append(incomplete, m)
+				break
+			}
+		}
+	}
+	return incomplete
+}
+
+// OrphanPart describes a partially-downloaded model that has on-disk `.part`
+// files but no registry entry — a download that failed before completing and so
+// never appears in the model list. Filename is a shard member (the first shard
+// for multi-part sets, or the bare filename) suitable for passing back to the
+// downloader, which resumes from the existing `.part` data.
+type OrphanPart struct {
+	ModelID     string `json:"model_id"`
+	Filename    string `json:"filename"`
+	BytesOnDisk int64  `json:"bytes_on_disk"`
+	PartCount   int    `json:"part_count"`
+}
+
+// OrphanParts scans the models directory for `.part` files that don't belong to
+// any registered model, grouping multi-shard partials into a single entry. The
+// returned entries can be resumed via the normal download path. Partials that
+// belong to a registered-but-incomplete model are excluded — those surface as a
+// per-card indicator via IncompleteRegistered instead.
+func (r *Registry) OrphanParts() []OrphanPart {
+	modelsDir := r.modelsDir
+	if _, err := os.Stat(modelsDir); err != nil {
+		return nil
+	}
+
+	// filepath.Walk won't descend a symlinked dir; resolve then remap returned
+	// paths back under modelsDir (same approach as ScanModels).
+	walkRoot := modelsDir
+	if resolved, err := filepath.EvalSymlinks(modelsDir); err == nil && resolved != modelsDir {
+		walkRoot = resolved
+	}
+
+	// All shard paths of every registered model, so a `.part` that's really a
+	// missing shard of a registered model isn't double-reported here.
+	r.mu.RLock()
+	registered := make(map[string]bool)
+	for _, m := range r.data.Models {
+		for _, sh := range findShards(filepath.Dir(m.FilePath), filepath.Base(m.FilePath)) {
+			registered[sh] = true
+		}
+	}
+	r.mu.RUnlock()
+
+	type group struct {
+		modelID  string
+		filename string   // first shard / bare filename to resume with
+		set      []string // full shard paths under modelsDir
+		parts    int
+	}
+	groups := make(map[string]*group)
+
+	filepath.Walk(walkRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".part") {
+			return nil
+		}
+		// Remap back under modelsDir so derived IDs match registry conventions.
+		if walkRoot != modelsDir {
+			if rel, relErr := filepath.Rel(walkRoot, path); relErr == nil {
+				path = filepath.Join(modelsDir, rel)
+			}
+		}
+		finalPath := strings.TrimSuffix(path, ".part")
+		if registered[finalPath] {
+			return nil // belongs to a registered (incomplete) model
+		}
+		rel, relErr := filepath.Rel(modelsDir, finalPath)
+		if relErr != nil {
+			return nil
+		}
+		parts := strings.SplitN(rel, string(filepath.Separator), 2)
+		if len(parts) < 2 {
+			return nil // .part directly under modelsDir — no owning model dir
+		}
+		modelID := strings.ReplaceAll(parts[0], "--", "/")
+		dir := filepath.Dir(finalPath)
+		shards := findShards(dir, filepath.Base(finalPath))
+		firstName := filepath.Base(shards[0])
+		key := dir + "::" + firstName
+		g := groups[key]
+		if g == nil {
+			g = &group{modelID: modelID, filename: firstName, set: shards}
+			groups[key] = g
+		}
+		g.parts++
+		return nil
+	})
+
+	var out []OrphanPart
+	for _, g := range groups {
+		var bytes int64
+		for _, sh := range g.set {
+			if info, err := os.Stat(sh); err == nil {
+				bytes += info.Size()
+			} else if pinfo, perr := os.Stat(sh + ".part"); perr == nil {
+				bytes += pinfo.Size()
+			}
+		}
+		out = append(out, OrphanPart{
+			ModelID:     g.modelID,
+			Filename:    g.filename,
+			BytesOnDisk: bytes,
+			PartCount:   g.parts,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ModelID < out[j].ModelID })
+	return out
+}
+
 // ScanModels walks the models directory for GGUF files not already in the
 // registry and adds them. Returns the number of new models found.
 func (r *Registry) ScanModels() int {

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -284,6 +284,9 @@
         .model-card-orphan {
             opacity: 0.6;
         }
+        .model-card-incomplete {
+            border-left: 3px solid var(--pico-del-color);
+        }
         /* Shared grid template — header row and each card's metadata row
            use the same fixed column widths so columns align across rows.
            (Each card is its own grid container, so fixed widths are needed

--- a/web/templates/models.html
+++ b/web/templates/models.html
@@ -24,6 +24,13 @@
      hx-on::after-swap="var has=this.innerHTML.trim().length>0;if(this.dataset.wasActive==='1'&&!has){htmx.trigger(document.body,'modelsChanged');}this.dataset.wasActive=has?'1':'0';">
 </div>
 
+<div id="incomplete-downloads"
+     hx-get="/api/hf/incomplete"
+     hx-trigger="load, every 5s, modelsChanged from:body"
+     hx-swap="innerHTML"
+     hx-on::before-swap="if(event.detail.xhr.responseText===this.innerHTML){event.detail.shouldSwap=false;}">
+</div>
+
 <div id="model-list" hx-get="/api/models" hx-trigger="load, modelsChanged from:body" hx-swap="innerHTML">
     Loading...
 </div>

--- a/web/templates/partials/model_card.html
+++ b/web/templates/partials/model_card.html
@@ -1,5 +1,5 @@
 {{define "model_card"}}
-<article class="model-card{{if .IsOrphan}} model-card-orphan{{end}}"
+<article class="model-card{{if .IsOrphan}} model-card-orphan{{end}}{{if .IsIncomplete}} model-card-incomplete{{end}}"
          id="model-card-{{cssID .ID}}"
          data-search="{{.SearchText}}">
     <div class="model-card-row">
@@ -7,9 +7,9 @@
             <span style="display: inline-flex; align-items: center; gap: 0.25rem;">
                 <input type="checkbox" role="switch" style="margin: 0;"
                        {{if .IsEnabled}}checked{{end}}
-                       {{if .IsOrphan}}disabled{{end}}
-                       title="{{if .IsOrphan}}Model file is missing — cannot be enabled{{else}}Enable this model for the inference server{{end}}"
-                       {{if not .IsOrphan}}
+                       {{if or .IsOrphan .IsIncomplete}}disabled{{end}}
+                       title="{{if .IsOrphan}}Model file is missing — cannot be enabled{{else if .IsIncomplete}}Download is incomplete — resume it before enabling{{else}}Enable this model for the inference server{{end}}"
+                       {{if not (or .IsOrphan .IsIncomplete)}}
                        hx-put="/api/models/{{.ID}}/enable"
                        hx-target="closest .model-card"
                        hx-swap="outerHTML"
@@ -27,6 +27,7 @@
             {{if .SupportsTools}} <mark style="padding:0 0.3rem;font-size:0.75rem;">tools</mark>{{end}}
             {{if .GPULabel}} <mark style="padding:0 0.3rem;font-size:0.75rem;background:var(--pico-muted-border-color);color:var(--pico-color);">{{.GPULabel}}</mark>{{end}}
             {{if .IsOrphan}} <del>missing</del>{{end}}
+            {{if .IsIncomplete}} <mark style="padding:0 0.3rem;font-size:0.75rem;background:var(--pico-del-color);color:var(--pico-card-background-color);">incomplete</mark>{{end}}
         </div>
         <div class="model-card-quant"><kbd>{{.Quant}}</kbd></div>
         <div class="model-card-vram" id="vram-{{.ID}}" title="Estimated VRAM at the configured context size — llama.cpp pre-allocates the full KV cache at load time, so this is what the model actually needs to load">{{printf "%.1f" .VRAMGB}} GB</div>
@@ -40,6 +41,24 @@
                     hx-swap="outerHTML">
                 Remove
             </button>
+            {{else if .IsIncomplete}}
+            <div role="group">
+                <button type="button" class="outline"
+                        title="Resume the download — picks up from the files already on disk"
+                        hx-post="/api/hf/download"
+                        hx-vals='{"model_id":"{{.ModelID}}","filename":"{{.ResumeFilename}}","size":"0"}'
+                        hx-target="#model-config-{{cssID .ID}}"
+                        hx-swap="innerHTML">
+                    Resume
+                </button>
+                <button type="button" class="outline secondary"
+                        hx-delete="/api/models/{{.ID}}"
+                        hx-confirm="Remove this model and delete its partial files?"
+                        hx-target="closest .model-card"
+                        hx-swap="outerHTML">
+                    Remove
+                </button>
+            </div>
             {{else}}
             <div role="group">
                 <button type="button" class="outline"


### PR DESCRIPTION
## Problem

Model downloads that fail partway through (common with large multi-shard models) were invisible on the Models page — you only discovered missing files when trying to **load** the model and the server failed.

Two distinct incomplete states existed in the code, neither surfaced:

1. **Registered but silently broken.** A multi-shard model only registers after *all* shards finish, but "Scan for Models" registers it off its **first shard** alone, and `FindOrphans` only stats that first shard. A model missing later shards looked perfectly healthy until load.
2. **Unregistered partial.** A download that failed before completing left orphaned `.part` files with no registry entry, so it never appeared on the page at all.

## Changes

- **Detection** (`internal/models/registry.go`), reusing the existing `findShards` helper:
  - `IncompleteRegistered()` — registered models whose shard set is incomplete.
  - `OrphanParts()` — unregistered `.part` files, grouped per shard set and reconciled against registered models so nothing is double-reported.
- **UI:** incomplete models get an `incomplete` badge + **Resume** button on their card (enable toggle disabled); unregistered partials appear in a new **Incomplete downloads** panel with Resume/Discard. Resuming fires the existing `modelsChanged` event, so items move from panel/badge → healthy card automatically.
- **Endpoints:** `GET /api/hf/incomplete` (panel) and `DELETE /api/hf/incomplete` (discard, path-guarded to the models dir). **Resume reuses `POST /api/hf/download`** — the downloader already resumes from existing `.part` data, so there's no new download logic.

## Testing

- `go build`, `go vet`, `go test ./...` all pass.
- New unit tests for `IncompleteRegistered`/`OrphanParts` (`internal/models/incomplete_test.go`) and render tests for the card states (`internal/api/model_card_render_test.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)