### PR TITLE
fix: parse extra flags shell-style to preserve spaces (#67)

### DIFF
--- a/internal/models/preset.go
+++ b/internal/models/preset.go
@@ -246,17 +246,100 @@ func writeConfigParams(b *strings.Builder, cfg *ModelConfig, isEmbedding bool) {
 		b.WriteString(fmt.Sprintf("repeat-penalty = %g\n", *cfg.RepeatPenalty))
 	}
 
-	// Extra flags
-	if cfg.ExtraFlags != "" {
-		for _, flag := range strings.Fields(cfg.ExtraFlags) {
-			flag = strings.TrimLeft(flag, "-")
-			if parts := strings.SplitN(flag, "=", 2); len(parts) == 2 {
-				b.WriteString(fmt.Sprintf("%s = %s\n", parts[0], parts[1]))
+	// Extra flags. Parse shell-style so "--flag value" (space-separated) and
+	// quoted values containing spaces survive intact. The old strings.Fields
+	// split shredded "--reasoning-budget 4096 --msg \"a b c\"" into a pile of
+	// bogus "4096 = true" / "b = true" keys (issue #67).
+	for _, kv := range parseExtraFlags(cfg.ExtraFlags) {
+		b.WriteString(fmt.Sprintf("%s = %s\n", kv.key, kv.value))
+	}
+}
+
+type extraFlag struct {
+	key   string
+	value string
+}
+
+// parseExtraFlags tokenizes a raw extra-flags string the way a shell would —
+// honoring single and double quotes so values containing spaces stay together —
+// then pairs each "--flag" with its value. Both "--flag value" and
+// "--flag=value" are accepted, and a flag with no following value becomes
+// "true" (a boolean switch). Values are written verbatim into the INI; the
+// llama.cpp preset parser reads the rest of the line, so spaces are fine.
+func parseExtraFlags(raw string) []extraFlag {
+	tokens := tokenizeFlags(raw)
+	var out []extraFlag
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		if !strings.HasPrefix(tok, "-") {
+			// A value with no preceding flag — nothing sensible to do, skip.
+			continue
+		}
+		key := strings.TrimLeft(tok, "-")
+		if key == "" {
+			continue
+		}
+		if eq := strings.IndexByte(key, '='); eq >= 0 {
+			out = append(out, extraFlag{key[:eq], key[eq+1:]})
+			continue
+		}
+		// A following non-flag token is this flag's value. Negative numbers
+		// (e.g. "-1") count as values, not flags.
+		if i+1 < len(tokens) && !looksLikeFlag(tokens[i+1]) {
+			out = append(out, extraFlag{key, tokens[i+1]})
+			i++
+			continue
+		}
+		out = append(out, extraFlag{key, "true"})
+	}
+	return out
+}
+
+// looksLikeFlag reports whether a token introduces a new flag rather than
+// being a value. A leading dash followed by a digit or dot (e.g. "-1",
+// "-.5") is treated as a negative-number value.
+func looksLikeFlag(tok string) bool {
+	if len(tok) < 2 || tok[0] != '-' {
+		return false
+	}
+	c := tok[1]
+	return !(c >= '0' && c <= '9') && c != '.'
+}
+
+// tokenizeFlags splits a command-line string into tokens, honoring single and
+// double quotes (which are removed, their contents kept as part of the token).
+// Whitespace outside quotes separates tokens.
+func tokenizeFlags(raw string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inToken := false
+	var quote rune // 0 when not inside quotes
+	for _, r := range raw {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
 			} else {
-				b.WriteString(fmt.Sprintf("%s = true\n", flag))
+				cur.WriteRune(r)
 			}
+		case r == '\'' || r == '"':
+			quote = r
+			inToken = true
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			if inToken {
+				tokens = append(tokens, cur.String())
+				cur.Reset()
+				inToken = false
+			}
+		default:
+			cur.WriteRune(r)
+			inToken = true
 		}
 	}
+	if inToken {
+		tokens = append(tokens, cur.String())
+	}
+	return tokens
 }
 
 // RouterName returns the model name that the llama.cpp router uses for

--- a/internal/models/preset_test.go
+++ b/internal/models/preset_test.go
@@ -65,6 +65,117 @@ func TestGeneratePresetINIAliasesIncludeDirnameOnlyWhenUnique(t *testing.T) {
 	}
 }
 
+// TestParseExtraFlags pins down the extra-flags parsing fixed for issue #67.
+// strings.Fields used to split on every space, turning "--reasoning-budget
+// 4096" into the bogus keys "4096 = true" and shredding quoted messages.
+func TestParseExtraFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []extraFlag
+	}{
+		{
+			name: "space-separated flag and value",
+			raw:  "--reasoning-budget 4096",
+			want: []extraFlag{{"reasoning-budget", "4096"}},
+		},
+		{
+			name: "equals form",
+			raw:  "--reasoning-budget=4096",
+			want: []extraFlag{{"reasoning-budget", "4096"}},
+		},
+		{
+			name: "double-quoted value with spaces",
+			raw:  `--reasoning-budget-message "... thinking budget exceeded, let's answer now."`,
+			want: []extraFlag{{"reasoning-budget-message", "... thinking budget exceeded, let's answer now."}},
+		},
+		{
+			name: "single-quoted value with spaces",
+			raw:  `--reasoning-budget-message 'thinking budget exceeded'`,
+			want: []extraFlag{{"reasoning-budget-message", "thinking budget exceeded"}},
+		},
+		{
+			name: "equals with quoted value",
+			raw:  `--reasoning-budget-message="a b c"`,
+			want: []extraFlag{{"reasoning-budget-message", "a b c"}},
+		},
+		{
+			name: "boolean switch",
+			raw:  "--jinja",
+			want: []extraFlag{{"jinja", "true"}},
+		},
+		{
+			name: "negative number value",
+			raw:  "--some-flag -1",
+			want: []extraFlag{{"some-flag", "-1"}},
+		},
+		{
+			name: "the full issue #67 case",
+			raw:  `--reasoning-budget 4096 --reasoning-budget-message "... thinking budget exceeded, let's answer now."`,
+			want: []extraFlag{
+				{"reasoning-budget", "4096"},
+				{"reasoning-budget-message", "... thinking budget exceeded, let's answer now."},
+			},
+		},
+		{
+			name: "empty",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name: "multiple booleans then valued flag",
+			raw:  "--flash-attn --jinja --ctx-size 4096",
+			want: []extraFlag{
+				{"flash-attn", "true"},
+				{"jinja", "true"},
+				{"ctx-size", "4096"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseExtraFlags(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseExtraFlags(%q) = %+v; want %+v", tt.raw, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseExtraFlags(%q)[%d] = %+v; want %+v", tt.raw, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestGeneratePresetINIExtraFlagsWithSpaces is the end-to-end guard for
+// issue #67: a quoted extra-flag value with spaces must land as a single
+// INI line, not a cascade of "word = true" entries.
+func TestGeneratePresetINIExtraFlagsWithSpaces(t *testing.T) {
+	mods := []*Model{
+		{ID: "u--R-GGUF--R-Q8_0", ModelID: "u/R-GGUF", Quant: "Q8_0", FilePath: "/data/models/u--R-GGUF/R-Q8_0.gguf"},
+	}
+	cfgs := map[string]*ModelConfig{
+		"u--R-GGUF--R-Q8_0": {
+			Enabled:    true,
+			ExtraFlags: `--reasoning-budget 4096 --reasoning-budget-message "... thinking budget exceeded, let's answer now."`,
+		},
+	}
+	out := GeneratePresetINI("/data/models", mods, cfgs)
+
+	if !strings.Contains(out, "reasoning-budget = 4096\n") {
+		t.Errorf("expected 'reasoning-budget = 4096'; got:\n%s", out)
+	}
+	if !strings.Contains(out, "reasoning-budget-message = ... thinking budget exceeded, let's answer now.\n") {
+		t.Errorf("expected the message on one line; got:\n%s", out)
+	}
+	// None of the shredded keys from the old strings.Fields behavior.
+	for _, bogus := range []string{"4096 = true", "budget = true", "now.\" = true", "let's = true"} {
+		if strings.Contains(out, bogus) {
+			t.Errorf("found shredded key %q in output:\n%s", bogus, out)
+		}
+	}
+}
+
 // sectionBody returns the lines of the given INI section, up to (but not
 // including) the next section header.
 func sectionBody(ini, section string) string {


### PR DESCRIPTION
Closes #67.

## Problem
Extra flags entered on the model config were split with `strings.Fields`, which breaks on every space. So `--reasoning-budget 4096` became the bogus preset keys `reasoning-budget = true` **and** `4096 = true`, and a quoted value like `--reasoning-budget-message "... budget exceeded ..."` got shredded into `"... = true`, `budget = true`, etc. The resulting `preset.ini` was malformed and failed to load.

## Fix
Replace the split with a shell-style tokenizer that:
- honors single/double quotes, so values with spaces stay intact (quotes stripped),
- accepts both `--flag value` and `--flag=value`,
- emits `= true` only for valueless switches,
- treats `-1` / `-.5` as values, not new flags.

The llama.cpp preset parser reads the rest of the line as the value, so spaces in values are fine.

## Tests
`TestParseExtraFlags` covers every form (space-separated, equals, single/double quotes, booleans, negative numbers, the exact issue case) and `TestGeneratePresetINIExtraFlagsWithSpaces` asserts the quoted message lands on one line with none of the old shredded keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)