### PR TITLE
fix: correct GPU detection — name by Device Type + pin CUDA order (#68)

### DIFF
--- a/internal/monitor/rocm.go
+++ b/internal/monitor/rocm.go
@@ -181,21 +181,70 @@ func readVRAMSysfs(gpuIdx int) (usedMB, totalMB int) {
 }
 
 func readGPUNameSysfs(gpuIdx int) string {
-	// Try to get marketing name from rocminfo cache or use a generic name
 	if out, err := exec.Command("rocminfo").Output(); err == nil {
-		var currentAgent int
-		for _, line := range strings.Split(string(out), "\n") {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "Marketing Name:") {
-				name := strings.TrimSpace(strings.TrimPrefix(line, "Marketing Name:"))
-				if name != "" && !strings.HasPrefix(name, "AMD Ryzen") && !strings.HasPrefix(name, "AMD EPYC") {
-					if currentAgent == gpuIdx {
-						return name
-					}
-					currentAgent++
-				}
-			}
+		names := parseROCmGPUNames(string(out))
+		if gpuIdx >= 0 && gpuIdx < len(names) {
+			return names[gpuIdx]
 		}
 	}
 	return fmt.Sprintf("AMD GPU %d", gpuIdx)
+}
+
+// parseROCmGPUNames extracts the marketing names of GPU agents from rocminfo
+// output, in agent order. rocminfo lists every HSA agent — including the host
+// CPU — under "Agent N" blocks, each carrying a "Device Type:" (CPU or GPU)
+// and a "Marketing Name:". Only GPU agents are returned.
+//
+// The previous approach blacklisted marketing names starting with "AMD Ryzen"
+// or "AMD EPYC" to skip the CPU agent. That let any other CPU leak through and
+// get labelled as GPU 0 — e.g. an Intel Xeon host showed up as "GPU 0 Intel(R)
+// Xeon(R) W-2225 CPU" (issue #68). Keying off "Device Type: GPU" is robust to
+// the CPU vendor.
+//
+// When a GPU agent reports no marketing name, its "Name:" (e.g. "gfx1100") is
+// used as a fallback so the entry is never blank.
+func parseROCmGPUNames(out string) []string {
+	type agent struct {
+		name      string
+		marketing string
+		isGPU     bool
+	}
+	var agents []agent
+	cur := -1
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "Agent "):
+			agents = append(agents, agent{})
+			cur = len(agents) - 1
+		case cur < 0:
+			// Header lines before the first agent block.
+			continue
+		case strings.HasPrefix(line, "Marketing Name:"):
+			agents[cur].marketing = strings.TrimSpace(strings.TrimPrefix(line, "Marketing Name:"))
+		case strings.HasPrefix(line, "Name:"):
+			// Record only the first "Name:" of a block (the agent name);
+			// later Name fields belong to nested pool/cache entries.
+			if agents[cur].name == "" {
+				agents[cur].name = strings.TrimSpace(strings.TrimPrefix(line, "Name:"))
+			}
+		case strings.HasPrefix(line, "Device Type:"):
+			if strings.Contains(line, "GPU") {
+				agents[cur].isGPU = true
+			}
+		}
+	}
+
+	var names []string
+	for _, a := range agents {
+		if !a.isGPU {
+			continue
+		}
+		if a.marketing != "" {
+			names = append(names, a.marketing)
+		} else {
+			names = append(names, a.name)
+		}
+	}
+	return names
 }

--- a/internal/monitor/rocm_test.go
+++ b/internal/monitor/rocm_test.go
@@ -1,0 +1,114 @@
+//go:build linux
+
+package monitor
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseROCmGPUNamesSkipsCPU guards issue #68: rocminfo lists the host CPU
+// as an agent, and the old name-blacklist let non-AMD CPUs (e.g. an Intel
+// Xeon) leak through and get labelled as "GPU 0". Selecting by Device Type
+// must drop the CPU agent regardless of its vendor.
+func TestParseROCmGPUNamesSkipsCPU(t *testing.T) {
+	// Abridged rocminfo output: an Intel Xeon CPU agent followed by an AMD GPU.
+	out := `ROCk module is loaded
+=====================
+HSA System Attributes
+=====================
+Runtime Version:         1.1
+*******
+Agent 1
+*******
+  Name:                    Intel(R) Xeon(R) W-2225 CPU @ 4.10GHz
+  Uuid:                    CPU-XX
+  Marketing Name:          Intel(R) Xeon(R) W-2225 CPU @ 4.10GHz
+  Device Type:             CPU
+  Pool Info:
+    Pool 1
+      Segment:               GLOBAL; FLAGS: FINE GRAINED
+*******
+Agent 2
+*******
+  Name:                    gfx1100
+  Uuid:                    GPU-XX
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+  Pool Info:
+    Pool 1
+      Segment:               GLOBAL; FLAGS: COARSE GRAINED
+`
+	got := parseROCmGPUNames(out)
+	want := []string{"AMD Radeon RX 7900 XTX"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseROCmGPUNames = %v; want %v", got, want)
+	}
+}
+
+// TestParseROCmGPUNamesMultiGPU verifies GPU agents are returned in order and
+// the CPU between/around them is skipped.
+func TestParseROCmGPUNamesMultiGPU(t *testing.T) {
+	out := `*******
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 7950X
+  Marketing Name:          AMD Ryzen 9 7950X 16-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+`
+	got := parseROCmGPUNames(out)
+	want := []string{"AMD Radeon RX 7900 XTX", "AMD Radeon RX 7900 XTX"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseROCmGPUNames = %v; want %v", got, want)
+	}
+}
+
+// TestParseROCmGPUNamesFallbackToName covers a GPU agent with no marketing
+// name — the gfx id stands in so the entry is never blank.
+func TestParseROCmGPUNamesFallbackToName(t *testing.T) {
+	out := `*******
+Agent 1
+*******
+  Name:                    AMD Eng Sample
+  Marketing Name:          AMD Eng Sample
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1151
+  Marketing Name:
+  Device Type:             GPU
+`
+	got := parseROCmGPUNames(out)
+	want := []string{"gfx1151"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseROCmGPUNames = %v; want %v", got, want)
+	}
+}
+
+// TestParseROCmGPUNamesNoGPU returns nil when only a CPU agent is present, so
+// readGPUNameSysfs falls back to a generic label rather than the CPU name.
+func TestParseROCmGPUNamesNoGPU(t *testing.T) {
+	out := `*******
+Agent 1
+*******
+  Name:                    Intel(R) Xeon(R) W-2225 CPU @ 4.10GHz
+  Marketing Name:          Intel(R) Xeon(R) W-2225 CPU @ 4.10GHz
+  Device Type:             CPU
+`
+	if got := parseROCmGPUNames(out); len(got) != 0 {
+		t.Errorf("parseROCmGPUNames = %v; want empty", got)
+	}
+}

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -124,7 +124,7 @@ func (m *Manager) Start(cfg RouterConfig) error {
 	// The variable name differs per OS; on Windows we prepend to PATH instead
 	// of setting a separate var, since that's how Windows resolves DLLs.
 	binDir := filepath.Dir(cfg.BinaryPath)
-	cmd.Env = appendLibraryPath(os.Environ(), binDir)
+	cmd.Env = pinCUDADeviceOrder(appendLibraryPath(os.Environ(), binDir))
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -451,6 +451,22 @@ func (m *Manager) CheckHealth() bool {
 // set so the child process can find shared libraries co-located with the
 // binary. On Linux this is LD_LIBRARY_PATH, on macOS DYLD_LIBRARY_PATH, on
 // Windows we prepend to PATH (since that's how the loader finds DLLs).
+// pinCUDADeviceOrder forces llama-server's CUDA backend to enumerate GPUs in
+// PCI bus order, matching nvidia-smi (whose indices drive the web UI's "GPU N"
+// labels and the --main-gpu / --tensor-split values we generate). Without this
+// the CUDA runtime defaults to CUDA_DEVICE_ORDER=FASTEST_FIRST — a perf-based
+// ordering that diverges from nvidia-smi on heterogeneous multi-GPU boxes, so
+// "GPU 0" in the UI could map to a different physical card in llama-server
+// (issue #68). A user-provided CUDA_DEVICE_ORDER is left untouched.
+func pinCUDADeviceOrder(env []string) []string {
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CUDA_DEVICE_ORDER=") {
+			return env
+		}
+	}
+	return append(env, "CUDA_DEVICE_ORDER=PCI_BUS_ID")
+}
+
 func appendLibraryPath(env []string, dir string) []string {
 	switch runtime.GOOS {
 	case "darwin":

--- a/internal/process/manager_test.go
+++ b/internal/process/manager_test.go
@@ -1,0 +1,39 @@
+package process
+
+import (
+	"strings"
+	"testing"
+)
+
+// countCUDAOrder returns how many CUDA_DEVICE_ORDER entries are in env and the
+// value of the last one (the one that wins).
+func countCUDAOrder(env []string) (n int, last string) {
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CUDA_DEVICE_ORDER=") {
+			n++
+			last = strings.TrimPrefix(kv, "CUDA_DEVICE_ORDER=")
+		}
+	}
+	return n, last
+}
+
+// TestPinCUDADeviceOrderAdds pins issue #68: when the user hasn't set
+// CUDA_DEVICE_ORDER, we add PCI_BUS_ID so the CUDA backend's device indices
+// match nvidia-smi (and thus the web UI's "GPU N" labels).
+func TestPinCUDADeviceOrderAdds(t *testing.T) {
+	env := pinCUDADeviceOrder([]string{"PATH=/usr/bin", "HOME=/root"})
+	n, last := countCUDAOrder(env)
+	if n != 1 || last != "PCI_BUS_ID" {
+		t.Fatalf("expected exactly one CUDA_DEVICE_ORDER=PCI_BUS_ID; got count=%d last=%q env=%v", n, last, env)
+	}
+}
+
+// TestPinCUDADeviceOrderRespectsExisting verifies a user-provided value is
+// left untouched — we never override an explicit choice.
+func TestPinCUDADeviceOrderRespectsExisting(t *testing.T) {
+	env := pinCUDADeviceOrder([]string{"PATH=/usr/bin", "CUDA_DEVICE_ORDER=FASTEST_FIRST"})
+	n, last := countCUDAOrder(env)
+	if n != 1 || last != "FASTEST_FIRST" {
+		t.Fatalf("expected the existing FASTEST_FIRST to survive untouched; got count=%d last=%q env=%v", n, last, env)
+	}
+}


### PR DESCRIPTION
Closes #68.

Two related GPU-detection bugs surfaced in this issue. Stacked here as one PR.

## 1. CPU shown as the GPU name
The GPU Allocation Map labelled `GPU 0` with the host CPU string (`Intel(R) Xeon(R) W-2225 CPU @ 4.10GHz` in the report). `readGPUNameSysfs` pulled `Marketing Name:` lines from `rocminfo` and only skipped names starting with `AMD Ryzen`/`AMD EPYC` — so any other CPU vendor leaked through and became the GPU name.

**Fix:** parse `rocminfo` by agent block and take marketing names only from agents whose `Device Type:` is `GPU` (falling back to the gfx `Name:` when a GPU has no marketing name). Robust to CPU vendor; returns nothing on a GPU-less host so it falls back to a generic label.

## 2. GPU ordering mismatch vs llama-server
Reported in the thread: the UI numbers GPUs by `nvidia-smi` index (PCI bus order) and generates `--main-gpu` / `--tensor-split` against those indices, but llama-server's CUDA backend defaults to `CUDA_DEVICE_ORDER=FASTEST_FIRST` — a perf-based order that diverges from `nvidia-smi` on heterogeneous multi-GPU hosts. So "GPU 0" in the UI could map to a different physical card at launch.

**Fix:** export `CUDA_DEVICE_ORDER=PCI_BUS_ID` in llama-server's launch environment so CUDA device indices match `nvidia-smi` and the UI. A user-set value is preserved. ROCm/HIP already enumerate in PCI/node order, so no change needed there.

## Tests
- `parseROCmGPUNames`: Intel-CPU leak, multi-GPU ordering, blank-marketing-name fallback, CPU-only host.
- `pinCUDADeviceOrder`: adds `PCI_BUS_ID` when unset, preserves an existing value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)