### PR TITLE
fix: discover system config at /etc/llama-toolchest (#61)

### DIFF
--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -42,6 +42,25 @@ sudoedit /etc/llama-toolchest/llama-toolchest.yaml          # set data_dir to /v
 sudo systemctl enable --now llama-toolchest
 ```
 
+## Where the config is read from
+
+On startup the binary loads the first config file it finds, in this order:
+
+1. `$LLAMA_TOOLCHEST_CONFIG` — explicit override (set it in a systemd drop-in to force a specific path)
+2. `$XDG_CONFIG_HOME/llama-toolchest/llama-toolchest.yaml` (if `XDG_CONFIG_HOME` is set)
+3. `~/.config/llama-toolchest/llama-toolchest.yaml` — user-scope
+4. `/etc/llama-toolchest/llama-toolchest.yaml` — system-scope
+
+A user config takes precedence over the system one when both exist. If none
+exist, built-in defaults are used. So the system-scope flow above works with
+the packaged unit as-is — no `--config` flag or env var needed. To pin a
+non-standard location anyway:
+
+```bash
+sudo systemctl edit llama-toolchest    # add under [Service]:
+# Environment=LLAMA_TOOLCHEST_CONFIG=/path/to/llama-toolchest.yaml
+```
+
 ## GPU SDKs
 
 The package doesn't pull GPU SDKs — install them yourself for the backend you want to compile against:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,8 +3,57 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
+
+// TestConfigSearchPathsIncludesEtc guards issue #61: a system-scope install
+// puts its config at /etc/llama-toolchest/llama-toolchest.yaml, but the binary
+// never searched there, so a root service silently ignored it. /etc must be a
+// candidate, ordered after the per-user paths so a user config still wins.
+func TestConfigSearchPathsIncludesEtc(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skipf("system /etc path is Linux-specific; GOOS=%s", runtime.GOOS)
+	}
+	paths := configSearchPaths()
+	want := filepath.Join("/etc", appName, "llama-toolchest.yaml")
+	if len(paths) == 0 || paths[len(paths)-1] != want {
+		t.Fatalf("expected %q as the last (lowest-priority) candidate; got %v", want, paths)
+	}
+}
+
+// TestDefaultConfigPathEnvWins verifies LLAMA_TOOLCHEST_CONFIG short-circuits
+// the search entirely — this is the documented escape hatch.
+func TestDefaultConfigPathEnvWins(t *testing.T) {
+	t.Setenv("LLAMA_TOOLCHEST_CONFIG", "/custom/spot/config.yaml")
+	if got := DefaultConfigPath(); got != "/custom/spot/config.yaml" {
+		t.Fatalf("DefaultConfigPath() = %q, want the env override", got)
+	}
+}
+
+// TestDefaultConfigPathPrefersExistingConfig verifies the first candidate that
+// actually exists on disk is returned, rather than a fixed canonical path.
+func TestDefaultConfigPathPrefersExistingConfig(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skipf("uses XDG_CONFIG_HOME; GOOS=%s", runtime.GOOS)
+	}
+	t.Setenv("LLAMA_TOOLCHEST_CONFIG", "") // disable the env override
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir := filepath.Join(tmp, appName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "llama-toolchest.yaml")
+	if err := os.WriteFile(want, []byte("data_dir: /tmp\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DefaultConfigPath(); got != want {
+		t.Fatalf("DefaultConfigPath() = %q, want the existing XDG config %q", got, want)
+	}
+}
 
 // TestSalvageModelsDir verifies that a config with a non-existent
 // models_dir falls back to <DataDir>/models. This salvages registries

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -31,28 +31,59 @@ func DefaultDataDir() string {
 	return "/data"
 }
 
-// DefaultConfigPath returns the platform-appropriate config file path.
-// Honors LLAMA_TOOLCHEST_CONFIG if set.
+// DefaultConfigPath returns the config file path to load. It honors
+// LLAMA_TOOLCHEST_CONFIG if set; otherwise it returns the first candidate
+// location that exists, falling back to the preferred user-scope path for
+// writing when none exist.
+//
+// The existence check is what lets a system-scope install find
+// /etc/llama-toolchest/llama-toolchest.yaml without the systemd unit having to
+// pass --config or set an env var. Before this, the default resolved only to
+// ~/.config (or /data), so a root service silently ignored the documented
+// /etc config and used built-in defaults instead (issue #61).
 func DefaultConfigPath() string {
 	if path := os.Getenv("LLAMA_TOOLCHEST_CONFIG"); path != "" {
 		return path
 	}
+	candidates := configSearchPaths()
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	// Nothing exists yet — return the preferred writable default (the first
+	// candidate), so a later save lands in the conventional per-user location.
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+	return "/data/config/llama-toolchest.yaml"
+}
+
+// configSearchPaths returns the candidate config locations for the current OS,
+// in priority order. The first existing one wins in DefaultConfigPath.
+func configSearchPaths() []string {
+	const file = "llama-toolchest.yaml"
 	switch runtime.GOOS {
 	case "darwin":
 		if home, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(home, "Library", "Application Support", appName, "llama-toolchest.yaml")
+			return []string{filepath.Join(home, "Library", "Application Support", appName, file)}
 		}
 	case "windows":
 		if dir := os.Getenv("LOCALAPPDATA"); dir != "" {
-			return filepath.Join(dir, appName, "llama-toolchest.yaml")
+			return []string{filepath.Join(dir, appName, file)}
 		}
 	default:
+		var paths []string
 		if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-			return filepath.Join(dir, appName, "llama-toolchest.yaml")
+			paths = append(paths, filepath.Join(dir, appName, file))
 		}
 		if home, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(home, ".config", appName, "llama-toolchest.yaml")
+			paths = append(paths, filepath.Join(home, ".config", appName, file))
 		}
+		// System-scope install location, checked after the per-user paths so a
+		// user config still takes precedence when both are present.
+		paths = append(paths, filepath.Join("/etc", appName, file))
+		return paths
 	}
-	return "/data/config/llama-toolchest.yaml"
+	return []string{"/data/config/llama-toolchest.yaml"}
 }

--- a/packaging/systemd/llama-toolchest.service
+++ b/packaging/systemd/llama-toolchest.service
@@ -20,6 +20,10 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 ProtectHome=read-only
+# ProtectSystem=full makes /etc read-only; carve out the config dir so the
+# Settings page can save back to /etc/llama-toolchest/llama-toolchest.yaml.
+# The leading "-" tolerates the dir being absent.
+ReadWritePaths=-/etc/llama-toolchest
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #61.

## Problem
A system-scope install puts its config at `/etc/llama-toolchest/llama-toolchest.yaml` (per the docs and the `.yaml.example` header), but `DefaultConfigPath()` on Linux only ever resolved to `$LLAMA_TOOLCHEST_CONFIG` → `$XDG_CONFIG_HOME/...` → `~/.config/...` → `/data/config/...`. It **never looked at `/etc`**.

So a root systemd service running the packaged unit (`ExecStart=/usr/bin/llama-toolchest`, no `--config`) landed on `/root/.config/...`, silently ignored the `/etc` config the admin had created, and used built-in defaults — most visibly the wrong `data_dir`. The reporter only got it working by setting `LLAMA_TOOLCHEST_CONFIG` in a systemd drop-in.

This affects bare-package installs **and** `setup.sh` in package+system mode (the script only writes a `--config` drop-in for *source* installs).

## Fix
- `DefaultConfigPath()` now searches candidate locations and loads the first that **exists**, adding `/etc/llama-toolchest/llama-toolchest.yaml` — checked *after* the per-user paths so a user config still wins. The packaged system unit now works as-is, no `--config` or env var needed.
- The hardened system unit has `ProtectSystem=full` (which makes `/etc` read-only), so reading from `/etc` would leave Settings saves failing with EROFS. Added `ReadWritePaths=-/etc/llama-toolchest` to carve out just that dir (leading `-` tolerates its absence on user-scope installs).
- Documented the resolution order — and the `LLAMA_TOOLCHEST_CONFIG` escape hatch the reporter asked for — in `docs/manual-install.md`.

## Tests
`TestConfigSearchPathsIncludesEtc` (/etc present, lowest priority), `TestDefaultConfigPathEnvWins` (env override), `TestDefaultConfigPathPrefersExistingConfig` (first-existing wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)