### PR TITLE
feat: optional secure deploy (Caddy reverse proxy) + scriptable installer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,19 @@
 LLAMA_TOOLCHEST_PORT=3000
 LLAMA_TOOLCHEST_INFERENCE_PORT=8080
 
+# ─── Secure install (Caddy reverse proxy) ────────────────────────────────────
+# Written automatically by `./setup.sh install --secure`. Do not hand-edit
+# unless you know what you're doing — see docs/secure.md. In secure mode the
+# app binds to loopback (LLAMA_TOOLCHEST_BIND) and Caddy publishes 80/443/8080.
+#
+# LLAMA_TOOLCHEST_SECURE=1                       # stack docker-compose.secure.yml
+# LLAMA_TOOLCHEST_BIND=127.0.0.1:                # interface prefix for app ports
+# LLAMA_TOOLCHEST_EXTERNAL_URL=https://host      # makes UI links render over HTTPS
+# CADDY_HTTP_PORT=80
+# CADDY_HTTPS_PORT=443
+# CADDY_CHAT_PORT=8080
+# (admin username + bcrypt hash live in ./Caddyfile, not here)
+
 # ─── Model storage ───────────────────────────────────────────────────────────
 # Mount a host directory for model storage so models survive container/volume
 # removal. Leave commented out to store models in the Docker volume.

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ dist/
 /agent
 *.pid
 .env
+# Rendered from Caddyfile.template by `setup.sh install --secure`; contains the
+# admin bcrypt hash, so it must never be committed. The template is tracked.
+/Caddyfile
 .claude/
 debug_output.txt

--- a/Caddyfile.template
+++ b/Caddyfile.template
@@ -1,0 +1,62 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  llama-toolchest — Caddy reverse proxy: HTTPS + single-admin Basic Auth
+# ─────────────────────────────────────────────────────────────────────────────
+#
+#  ⚠️  BEST-EFFORT SECURITY — PLEASE READ
+#
+#      This configuration is provided as a convenience starting point, AS-IS
+#      and WITHOUT WARRANTY. It has NOT been hardened for any specific threat
+#      model. YOU are responsible for reviewing and auditing it before relying
+#      on it — including (but not limited to): TLS/cipher policy, the
+#      authentication mechanism and its strength, which ports are exposed, rate
+#      limiting, request-size limits, logging/PII, and your host firewall and
+#      network policy. If this server is reachable from an untrusted network,
+#      treat the security of the deployment as your responsibility.
+#
+#      See docs/secure.md for the threat model this does and does NOT address.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+#  This file is a TEMPLATE. `setup.sh install --secure` renders it to ./Caddyfile,
+#  replacing the placeholder tokens (each written as AT-AT NAME AT-AT) with:
+#    GLOBAL        global options block (ACME email for Let's Encrypt, or empty)
+#    SITE_ADDRESS  e.g. ":443" (self-signed / internal CA) or "llm.example.com"
+#    CHAT_ADDRESS  e.g. ":8080" or "llm.example.com:8080"
+#    AUTH_USER     admin username
+#    AUTH_HASH     bcrypt hash from: caddy hash-password
+#  To deploy by hand, copy this file to ./Caddyfile and substitute those tokens.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@@GLOBAL@@
+
+# Management UI + API + OpenAI-compatible inference proxy.
+@@SITE_ADDRESS@@ {
+	@@TLS@@
+	# /v1/* is the OpenAI-compatible API. It is INTENTIONALLY not behind Basic
+	# Auth: programmatic clients authenticate with the app's own Bearer
+	# api_key (set under Settings). A Basic-Auth challenge here would collide
+	# with the "Authorization: Bearer …" header those clients send.
+	@v1 path /v1 /v1/*
+	handle @v1 {
+		reverse_proxy llama-toolchest:3000
+	}
+
+	# Everything else — the web UI and the /api/* management endpoints —
+	# requires the single admin login.
+	handle {
+		basic_auth {
+			@@AUTH_USER@@ @@AUTH_HASH@@
+		}
+		reverse_proxy llama-toolchest:3000
+	}
+}
+
+# llama.cpp router chat UI (the in-app "Open Chat UI →" link points here),
+# behind the same admin login. Programmatic API clients should use the /v1
+# endpoint on the main site above, not this port.
+@@CHAT_ADDRESS@@ {
+	@@TLS@@
+	basic_auth {
+		@@AUTH_USER@@ @@AUTH_HASH@@
+	}
+	reverse_proxy llama-toolchest:8080
+}

--- a/README.md
+++ b/README.md
@@ -156,12 +156,22 @@ auto_start: false           # Start the inference router on container startup
 
 To persist models on the host filesystem (so they survive `docker volume rm`), set `LLAMA_TOOLCHEST_MODELS_DIR=/path/to/models` in `.env` before running `setup.sh`. Existing models in the volume won't be visible after switching — move them first.
 
+`external_url` and `llama_port` can also be set from the environment (`LLAMA_TOOLCHEST_EXTERNAL_URL`, `LLAMA_TOOLCHEST_LLAMA_PORT`), which overrides the YAML — handy for container deploys that inject values via compose.
+
+### Securing with HTTPS + a login
+
+By default the UI, management API, and inference ports are served over plain HTTP with no authentication. For deployments reachable beyond a trusted LAN, `./setup.sh install --secure` puts a [Caddy](https://caddyserver.com) reverse proxy in front for HTTPS (self-signed or Let's Encrypt) and a single admin login. It's interactive, or fully scriptable with flags. See **[docs/secure.md](docs/secure.md)**.
+
+> ⚠️ The bundled Caddy config is a best-effort starting point, provided as-is — you are responsible for auditing it for your own threat model.
+
 ## Ports
 
 | Port | Service |
 |------|---------|
 | 3000 | Management UI + OpenAI proxy (`/v1`) |
 | 8080 | llama.cpp router + built-in chat UI |
+
+In a [secure install](docs/secure.md), Caddy fronts these on `443` (UI/API/`/v1`) and `8080` (chat UI) with `80` redirecting to HTTPS, and the app itself is bound to loopback.
 
 ## GPU Backend Notes
 

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -16,8 +16,8 @@ services:
     image: localhost/llama-toolchest:latest
     container_name: llama-toolchest
     ports:
-      - "${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI
-      - "${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"   # llama-server router (chat UI + inference)
+      - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI
+      - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"   # llama-server router (chat UI + inference)
     volumes:
       - llama-toolchest-data:/data:z
     env_file:

--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -16,8 +16,8 @@ services:
     image: localhost/llama-toolchest:latest
     container_name: llama-toolchest
     ports:
-      - "${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI
-      - "${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"   # llama-server router (chat UI + inference)
+      - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI
+      - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"   # llama-server router (chat UI + inference)
     volumes:
       - llama-toolchest-data:/data:z
     env_file:

--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -19,8 +19,8 @@ services:
     image: localhost/llama-toolchest:latest
     container_name: llama-toolchest
     ports:
-      - "${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI
-      - "${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"   # llama-server router (chat UI + inference)
+      - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI
+      - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"   # llama-server router (chat UI + inference)
     volumes:
       - llama-toolchest-data:/data:z
     devices:

--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -1,0 +1,44 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  Secure overlay — puts a Caddy reverse proxy (HTTPS + single-admin Basic Auth)
+#  in front of llama-toolchest. Stack it on a base GPU compose file:
+#
+#    docker compose -f docker-compose.cuda.yml -f docker-compose.secure.yml up -d
+#
+#  `setup.sh install --secure` wires this automatically (and renders ./Caddyfile
+#  from Caddyfile.template). In secure mode the base app ports are bound to
+#  loopback via LLAMA_TOOLCHEST_BIND (set in .env), so only Caddy faces the
+#  network.
+#
+#  ⚠️  BEST-EFFORT SECURITY: the bundled Caddy config is a convenience starting
+#      point, not a hardened deployment. You are responsible for auditing it for
+#      your own threat model. See Caddyfile.template / docs/secure.md.
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+  llama-toolchest:
+    # Make the UI's chat/API links render with the externally reachable URL.
+    # Read by config.Load's env override, so we don't have to edit the config
+    # baked into the /data volume.
+    environment:
+      LLAMA_TOOLCHEST_EXTERNAL_URL: "${LLAMA_TOOLCHEST_EXTERNAL_URL:-https://localhost}"
+
+  caddy:
+    image: docker.io/library/caddy:2   # fully-qualified for Podman short-name resolution
+    container_name: llama-toolchest-caddy
+    depends_on:
+      - llama-toolchest
+    ports:
+      - "${CADDY_HTTP_PORT:-80}:80"      # ACME HTTP-01 challenge + HTTP→HTTPS redirect
+      - "${CADDY_HTTPS_PORT:-443}:443"   # management UI + API + /v1
+      - "${CADDY_CHAT_PORT:-8080}:8080"  # router chat UI (matches the in-app link)
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro,z
+      - caddy-data:/data:z       # persisted certs / ACME account — do not delete casually
+      - caddy-config:/config:z
+    restart: unless-stopped
+
+volumes:
+  caddy-data:
+    name: llama-toolchest-caddy-data
+  caddy-config:
+    name: llama-toolchest-caddy-config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     image: localhost/llama-toolchest:latest
     container_name: llama-toolchest
     ports:
-      - "${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI
-      - "${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"   # llama-server router (chat UI + inference)
+      - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_PORT:-3000}:3000"   # llama-toolchest management UI
+      - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"   # llama-server router (chat UI + inference)
     volumes:
       - llama-toolchest-data:/data:z
     devices:

--- a/docs/secure.md
+++ b/docs/secure.md
@@ -1,0 +1,211 @@
+# Securing llama-toolchest (HTTPS + admin login)
+
+By default llama-toolchest serves its web UI, management API, and inference
+endpoints over **plain HTTP with no authentication**. That's fine on a trusted
+LAN or behind a VPN/Tailscale, but if the server is reachable from an untrusted
+network you'll want HTTPS and a login in front of it.
+
+The **secure install** option does this by running a [Caddy](https://caddyserver.com)
+reverse proxy in a second container: Caddy terminates TLS and enforces a single
+admin Basic-Auth account, and llama-toolchest itself is bound to loopback so
+nothing but Caddy faces the network.
+
+> ## ⚠️ Best-effort security — please read
+>
+> The bundled Caddy configuration is provided as a **convenience starting
+> point, AS-IS and without warranty**. It has **not** been hardened for any
+> specific threat model. **You are responsible for reviewing and auditing it**
+> before relying on it — including TLS/cipher policy, the strength of the
+> authentication, which ports are exposed, rate limiting, request-size limits,
+> logging/PII, and your host firewall and network policy.
+>
+> The rendered config lives at `./Caddyfile` (generated from
+> [`Caddyfile.template`](../Caddyfile.template)). Read it. If this server is
+> reachable from an untrusted network, treat the security of the deployment as
+> **your** responsibility.
+
+---
+
+## What it protects (and what it doesn't)
+
+| Surface | Without secure install | With secure install |
+|---|---|---|
+| Web UI (`/`, `/server`, `/settings`, …) | open, HTTP | HTTPS + admin login |
+| Management API (`/api/*`) | open, HTTP | HTTPS + admin login |
+| OpenAI API (`/v1/*`) | optional Bearer key, HTTP | HTTPS; Bearer `api_key` (no Basic Auth, so clients work) |
+| Router chat UI / raw inference (`:8080`) | open, HTTP, bypasses the key | HTTPS + admin login via Caddy; raw port no longer LAN-exposed |
+
+**Not** addressed (your responsibility): OS/container hardening, firewalling,
+keeping images patched, rate limiting, DDoS, securing the host itself, and
+anything specific to your environment. One admin account is the only identity —
+there is no multi-user/RBAC.
+
+---
+
+## Prerequisites
+
+- A **container** install (Docker or Podman). Secure mode is container-only; it
+  can't be combined with `--host`.
+- For **Let's Encrypt**: a public DNS name pointing at the host, and inbound
+  ports **80 and 443** reachable from the internet.
+- For **self-signed**: nothing extra — works on any LAN/IP.
+- **Rootless Podman:** binding ports 80/443 requires lowering the kernel's
+  unprivileged-port floor. The installer detects this and offers to set
+  `net.ipv4.ip_unprivileged_port_start=80` (host-wide, persisted, needs sudo).
+  Decline if you'd rather run rootful Podman, or set `CADDY_HTTP_PORT` /
+  `CADDY_HTTPS_PORT` to values ≥ 1024 in `.env` (and adjust your URL
+  accordingly).
+
+---
+
+## Quick start — self-signed (LAN / homelab)
+
+```bash
+./setup.sh install --secure
+```
+
+You'll be asked for the TLS mode (pick **self-signed**), an admin username, and
+a password. That's it. Caddy serves its own internal-CA certificate.
+
+- Open `https://<host>` — your browser will show a **certificate warning** until
+  you trust Caddy's root CA (it's self-signed; that's expected). To remove the
+  warning, export Caddy's root and import it into your OS/browser trust store:
+  ```bash
+  docker exec llama-toolchest-caddy \
+    cat /data/caddy/pki/authorities/local/root.crt > caddy-root.crt
+  # then import caddy-root.crt into your trust store
+  ```
+
+## Quick start — Let's Encrypt (public domain)
+
+```bash
+./setup.sh install --secure --tls letsencrypt \
+  --domain llm.example.com --acme-email you@example.com
+```
+
+Caddy automatically obtains and renews a trusted certificate. Make sure
+`llm.example.com` resolves to this host and ports 80/443 are reachable.
+
+---
+
+## Non-interactive / scripted installs
+
+Every prompt can be supplied by a flag or environment variable, and `--yes`
+skips confirmations (required when stdin isn't a TTY).
+
+| Flag | Env | Meaning |
+|---|---|---|
+| `--secure` / `--no-secure` | `SECURE=1` | enable/disable the Caddy proxy |
+| `--tls self-signed\|letsencrypt` | `TLS_MODE` | certificate strategy (default `self-signed`) |
+| `--domain <fqdn>` | `DOMAIN` | public domain (required for Let's Encrypt) |
+| `--acme-email <email>` | `ACME_EMAIL` | ACME account email (recommended for LE) |
+| `--auth-user <name>` | `AUTH_USER` | admin username (default `admin`) |
+| `--auth-hash <bcrypt>` | — | precomputed bcrypt hash (best for CI) |
+| `--auth-pass-file <path>` | `AUTH_PASS` | password source, hashed during install |
+| `-y`, `--yes` | `ASSUME_YES=1` | skip confirmations |
+
+**The plaintext password is never accepted on argv** (it would leak via `ps`
+and shell history). Provide it as a precomputed hash, a file, or the `AUTH_PASS`
+env var.
+
+```bash
+# Self-signed, precomputed hash — nothing secret on the command line:
+./setup.sh install --secure --tls self-signed \
+  --auth-user admin \
+  --auth-hash "$(docker run --rm docker.io/library/caddy:2 caddy hash-password --plaintext 's3cret')" \
+  --yes
+
+# Let's Encrypt, password from the environment (hashed during install):
+AUTH_PASS="$(cat ~/secret)" ./setup.sh install --secure --tls letsencrypt \
+  --domain llm.example.com --acme-email you@example.com --auth-user admin --yes
+```
+
+---
+
+## Day-2 operations
+
+These work the same as a normal install and manage **both** containers:
+
+```bash
+./setup.sh up        # start app + Caddy
+./setup.sh down      # stop both
+./setup.sh logs      # follow both
+./setup.sh enable    # start on boot (both)
+./setup.sh disable   # cancel boot autostart
+./setup.sh uninstall # remove both containers (data + cert volumes are kept)
+```
+
+- **Docker / rootful Podman:** autostart is the containers' `unless-stopped`
+  restart policy.
+- **Rootless Podman:** autostart uses systemd **Quadlet** units — a shared
+  network plus an app unit and a Caddy unit (ordered after the app). Both are
+  written to `~/.config/containers/systemd/` and activate on boot via linger.
+
+### Changing the username or password
+
+Re-run the install with new credentials, or regenerate the hash and edit
+`./Caddyfile` directly:
+
+```bash
+docker run --rm docker.io/library/caddy:2 caddy hash-password --plaintext 'newpass'
+# replace the hash after the username in ./Caddyfile, then:
+./setup.sh down && ./setup.sh up
+```
+
+### Connecting API clients
+
+Point OpenAI-compatible clients at the **HTTPS** endpoint and authenticate with
+the app's Bearer `api_key` (set under Settings), **not** the Basic-Auth login:
+
+```
+https://<host>/v1
+```
+
+The router's raw `:8080` is fronted by Caddy with the admin login, so it's for
+the browser chat UI — not for programmatic clients.
+
+---
+
+## How it works (and what to audit)
+
+- **Ports.** In secure mode the app binds to `127.0.0.1` only (loopback), so it
+  is not reachable from the network; Caddy publishes `80` (HTTP→HTTPS redirect +
+  ACME), `443` (UI/API/`/v1`), and `8080` (chat UI). The app's raw router is
+  reachable only from the host itself, on a loopback debug port.
+- **`ExternalURL`.** The installer sets `LLAMA_TOOLCHEST_EXTERNAL_URL=https://…`
+  so the UI's chat/API links render with the externally reachable URL. If you
+  change domains, update it (Settings → External URL, or the env in `.env`).
+- **TLS termination.** Browser ↔ Caddy is encrypted; Caddy ↔ app is plain HTTP
+  over the private container network and never leaves the host.
+- **Auth split.** Everything except `/v1/*` requires Basic Auth. `/v1/*` is left
+  to the app's Bearer `api_key` so OpenAI clients (which send
+  `Authorization: Bearer …`) aren't broken by a Basic-Auth challenge.
+
+Read [`Caddyfile.template`](../Caddyfile.template) and your rendered
+`./Caddyfile` to confirm all of the above matches your expectations before
+exposing the server.
+
+---
+
+## Limitations
+
+- Container installs only (no `--host`).
+- A single admin account (no multi-user, no RBAC, no SSO/OIDC/mTLS).
+- The bundled config is a starting point — **audit it for your threat model.**
+
+## Troubleshooting
+
+- **Browser cert warning (self-signed):** expected. Trust Caddy's root CA (see
+  above) or switch to Let's Encrypt.
+- **Let's Encrypt fails to issue:** confirm the domain resolves to this host and
+  ports 80/443 are reachable from the internet; check `./setup.sh logs`.
+- **Port already in use:** something else holds 80/443/8080. Stop it, or adjust
+  `CADDY_HTTP_PORT` / `CADDY_HTTPS_PORT` / `CADDY_CHAT_PORT` in `.env` (note the
+  chat link expects `8080`). A common case is a **host-mode** llama-toolchest on
+  port 3000 — the installer detects it and offers to stop the host service.
+- **`rootlessport cannot expose privileged port 80` (rootless Podman):** the
+  kernel won't let an unprivileged user bind ports < 1024. Accept the
+  installer's offer to lower `net.ipv4.ip_unprivileged_port_start`, or set
+  `CADDY_HTTP_PORT`/`CADDY_HTTPS_PORT` ≥ 1024, or run rootful Podman.
+- **Chat link points at `http://localhost:8080`:** `ExternalURL` wasn't applied;
+  set it under Settings or via `LLAMA_TOOLCHEST_EXTERNAL_URL`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"gopkg.in/yaml.v3"
 )
@@ -53,8 +54,29 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	applyEnvOverrides(cfg)
 	salvageModelsDir(cfg)
 	return cfg, nil
+}
+
+// applyEnvOverrides lets a few deployment-critical fields be set from the
+// environment, overriding the YAML. This exists so a containerized deploy can
+// inject values through compose `environment:` without editing the config file
+// baked into the image's /data volume — notably ExternalURL, which a reverse
+// proxy (see docs/secure.md) must set so the UI's chat/API links render with
+// the externally reachable scheme and host. Empty/unset env vars are ignored,
+// so they never clobber a YAML value.
+func applyEnvOverrides(cfg *Config) {
+	if v := os.Getenv("LLAMA_TOOLCHEST_EXTERNAL_URL"); v != "" {
+		cfg.ExternalURL = v
+	}
+	if v := os.Getenv("LLAMA_TOOLCHEST_LLAMA_PORT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LlamaPort = n
+		} else {
+			slog.Warn("ignoring non-numeric LLAMA_TOOLCHEST_LLAMA_PORT", "value", v)
+		}
+	}
 }
 
 // salvageModelsDir blanks ModelsDir if it points to a path that doesn't exist

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,6 +31,45 @@ func TestDefaultConfigPathEnvWins(t *testing.T) {
 	}
 }
 
+// TestEnvOverrides verifies the deployment env hooks override YAML (so a
+// reverse-proxy deploy can set ExternalURL via compose) but ignore empty/unset
+// values and non-numeric ports.
+func TestEnvOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "cfg.yaml")
+	if err := os.WriteFile(path, []byte("external_url: \"http://localhost:3000\"\nllama_port: 8080\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set overrides → they win over the YAML.
+	t.Setenv("LLAMA_TOOLCHEST_EXTERNAL_URL", "https://llm.example.com")
+	t.Setenv("LLAMA_TOOLCHEST_LLAMA_PORT", "9090")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ExternalURL != "https://llm.example.com" {
+		t.Errorf("ExternalURL = %q, want env override", cfg.ExternalURL)
+	}
+	if cfg.LlamaPort != 9090 {
+		t.Errorf("LlamaPort = %d, want 9090", cfg.LlamaPort)
+	}
+
+	// Empty env must not clobber the YAML value; non-numeric port is ignored.
+	t.Setenv("LLAMA_TOOLCHEST_EXTERNAL_URL", "")
+	t.Setenv("LLAMA_TOOLCHEST_LLAMA_PORT", "not-a-number")
+	cfg, err = Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ExternalURL != "http://localhost:3000" {
+		t.Errorf("empty env clobbered ExternalURL: %q", cfg.ExternalURL)
+	}
+	if cfg.LlamaPort != 8080 {
+		t.Errorf("non-numeric port should be ignored, got %d", cfg.LlamaPort)
+	}
+}
+
 // TestDefaultConfigPathPrefersExistingConfig verifies the first candidate that
 // actually exists on disk is returned, rather than a fixed canonical path.
 func TestDefaultConfigPathPrefersExistingConfig(t *testing.T) {

--- a/plan/secure-caddy-deploy.md
+++ b/plan/secure-caddy-deploy.md
@@ -1,0 +1,454 @@
+# Plan: Optional Secure Deploy (Caddy reverse proxy) + Scriptable `setup.sh`
+
+> Offer a one-command **secure** container install that puts the llama-toolchest
+> UI and API behind **HTTPS + a single admin login**, using Caddy as a reverse
+> proxy in a second container. No Go code changes. Along the way, give
+> `setup.sh` a proper **non-interactive mode** and an **interactive
+> host-vs-container prompt**, so every install path is both guided *and*
+> scriptable.
+
+---
+
+## 1. Motivation
+
+llama-toolchest is reachable today with **no authentication** on the management
+UI or `/api/*`, and the only auth that exists (`api_key` on `/v1/*`) is sent in
+**plaintext over HTTP**. A few external users are now running it, so we want to
+*offer* (not force) a hardened deployment for anyone exposing it beyond a
+trusted LAN. The registry data and serving already work; this is purely a
+deployment/packaging concern.
+
+Constraints from the maintainer:
+- **No Go changes.** Solve it entirely in compose + Caddy + `setup.sh` + docs.
+- **Low effort to ship and to use** — easy with *or* without Caddy.
+- Must work **interactively and non-interactively** (flags / env), and we must
+  not regress the existing plain install.
+
+---
+
+## 2. Current state (audit)
+
+### 2.1 Security surfaces
+| Surface | Port | Auth today |
+|---|---|---|
+| Management UI (`/`, `/server`, `/models`, `/settings`…) | 3000 | none |
+| Management API (`/api/*` — delete models, start/stop, settings) | 3000 | none |
+| OpenAI proxy (`/v1/*`) | 3000 | optional Bearer `api_key`, plaintext |
+| llama.cpp router (own chat UI + raw inference) | 8080 | none |
+
+Two non-obvious facts that shape the design:
+- **8080 bypasses the `api_key`.** The token only guards 3000's `/v1`; the raw
+  router on 8080 is published and unauthenticated, so a client can reach
+  inference without ever touching the token.
+- **The "Open Chat UI →" link points straight at 8080.** Built in
+  `internal/api/server.go:560-565` as `scheme://host:LlamaPort`, where `scheme`
+  and `host` come from `ExternalURL`. `apiURL` (`server.go:459`) is likewise
+  `ExternalURL + "/v1"`. So **both rendered links derive their scheme from
+  `ExternalURL`** — the reason they show `http` today is simply that
+  `ExternalURL` is an `http://…` value. `LlamaPort` is dual-purpose: it's both
+  the port in that external link *and* the in-container port the app uses to
+  reach the router (`proxy.go:35`, `settings.go:119`), so it can't be
+  repurposed to point the link elsewhere without Go changes.
+
+### 2.2 `setup.sh` interactivity vs. flags
+- **Flags are boolean-only.** The parser (`main()`, ~setup.sh:1507-1538) is a
+  `case` loop of bare toggles; nothing ever `shift`s a value. There is **no
+  `--flag value` / `--flag=value` support**.
+- **Partial env-var inputs** exist (`INSTALL_MODE`, `HOST_INSTALL_MODE`, `GPU`,
+  `LT_VERSION`, `LLAMA_TOOLCHEST_MODELS_DIR`).
+- **No deliberate non-interactive mode.** `prompt_confirm` / `prompt_ports` /
+  `prompt_models_dir` call `read` unconditionally; there is no `--yes`/`-y`, no
+  `ASSUME_YES`, and no `[ -t 0 ]` TTY guard. EOF behavior is accidental:
+  `prompt_confirm` is usually called as `if ! prompt_confirm …`, and in that
+  condition context `set -e` is suppressed so an EOF read falls through to the
+  default and auto-accepts — but `prompt_ports`' bare `read` loops run with
+  `set -e` active and **hard-abort on EOF** in the port-conflict path. Net:
+  scriptable installs work by luck in the happy path and crash otherwise.
+- **No interactive mode selection.** `install` defaults to `container`
+  (`INSTALL_MODE="${INSTALL_MODE:-container}"`, setup.sh:36) and only switches
+  to host via `--host`/`--from-source`/`--cuda`/etc. There is no prompt.
+- **No args → help.** `command="${1:-help}"` (setup.sh:1501) → prints usage and
+  exits. Bare `./setup.sh` does not start an install.
+- **Single compose chokepoint.** `compose_cmd()` (setup.sh:878) already stacks
+  `-f docker-compose.models.yml` conditionally — the exact seam for adding a
+  secure overlay.
+
+---
+
+## 3. Goals / non-goals
+
+**Goals**
+1. A second-container **Caddy** secure deploy: HTTPS + single admin Basic-Auth
+   account, selectable as **self-signed (internal CA)** or **Let's Encrypt**.
+2. Close the 8080 bypass and keep the in-app chat/API links working over TLS,
+   with **zero Go changes**.
+3. A **general non-interactive foundation** for `setup.sh` (`--yes`, TTY guard,
+   `--flag value` parsing) that benefits every install, not just the secure one.
+4. An **interactive host-vs-container prompt** so host mode is discoverable
+   without knowing `--host`.
+5. Plain (non-secure) install behavior is **byte-for-byte unchanged** by default.
+6. Secure mode works under **both compose and Podman Quadlet (systemd)**:
+   `up`/`down`/`enable`/`disable` and boot-autostart manage *both* containers.
+
+**Non-goals**
+- No RBAC / multi-user / per-user keys — exactly one admin account.
+- No Go-side auth, sessions, or login page.
+- No change to the default no-args behavior (still prints help).
+
+Note: secure mode is supported under **both** compose and Podman Quadlet, so
+`up`/`down`/`enable`/boot-autostart behave identically to plain installs — see §6A.
+
+---
+
+## 4. Architecture — the secure overlay
+
+Caddy becomes the **only LAN-facing container**. The app publishes nothing to
+the LAN (loopback-only, for host-local debugging). Caddy reaches the app over
+the compose network by service name and terminates TLS at the edge; the
+Caddy↔app hop is plain HTTP but never leaves the host.
+
+```
+                       ┌──────────── Caddy (TLS + Basic Auth) ───────────┐
+LAN ── 443  ──────────►│  / , /api/*   → llama-toolchest:3000  (gated)    │
+LAN ── 8080 ──────────►│  chat UI      → llama-toolchest:8080  (gated)    │
+LAN ── 443/v1 ────────►│  /v1/*        → llama-toolchest:3000  (Bearer)   │
+LAN ── 80   ──────────►│  → 308 redirect to 443                          │
+                       └──────────────── internal compose net ───────────┘
+   llama-toolchest 3000/8080 bound to 127.0.0.1 only (not LAN-reachable)
+```
+
+### 4.1 Port handling
+Compose **appends** `ports` lists across overlay files, so an overlay can't
+*remove* a published port. Therefore the base files are parameterized with a
+bind-interface prefix:
+
+```yaml
+# docker-compose.{cuda,rocm,cpu}.yml
+ports:
+  - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_PORT:-3000}:3000"
+  - "${LLAMA_TOOLCHEST_BIND:-}${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"
+```
+
+- Default `LLAMA_TOOLCHEST_BIND` is empty → `"3000:3000"` exactly as today
+  (**no behavior change** for plain installs).
+- Secure `.env` sets `LLAMA_TOOLCHEST_BIND=127.0.0.1:` → `"127.0.0.1:3000:3000"`,
+  binding loopback-only. Caddy still reaches the app via the compose network.
+
+### 4.2 Chat link + API endpoint over TLS
+The secure `.env` sets `ExternalURL=https://<domain-or-host>`. Because both
+links derive their scheme from `ExternalURL`:
+- `apiURL`  → `https://host/v1`     → Caddy:443 → app:3000 `/v1`
+- `chatURL` → `https://host:8080`   → Caddy:8080 → app:8080 (router chat UI)
+
+Caddy listens on **8080 too** (TLS + auth), so the existing `https://host:8080`
+link resolves to Caddy instead of the raw router — the chat link works
+unchanged, now authenticated. **Invariant:** `ExternalURL` must match the Caddy
+front (`https://…`); the installer owns this, users shouldn't hand-edit it.
+
+### 4.3 Auth model
+- **UI + `/api/*`**: Caddy `basic_auth` (single account, bcrypt hash).
+- **`/v1/*`**: **exempted** from `basic_auth` (OpenAI clients send
+  `Authorization: Bearer`, which collides with Basic). Relies on the app's
+  existing optional `api_key`, now over TLS.
+- **Consequence:** anyone who pointed a client at `:8080/v1` directly now hits
+  Basic-Auth. Intended — `docs/secure.md` directs programmatic clients to the
+  443 `/v1` endpoint.
+
+---
+
+## 5. Caddyfile design
+
+Templated via env placeholders so no secrets are baked into the file:
+
+```caddyfile
+{
+    # ACME email only used in Let's Encrypt mode; harmless otherwise.
+    email {$ACME_EMAIL}
+}
+
+# Site address is the domain (LE) or :443 (self-signed/internal CA).
+{$CADDY_SITE_ADDRESS} {
+    @v1 path /v1 /v1/*
+    handle @v1 {
+        reverse_proxy llama-toolchest:3000
+    }
+    handle {
+        basic_auth {
+            {$CADDY_AUTH_USER} {$CADDY_AUTH_HASH}
+        }
+        reverse_proxy llama-toolchest:3000
+    }
+}
+
+# Router chat UI, behind the same login.
+{$CADDY_CHAT_ADDRESS} {
+    basic_auth {
+        {$CADDY_AUTH_USER} {$CADDY_AUTH_HASH}
+    }
+    reverse_proxy llama-toolchest:8080
+}
+```
+
+- **Self-signed / internal CA:** `CADDY_SITE_ADDRESS=:443`,
+  `CADDY_CHAT_ADDRESS=:8080`. Caddy serves its internal-CA cert; browser shows a
+  trust warning until the root is imported. Works on any IP/LAN, zero config.
+- **Let's Encrypt:** `CADDY_SITE_ADDRESS=<domain>`,
+  `CADDY_CHAT_ADDRESS=<domain>:8080`, `ACME_EMAIL` set. Requires the domain's
+  public DNS → this host and reachable ACME challenge (HTTP-01 on 80 or TLS-ALPN
+  on 443). The same cert covers the `:8080` site.
+
+`docker-compose.secure.yml` (sketch):
+```yaml
+services:
+  caddy:
+    image: caddy:2
+    container_name: llama-toolchest-caddy
+    depends_on: [llama-toolchest]
+    ports:
+      - "80:80"
+      - "443:443"
+      - "${LLAMA_TOOLCHEST_INFERENCE_PORT:-8080}:8080"
+    environment:
+      CADDY_SITE_ADDRESS: "${CADDY_SITE_ADDRESS}"
+      CADDY_CHAT_ADDRESS: "${CADDY_CHAT_ADDRESS}"
+      CADDY_AUTH_USER: "${CADDY_AUTH_USER}"
+      CADDY_AUTH_HASH: "${CADDY_AUTH_HASH}"
+      ACME_EMAIL: "${ACME_EMAIL:-}"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro,z
+      - caddy-data:/data:z      # persisted certs / ACME account
+      - caddy-config:/config:z
+    restart: unless-stopped
+volumes:
+  caddy-data:
+  caddy-config:
+```
+
+---
+
+## 6. `setup.sh` changes
+
+### 6.1 Non-interactive foundation (general)
+- Add `--yes` / `-y` and `ASSUME_YES=1`.
+- Add a TTY guard: compute `INTERACTIVE` from `[ -t 0 ]` (and `ASSUME_YES`).
+  When **not** interactive and `--yes` not given for a flow that needs input,
+  **fail fast** with a message listing the required flags — instead of today's
+  luck-of-the-draw EOF behavior.
+- `prompt_confirm`: return success immediately when `ASSUME_YES`.
+- `prompt_ports` / `prompt_models_dir` / all new prompts: when non-interactive,
+  use the value already supplied via flag/env and skip `read`.
+
+### 6.2 Value-bearing flag parsing
+Extend the `main()` `case` loop to consume `--flag value` and `--flag=value`
+(a small helper that detects `=` or shifts the next arg). Needed for §6.4.
+
+### 6.3 Interactive host-vs-container prompt (NEW)
+For the `install` command, when **mode was not set explicitly**
+(`INSTALL_MODE_EXPLICIT=false`, i.e. no `--host`/`--container`/`--from-*`/
+`--cuda`/`--rocm`/`--vulkan` and no `INSTALL_MODE` env) **and** interactive,
+prompt before the host short-circuit (~setup.sh:1630):
+
+```
+Install mode:
+  1) Container (Docker/Podman) — recommended, isolated     [default]
+  2) Host (install directly on this machine)
+Choose [1]:
+```
+
+- Choosing host sets `INSTALL_MODE=host` and continues into the existing
+  host flow (which already prompts for SDK backends).
+- Non-interactive without a mode flag keeps the current default (`container`);
+  no new required flag.
+- Only `install` prompts. `up/down/logs/rebuild/quick` keep auto-detecting the
+  existing install.
+- No-args behavior is unchanged (still prints help).
+
+### 6.4 Secure flags + flow
+| Flag | Env | Meaning |
+|---|---|---|
+| `--secure` / `--no-secure` | `SECURE=1` | enable/disable the Caddy stack |
+| `--tls self-signed\|letsencrypt` | `TLS_MODE` | cert strategy (default self-signed) |
+| `--domain <fqdn>` | `DOMAIN` | required for Let's Encrypt |
+| `--acme-email <email>` | `ACME_EMAIL` | LE account registration |
+| `--auth-user <name>` | `AUTH_USER` | admin username (default `admin`) |
+| `--auth-hash <bcrypt>` | — | precomputed hash (preferred non-interactive) |
+| `--auth-pass-file <path>` | `AUTH_PASS` | plaintext source, hashed during install |
+
+Interactive flow (slots in after `prompt_models_dir`, only when not already
+answered by flags), container mode only:
+```
+Enable access control + HTTPS (Caddy reverse proxy)? [y/N]
+  └─ TLS: 1) self-signed (LAN, browser warning)  2) Let's Encrypt (public domain)
+        └─ if 2: Domain? ___    ACME email? ___
+  └─ Admin username [admin]: ___
+  └─ Admin password: ***   (confirm) ***
+```
+
+### 6.5 Secret handling (decided: hash/file/env, no `--auth-pass`)
+Never accept the plaintext password on argv (leaks via `ps`/history).
+Precedence:
+1. `--auth-hash` — precomputed bcrypt; nothing secret in argv. Best for CI.
+2. `--auth-pass-file` / `AUTH_PASS` env — plaintext stays out of argv; hashed
+   during install.
+3. Interactive `read -rs` (confirm twice).
+
+Hashing uses the Caddy image itself so there's no host dependency:
+`$CONTAINER_CMD run --rm caddy:2 caddy hash-password --plaintext "$pw"`.
+Only the resulting bcrypt hash is written to `.env` (`CADDY_AUTH_HASH`).
+
+### 6.6 Wiring
+- A `SECURE` global makes `compose_cmd()` append `-f docker-compose.secure.yml`.
+- Secure mode works under both compose and Quadlet (§6A); no path is disabled.
+- `write_env_file()` additions when secure: `LLAMA_TOOLCHEST_BIND=127.0.0.1:`,
+  `ExternalURL=https://<domain-or-host>`, `CADDY_SITE_ADDRESS`,
+  `CADDY_CHAT_ADDRESS`, `CADDY_AUTH_USER`, `CADDY_AUTH_HASH`, `ACME_EMAIL`.
+- Final summary prints the `https://…` URLs and (self-signed) the
+  trust-the-root hint.
+
+## 6A. Dual-container Quadlet (systemd) support
+
+The single-container Quadlet path today (`generate_quadlet`, setup.sh:1053; one
+`.container` named by the hardcoded `PODMAN_SERVICE_NAME`) is the rootless-Podman
+autostart mechanism — `up`/`down`/`logs`/`enable`/`disable`/`uninstall` all key
+off that one service name. Secure mode needs the same systemd integration for
+**two** containers, so these paths become **set-aware**.
+
+### 6A.1 Unit layout (rootless Podman, secure mode)
+Generate three units instead of one, mirroring the compose topology so a single
+`Caddyfile` serves both:
+- `llama-toolchest.network` — shared Podman network providing name-based DNS.
+- `llama-toolchest.container` — the app. `Network=llama-toolchest.network`, GPU
+  args + data volume as today, but **no host `PublishPort`** (Caddy fronts it).
+- `llama-toolchest-caddy.container` — Caddy. `Network=llama-toolchest.network`,
+  `PublishPort=443/80/${INFERENCE_PORT}`, the `CADDY_*`/`ACME_EMAIL` env, and
+  `Caddyfile` + `caddy-data`/`caddy-config` volume mounts. Ordered after the app:
+  `After=llama-toolchest.service` + `Requires=llama-toolchest.service`.
+
+**Why `.network` + two `.container`, not a `.pod`:** a pod shares one network
+namespace, and both the router and Caddy's chat site bind **8080** — they would
+collide in a shared namespace. Separate containers on a network (as in compose)
+avoid the collision and let Caddy reach `llama-toolchest:3000` / `:8080` by name,
+so the **same Caddyfile works for compose and Quadlet** (service-name DNS).
+
+### 6A.2 Boot autostart
+Each `.container` unit carries `[Install] WantedBy=default.target`, so the
+Quadlet generator auto-activates **both** at boot; `Requires=`/`After=` orders
+Caddy after the app. Rootless still needs `loginctl enable-linger` (already
+handled). Docker / rootful-Podman don't use Quadlet — autostart is the
+`restart: unless-stopped` policy, which both the base app service and the
+secure overlay's `caddy` service already declare; `enable`/`disable` updates the
+policy on **both** containers.
+
+### 6A.3 Set-aware command paths
+Introduce a `quadlet_units()` helper returning the unit basenames for the current
+install — `["llama-toolchest"]` plain, or
+`["llama-toolchest", "llama-toolchest-caddy"]` (+ the `.network`) secure — and
+refactor the single-name call sites to iterate it:
+- `container_up`: start app → caddy (or start caddy and let `Requires=` pull the
+  app); `container_down`: stop caddy → app.
+- `has_quadlet`: unchanged trigger (app `.container` present); a `secure_quadlet`
+  check additionally detects the caddy unit.
+- `autostart_enable`/`disable` (rootless): write/remove the whole unit set +
+  `daemon-reload`; boot activation stays automatic via `WantedBy=`.
+- `container_uninstall`: remove all units + the `.network` + (optionally) the
+  `caddy-data`/`caddy-config` volumes.
+- `container_logs`: `journalctl --user -u llama-toolchest -u llama-toolchest-caddy`.
+
+This keeps `up`/`down`/`enable`/`disable`/boot-autostart behaving identically
+whether the install is plain (one unit) or secure (two units + network).
+
+---
+
+## 7. File inventory
+
+**New**
+- `docker-compose.secure.yml` — Caddy overlay.
+- `Caddyfile` — env-templated proxy + auth + TLS.
+- `docs/secure.md` — deploy guide.
+- `plan/secure-caddy-deploy.md` — this document.
+
+**Edited**
+- `docker-compose.cuda.yml`, `docker-compose.rocm.yml`, `docker-compose.cpu.yml`
+  — add `${LLAMA_TOOLCHEST_BIND:-}` prefix to published ports (no-op by default).
+- `setup.sh` — §6 + §6A (non-interactive foundation, value-flag parsing,
+  host/container prompt, secure flow, compose wiring, env writing, usage text,
+  and the set-aware Quadlet refactor: `quadlet_units()` helper + multi-unit
+  generation/up/down/enable/disable/uninstall/logs).
+- `README.md` — pointer to `docs/secure.md`.
+
+*(No Go files touched.)*
+
+---
+
+## 8. Behavior matrix
+
+| Scenario | Result |
+|---|---|
+| `./setup.sh` (no args) | prints help (unchanged) |
+| `install`, interactive, no mode flag | **prompts** host vs container (NEW) |
+| `install` (plain, container) | identical to today; `BIND` empty, no Caddy |
+| `install --secure` interactive | prompts TLS mode, domain/email, user, password |
+| `install --secure …flags… --yes` | fully non-interactive |
+| non-interactive, missing required flag | **fails fast** listing the needed flag (NEW) |
+| secure + Quadlet (rootless Podman) | network + app + caddy units; `up`/`down`/`enable` manage both |
+| secure + Docker / rootful Podman | both containers `unless-stopped`; `enable`/`disable` updates both |
+| `up`/`down` in secure mode | starts/stops **both** containers (compose or Quadlet) |
+| boot autostart in secure mode | both containers start at boot, Caddy ordered after the app |
+| API client at `:8080/v1` in secure mode | now behind Basic-Auth → use `443 /v1` |
+
+---
+
+## 9. Example invocations
+
+```bash
+# Guided (now asks host vs container, then optionally secure):
+./setup.sh install
+
+# Plain container, fully scripted:
+./setup.sh install --container --yes
+
+# Secure, self-signed, scripted (precomputed hash — no secret in argv):
+./setup.sh install --secure --tls self-signed \
+  --auth-user admin --auth-hash "$(caddy hash-password --plaintext 's3cret')" --yes
+
+# Secure, Let's Encrypt, scripted (password via file, hashed during install):
+AUTH_PASS="$(cat ~/secret)" ./setup.sh install --secure --tls letsencrypt \
+  --domain llm.example.com --acme-email me@example.com --auth-user admin --yes
+```
+
+---
+
+## 10. `docs/secure.md` outline
+1. What the secure deploy gives you (TLS + single admin login; what's protected).
+2. Quick start — self-signed (LAN), one command; trusting the internal CA root.
+3. Quick start — Let's Encrypt (domain prerequisites, ports 80/443 reachable).
+4. Interactive vs non-interactive (flag/env reference table).
+5. Changing the username/password (re-run, or regenerate hash + edit `.env`).
+6. Client guidance — UI via 443; programmatic via `https://host/v1` + Bearer.
+7. Limitations — compose-only (no Quadlet); 8080 now authenticated.
+8. Troubleshooting — cert warnings, ACME failures, port conflicts.
+
+---
+
+## 11. Acceptance checklist
+- [ ] `docker-compose.secure.yml` adds Caddy; app ports not LAN-published in secure mode.
+- [ ] Base compose files take `${LLAMA_TOOLCHEST_BIND:-}` with **no default-behavior change**.
+- [ ] `Caddyfile` gates UI/`/api`, exempts `/v1`, fronts 8080 chat, supports both TLS modes.
+- [ ] Chat link + API endpoint resolve over TLS via Caddy (`ExternalURL=https://…`).
+- [ ] `setup.sh`: `--yes`/TTY guard; `--flag value`/`--flag=value` parsing.
+- [ ] `setup.sh`: interactive host-vs-container prompt on `install`.
+- [ ] `setup.sh`: secure flags + interactive flow; secrets never on argv.
+- [ ] Password hashed via the Caddy image; only the bcrypt hash hits `.env`.
+- [ ] Dual-container Quadlet: `.network` + app + caddy units, ordered + boot-enabled (§6A).
+- [ ] `up`/`down`/`logs`/`enable`/`disable`/`uninstall` are set-aware (manage both containers).
+- [ ] Docker / rootful-Podman: `enable`/`disable` toggles restart policy on both containers.
+- [ ] Plain install verified unchanged (diff the rendered compose + `.env`, single Quadlet unit).
+- [ ] `docs/secure.md` written; README points to it; `usage()` documents new flags.
+
+---
+
+## 12. Out of scope / future
+- Go-side native login (single port, single cert, drop the `:8080` site). The
+  cleaner long-term shape, but deliberately deferred — this plan needs no Go.
+- Per-client API keys / rotating credentials.
+- mTLS / SSO / OIDC.

--- a/setup.sh
+++ b/setup.sh
@@ -38,6 +38,22 @@ HOST_INSTALL_MODE="${HOST_INSTALL_MODE:-package}"  # for --host: "package" (down
 HOST_SDK_BACKENDS=()    # backends to install host SDKs for (--cuda/--rocm/--vulkan); empty means autodetect+prompt
 MIGRATE_DIRECTION=""    # "to-host" or "to-container" when command=migrate
 
+# ── Non-interactive + secure-install state ──
+# ASSUME_YES (--yes/-y): skip confirmations and never block on a prompt.
+# INTERACTIVE: computed in main() from whether stdin is a TTY.
+case "${ASSUME_YES:-}" in 1|true|yes|y|Y) ASSUME_YES=true ;; *) ASSUME_YES=false ;; esac
+INTERACTIVE=true
+# SECURE (--secure): deploy behind the bundled Caddy reverse proxy (HTTPS +
+# single-admin Basic Auth). Container mode only. See docs/secure.md.
+case "${SECURE:-}" in 1|true|yes) SECURE=true; SECURE_EXPLICIT=true ;; *) SECURE=false; SECURE_EXPLICIT="${SECURE_EXPLICIT:-false}" ;; esac
+TLS_MODE="${TLS_MODE:-}"        # self-signed | letsencrypt
+DOMAIN="${DOMAIN:-}"            # FQDN, required for letsencrypt
+ACME_EMAIL="${ACME_EMAIL:-}"    # account email for letsencrypt
+AUTH_USER="${AUTH_USER:-}"      # admin username (defaults to "admin" later)
+AUTH_HASH=""                    # bcrypt hash: from --auth-hash, or computed during install
+AUTH_PASS_FILE=""               # --auth-pass-file: path to a file holding the plaintext password
+AUTH_PASS="${AUTH_PASS:-}"      # env-provided plaintext (hashed during install); never accepted on argv
+
 DISTRO_ID=""            # debian, ubuntu, fedora, arch, cachyos, opensuse-leap, etc.
 DISTRO_NAME=""          # Pretty name from os-release
 DISTRO_FAMILY=""        # debian, fedora, arch, suse
@@ -616,20 +632,127 @@ container_exists() {
 is_port_held_by_our_container() {
     local port="$1"
     [[ -z "$CONTAINER_CMD" ]] && return 1
-    for cname in llamactl llama-toolchest; do
+    for cname in llamactl llama-toolchest llama-toolchest-caddy; do
         container_exists "$cname" || continue
         # `docker/podman port <c>` outputs lines like "3000/tcp -> 0.0.0.0:3001".
         # Match the trailing :PORT to confirm this container is the binder.
         local mappings
-        mappings="$($CONTAINER_CMD port "$cname" 2>/dev/null)" || continue
+        mappings="$($CONTAINER_CMD port "$cname" 2>/dev/null)" || mappings=""
         if echo "$mappings" | grep -qE ":${port}(\s|$)"; then
+            return 0
+        fi
+        # `port` can come back empty (host networking, pasta, a stopped
+        # container that still reserves the port via its userspace proxy). Fall
+        # back to the published-port list from inspect, where the host port
+        # shows up as "HostPort":"3000", so we still recognize our own
+        # container instead of flagging a foreign-process conflict.
+        if $CONTAINER_CMD inspect --format '{{json .HostConfig.PortBindings}}' "$cname" 2>/dev/null \
+            | grep -qE "\"${port}\""; then
             return 0
         fi
     done
     return 1
 }
 
+# describe_port_holder prints "name (pid N)" for whatever is listening on a TCP
+# port, or nothing if it can't tell. Used to make port-conflict errors
+# actionable instead of a cryptic "address already in use" after a long build.
+describe_port_holder() {
+    local port="$1" info
+    need_cmd ss || return 0
+    info="$(ss -tlnpH "sport = :${port}" 2>/dev/null | grep -oE '"[^"]+",pid=[0-9]+' | head -1)" || true
+    [[ -z "$info" ]] && return 0
+    local pname="${info%%\",pid=*}"; pname="${pname#\"}"
+    printf '%s (pid %s)' "$pname" "${info##*pid=}"
+}
+
+# preflight_port_check aborts BEFORE the (slow) image build if any host port the
+# new stack needs is occupied by something we don't manage — e.g. a host-mode
+# llama-toolchest running directly on the machine. Our own containers are
+# cleared by stop_existing_containers first, so anything left is a real
+# conflict. If it's our own host process, offer to stop it.
+preflight_port_check() {
+    local ports=()
+    if [[ "$SECURE" == true ]]; then
+        ports=("$LLAMA_TOOLCHEST_PORT" "${SECURE_APP_DEBUG_INF_PORT:-8081}" \
+               "${CADDY_HTTP_PORT:-80}" "${CADDY_HTTPS_PORT:-443}" "${CADDY_CHAT_PORT:-8080}")
+    else
+        ports=("$LLAMA_TOOLCHEST_PORT" "$LLAMA_TOOLCHEST_INFERENCE_PORT")
+    fi
+
+    local p holder conflict=false saw_host=false
+    for p in "${ports[@]}"; do
+        is_port_available "$p" && continue
+        holder="$(describe_port_holder "$p")"
+        err "Port ${p} is already in use${holder:+ by ${holder}}."
+        conflict=true
+        [[ "$holder" == llama-toolchest* || "$holder" == llamactl* ]] && saw_host=true
+    done
+    [[ "$conflict" == false ]] && return 0
+
+    echo ""
+    if [[ "$saw_host" == true ]] && host_is_installed; then
+        echo "  That's a llama-toolchest installed directly on the host. Running it"
+        echo "  alongside the container conflicts now AND again on every reboot"
+        echo "  (the host service stays enabled), so just stopping it isn't enough."
+        if prompt_confirm "Uninstall the host install (stop, disable, remove binary) and continue?"; then
+            host_uninstall
+            local still=false
+            for p in "${ports[@]}"; do is_port_available "$p" || still=true; done
+            [[ "$still" == false ]] && { ok "Host install removed; continuing."; return 0; }
+            err "Ports are still busy after removing the host install."
+        fi
+        echo "  Or remove it yourself, then re-run:  ./setup.sh uninstall --host"
+    else
+        echo "  Stop the process(es) above, or pick different ports, then re-run."
+    fi
+    fatal "Port conflict — not building until the ports are free."
+}
+
+# ensure_unprivileged_ports: rootless Podman cannot bind ports below the kernel's
+# net.ipv4.ip_unprivileged_port_start (default 1024), but the secure stack
+# publishes 80/443. Offer to lower that floor (persisted across reboots, which
+# autostart needs). Only relevant for rootless Podman in secure mode.
+ensure_unprivileged_ports() {
+    [[ "$SECURE" == true ]] || return 0
+    [[ "$CONTAINER_CMD" == "podman" && $EUID -ne 0 ]] || return 0
+    need_cmd sysctl || return 0
+
+    local min_port=65535 p
+    for p in "${CADDY_HTTP_PORT:-80}" "${CADDY_HTTPS_PORT:-443}" "${CADDY_CHAT_PORT:-8080}"; do
+        (( p < min_port )) && min_port="$p"
+    done
+
+    local current
+    current="$(sysctl -n net.ipv4.ip_unprivileged_port_start 2>/dev/null || echo 1024)"
+    (( min_port >= current )) && return 0   # already permitted
+
+    echo ""
+    warn "Rootless Podman can't bind privileged port ${min_port} (kernel floor is ${current})."
+    echo "  The secure stack publishes ports 80/443. Either lower the floor"
+    echo "  (host-wide, one-time, persisted), or set CADDY_HTTP_PORT/CADDY_HTTPS_PORT"
+    echo "  to >= 1024 in .env and adjust your URL — or run rootful Podman."
+    echo ""
+    if prompt_confirm "Lower net.ipv4.ip_unprivileged_port_start to ${min_port}? (needs sudo)"; then
+        run_sudo sysctl -w "net.ipv4.ip_unprivileged_port_start=${min_port}" \
+            || fatal "Failed to set the sysctl. Set CADDY_* ports >= 1024 in .env, or run rootful."
+        if echo "net.ipv4.ip_unprivileged_port_start=${min_port}" \
+            | run_sudo tee /etc/sysctl.d/99-llama-toolchest-ports.conf >/dev/null 2>&1; then
+            ok "Privileged ports enabled for rootless containers (persisted)."
+        else
+            warn "Applied for this session but couldn't persist it; it may reset on reboot."
+        fi
+    else
+        fatal "Privileged ports 80/443 are unavailable to rootless Podman. Set CADDY_HTTP_PORT/CADDY_HTTPS_PORT >= 1024 in .env (and adjust the URL), or run rootful. See docs/secure.md."
+    fi
+}
+
 prompt_ports() {
+    # Non-interactive: accept the configured/flagged ports as-is, no prompting.
+    if [[ "$INTERACTIVE" != true || "$ASSUME_YES" == true ]]; then
+        return
+    fi
+
     echo ""
     echo -e "${BOLD}Port configuration${NC}"
     echo ""
@@ -694,6 +817,11 @@ prompt_ports() {
 }
 
 prompt_models_dir() {
+    # Non-interactive: keep the configured/flagged value (env or .env), no prompt.
+    if [[ "$INTERACTIVE" != true || "$ASSUME_YES" == true ]]; then
+        return
+    fi
+
     echo ""
     echo -e "${BOLD}Model storage${NC}"
     echo ""
@@ -763,6 +891,30 @@ load_env_ports() {
     [[ -n "$val" ]] && LLAMA_TOOLCHEST_INFERENCE_PORT="$val" || true
     val="$(grep '^LLAMA_TOOLCHEST_MODELS_DIR=' "$env_file" 2>/dev/null | cut -d= -f2)" || true
     [[ -n "$val" ]] && LLAMA_TOOLCHEST_MODELS_DIR="$val" || true
+
+    # Remember a prior secure install so up/down/rebuild re-add the Caddy
+    # overlay without needing --secure again. An explicit --secure/--no-secure
+    # on this run always wins.
+    if [[ "$SECURE_EXPLICIT" != true ]]; then
+        val="$(grep '^LLAMA_TOOLCHEST_SECURE=' "$env_file" 2>/dev/null | cut -d= -f2)" || true
+        [[ "$val" == "1" || "$val" == "true" ]] && SECURE=true || true
+    fi
+
+    # Reload the secure-mode values so a rebuild/quick (which re-runs
+    # write_env_file but NOT configure_secure) reproduces the same .env instead
+    # of resetting the external URL/ports to defaults.
+    if [[ "$SECURE" == true ]]; then
+        val="$(grep '^LLAMA_TOOLCHEST_EXTERNAL_URL=' "$env_file" 2>/dev/null | cut -d= -f2-)" || true
+        [[ -n "$val" ]] && SECURE_EXTERNAL_URL="$val" || true
+        val="$(grep '^LLAMA_TOOLCHEST_INFERENCE_PORT=' "$env_file" 2>/dev/null | cut -d= -f2)" || true
+        [[ -n "$val" ]] && SECURE_APP_DEBUG_INF_PORT="$val" || true
+        val="$(grep '^CADDY_HTTP_PORT=' "$env_file" 2>/dev/null | cut -d= -f2)" || true
+        [[ -n "$val" ]] && CADDY_HTTP_PORT="$val" || true
+        val="$(grep '^CADDY_HTTPS_PORT=' "$env_file" 2>/dev/null | cut -d= -f2)" || true
+        [[ -n "$val" ]] && CADDY_HTTPS_PORT="$val" || true
+        val="$(grep '^CADDY_CHAT_PORT=' "$env_file" 2>/dev/null | cut -d= -f2)" || true
+        [[ -n "$val" ]] && CADDY_CHAT_PORT="$val" || true
+    fi
 }
 
 # Legacy rename: copy contents of pre-rebrand 'llamactl-data' Docker volume
@@ -881,6 +1033,10 @@ compose_cmd() {
     if [[ -n "${LLAMA_TOOLCHEST_MODELS_DIR:-}" ]]; then
         cmd+=" -f docker-compose.models.yml"
     fi
+    # Add the Caddy reverse-proxy overlay for secure installs.
+    if [[ "$SECURE" == true ]]; then
+        cmd+=" -f docker-compose.secure.yml"
+    fi
     echo "$cmd"
 }
 
@@ -898,9 +1054,26 @@ write_env_file() {
     local env_file="${SCRIPT_DIR}/.env"
     : > "$env_file"
 
-    # Port configuration
-    echo "LLAMA_TOOLCHEST_PORT=${LLAMA_TOOLCHEST_PORT}" >> "$env_file"
-    echo "LLAMA_TOOLCHEST_INFERENCE_PORT=${LLAMA_TOOLCHEST_INFERENCE_PORT}" >> "$env_file"
+    if [[ "$SECURE" == true ]]; then
+        # Secure mode: only Caddy faces the network. Bind the app to loopback
+        # (host-local debugging) and shift its inference publish off 8080 so it
+        # doesn't collide with Caddy's published chat port. The public surface
+        # is Caddy's 80/443/8080; see docs/secure.md.
+        {
+            echo "LLAMA_TOOLCHEST_SECURE=1"
+            echo "LLAMA_TOOLCHEST_BIND=127.0.0.1:"
+            echo "LLAMA_TOOLCHEST_PORT=${LLAMA_TOOLCHEST_PORT}"
+            echo "LLAMA_TOOLCHEST_INFERENCE_PORT=${SECURE_APP_DEBUG_INF_PORT:-8081}"
+            echo "LLAMA_TOOLCHEST_EXTERNAL_URL=${SECURE_EXTERNAL_URL:-https://localhost}"
+            echo "CADDY_HTTP_PORT=${CADDY_HTTP_PORT:-80}"
+            echo "CADDY_HTTPS_PORT=${CADDY_HTTPS_PORT:-443}"
+            echo "CADDY_CHAT_PORT=${CADDY_CHAT_PORT:-8080}"
+        } >> "$env_file"
+    else
+        # Port configuration
+        echo "LLAMA_TOOLCHEST_PORT=${LLAMA_TOOLCHEST_PORT}" >> "$env_file"
+        echo "LLAMA_TOOLCHEST_INFERENCE_PORT=${LLAMA_TOOLCHEST_INFERENCE_PORT}" >> "$env_file"
+    fi
 
     # Model storage — bind-mount a host directory so models survive volume removal
     if [[ -n "$LLAMA_TOOLCHEST_MODELS_DIR" ]]; then
@@ -920,10 +1093,171 @@ write_env_file() {
     fi
 }
 
+# ─── Secure (Caddy reverse proxy) configuration ──────────────────────────────
+
+print_secure_disclaimer() {
+    echo ""
+    echo -e "${YELLOW}  ⚠  BEST-EFFORT SECURITY${NC}"
+    echo "     The bundled Caddy config is a convenience starting point, provided"
+    echo "     AS-IS with no warranty and NOT hardened for any specific threat"
+    echo "     model. You are responsible for reviewing and auditing it (TLS, auth,"
+    echo "     exposed ports, rate limiting, firewall/network policy) before relying"
+    echo "     on it. See docs/secure.md and the rendered ./Caddyfile."
+    echo ""
+}
+
+# Prompt for host vs container when the user didn't choose explicitly.
+prompt_install_mode() {
+    echo ""
+    echo -e "${BOLD}Install mode${NC}"
+    echo ""
+    echo "  1) Container  (Docker/Podman) — isolated, recommended"
+    echo "  2) Host       (install directly on this machine)"
+    echo ""
+    local choice
+    read -rp "$(echo -e "  ${BOLD}Choose${NC} [1]: ")" choice
+    case "${choice:-1}" in
+        1) INSTALL_MODE="container" ;;
+        2) INSTALL_MODE="host" ;;
+        *) err "Invalid choice: $choice"; prompt_install_mode; return ;;
+    esac
+    INSTALL_MODE_EXPLICIT=true
+}
+
+# caddy_hash_password hashes plaintext via the caddy image, feeding the secret
+# on STDIN (newline-terminated — hash-password reads a line) so it never appears
+# in argv / ps. Echoes the resulting hash. Caddy's basic_auth accepts both
+# bcrypt ($2…) and argon2id ($argon2id$…); the image default is bcrypt.
+caddy_hash_password() {
+    local plaintext="$1" hash
+    hash="$(printf '%s\n' "$plaintext" | $CONTAINER_CMD run --rm -i "$CADDY_IMAGE" caddy hash-password 2>/dev/null || true)"
+    hash="${hash%%$'\n'*}"
+    [[ "$hash" == \$* ]] || return 1
+    printf '%s' "$hash"
+}
+
+# render_caddyfile fills Caddyfile.template into ./Caddyfile. Values are
+# substituted with bash parameter expansion (not sed) so the bcrypt hash's
+# special chars ($ / .) are handled literally.
+render_caddyfile() {
+    local tpl="${SCRIPT_DIR}/Caddyfile.template" out="${SCRIPT_DIR}/Caddyfile"
+    [[ -f "$tpl" ]] || fatal "Missing $tpl"
+    local content; content="$(<"$tpl")"
+    content="${content//@@GLOBAL@@/$CADDY_GLOBAL}"
+    content="${content//@@TLS@@/$CADDY_TLS}"
+    content="${content//@@SITE_ADDRESS@@/$CADDY_SITE_ADDRESS}"
+    content="${content//@@CHAT_ADDRESS@@/$CADDY_CHAT_ADDRESS}"
+    content="${content//@@AUTH_USER@@/$AUTH_USER}"
+    content="${content//@@AUTH_HASH@@/$AUTH_HASH}"
+    printf '%s\n' "$content" > "$out"
+    chmod 600 "$out" 2>/dev/null || true
+    ok "Rendered ./Caddyfile — review it before exposing the server."
+}
+
+# configure_secure resolves all secure-install settings (flags > prompts >
+# defaults), computes the bcrypt hash, and renders ./Caddyfile. Container-only.
+configure_secure() {
+    # Offer it interactively when the user didn't pass --secure/--no-secure.
+    if [[ "$SECURE_EXPLICIT" != true && "$INTERACTIVE" == true && "$ASSUME_YES" != true ]]; then
+        if prompt_confirm "Enable access control + HTTPS (Caddy reverse proxy)?"; then
+            SECURE=true
+        fi
+    fi
+    [[ "$SECURE" == true ]] || return 0
+
+    print_secure_disclaimer
+
+    # ── TLS mode ──
+    if [[ -z "$TLS_MODE" ]]; then
+        if [[ "$INTERACTIVE" == true && "$ASSUME_YES" != true ]]; then
+            echo -e "${BOLD}TLS certificate${NC}"
+            echo "  1) Self-signed / internal CA — works on any LAN/IP; browser shows a warning"
+            echo "  2) Let's Encrypt            — trusted cert; needs a public domain + ports 80/443"
+            local c; read -rp "$(echo -e "  ${BOLD}Choose${NC} [1]: ")" c
+            case "${c:-1}" in 1) TLS_MODE="self-signed" ;; 2) TLS_MODE="letsencrypt" ;; *) fatal "Invalid choice: $c" ;; esac
+        else
+            TLS_MODE="self-signed"
+        fi
+    fi
+    case "$TLS_MODE" in
+        self-signed|letsencrypt) ;;
+        *) fatal "--tls must be 'self-signed' or 'letsencrypt' (got '$TLS_MODE')" ;;
+    esac
+
+    # ── Domain / ACME email (letsencrypt) ──
+    if [[ "$TLS_MODE" == letsencrypt ]]; then
+        if [[ -z "$DOMAIN" && "$INTERACTIVE" == true && "$ASSUME_YES" != true ]]; then
+            read -rp "$(echo -e "  ${BOLD}Public domain (FQDN)${NC}: ")" DOMAIN
+        fi
+        [[ -n "$DOMAIN" ]] || fatal "Let's Encrypt requires a domain (--domain <fqdn>)"
+        if [[ -z "$ACME_EMAIL" && "$INTERACTIVE" == true && "$ASSUME_YES" != true ]]; then
+            read -rp "$(echo -e "  ${BOLD}ACME account email${NC} (optional, recommended): ")" ACME_EMAIL
+        fi
+        [[ -n "$ACME_EMAIL" ]] || warn "No ACME email set; Let's Encrypt registration will be anonymous."
+    fi
+
+    # ── Admin credentials ──
+    [[ -n "$AUTH_USER" ]] || AUTH_USER="admin"
+    if [[ "$INTERACTIVE" == true && "$ASSUME_YES" != true && -z "$AUTH_HASH" && -z "$AUTH_PASS_FILE" && -z "$AUTH_PASS" ]]; then
+        local u; read -rp "$(echo -e "  ${BOLD}Admin username${NC} [${AUTH_USER}]: ")" u
+        [[ -n "$u" ]] && AUTH_USER="$u"
+    fi
+
+    # ── Resolve the bcrypt hash (plaintext never touches argv) ──
+    if [[ -z "$AUTH_HASH" ]]; then
+        local pw=""
+        if [[ -n "$AUTH_PASS_FILE" ]]; then
+            [[ -r "$AUTH_PASS_FILE" ]] || fatal "Cannot read --auth-pass-file: $AUTH_PASS_FILE"
+            pw="$(< "$AUTH_PASS_FILE")"; pw="${pw%%$'\n'*}"
+        elif [[ -n "$AUTH_PASS" ]]; then
+            pw="$AUTH_PASS"
+        elif [[ "$INTERACTIVE" == true && "$ASSUME_YES" != true ]]; then
+            local pw2
+            read -rsp "$(echo -e "  ${BOLD}Admin password${NC}: ")" pw; echo ""
+            read -rsp "$(echo -e "  ${BOLD}Confirm password${NC}: ")" pw2; echo ""
+            [[ "$pw" == "$pw2" ]] || fatal "Passwords do not match"
+        fi
+        [[ -n "$pw" ]] || fatal "No admin password. Provide --auth-hash, --auth-pass-file, or AUTH_PASS (or run interactively)."
+        log "Hashing password via the caddy image..."
+        AUTH_HASH="$(caddy_hash_password "$pw")" || fatal "Failed to hash password (is the caddy:2 image pullable?). Alternatively pass --auth-hash."
+        unset pw
+    fi
+
+    # ── Derive Caddy site addresses + the external URL for the app's links ──
+    local ext_host
+    if [[ "$TLS_MODE" == letsencrypt ]]; then
+        CADDY_SITE_ADDRESS="$DOMAIN"
+        CADDY_CHAT_ADDRESS="${DOMAIN}:${CADDY_CHAT_PORT:-8080}"
+        CADDY_GLOBAL=$'{\n\temail '"${ACME_EMAIL}"$'\n}'
+        CADDY_TLS="# Let's Encrypt cert is provisioned automatically for the domain"
+        ext_host="$DOMAIN"
+    else
+        # Bare port + internal CA. on_demand mints a self-signed cert for
+        # whatever hostname/IP the client uses (localhost, LAN IP, hostname),
+        # so a bare :443 site still presents a certificate instead of failing
+        # the TLS handshake.
+        CADDY_SITE_ADDRESS=":${CADDY_HTTPS_PORT:-443}"
+        CADDY_CHAT_ADDRESS=":${CADDY_CHAT_PORT:-8080}"
+        CADDY_GLOBAL="# self-signed / internal CA — no ACME"
+        CADDY_TLS=$'tls internal {\n\t\ton_demand\n\t}'
+        ext_host="${DOMAIN:-$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo localhost)}"
+    fi
+    local scheme_port=""
+    [[ "${CADDY_HTTPS_PORT:-443}" != "443" ]] && scheme_port=":${CADDY_HTTPS_PORT}"
+    SECURE_EXTERNAL_URL="https://${ext_host}${scheme_port}"
+
+    render_caddyfile
+}
+
 container_up() {
     if has_quadlet; then
         log "Starting llama-toolchest via systemd (Quadlet)..."
-        systemctl_cmd start "${PODMAN_SERVICE_NAME}.service"
+        # Start in order (app first, then Caddy). Each service's Requires=/After=
+        # also pulls its deps, but starting explicitly keeps output clear.
+        local svc
+        while read -r svc; do
+            systemctl_cmd start "$svc"
+        done < <(quadlet_services)
     else
         $(compose_cmd) up -d
     fi
@@ -932,14 +1266,44 @@ container_up() {
 container_down() {
     if has_quadlet; then
         log "Stopping llama-toolchest via systemd (Quadlet)..."
-        systemctl_cmd stop "${PODMAN_SERVICE_NAME}.service"
+        # Stop in reverse order (Caddy first, then app).
+        local svc
+        while read -r svc; do
+            systemctl_cmd stop "$svc" 2>/dev/null || true
+        done < <(quadlet_services | tac)
     else
         $(compose_cmd) down
     fi
 }
 
+# stop_existing_containers clears any running/stopped llama-toolchest containers
+# before a fresh `up`, so their published ports are free. This covers copies a
+# plain `compose up` won't manage: a different compose project name, a Quadlet
+# service, the pre-rename "llamactl" container, or a manually-started one.
+stop_existing_containers() {
+    # If Quadlet owns the containers, stop the services first so systemd doesn't
+    # immediately restart what we remove.
+    if has_quadlet; then
+        local svc
+        while read -r svc; do
+            systemctl_cmd stop "$svc" 2>/dev/null || true
+        done < <(quadlet_services | tac)
+    fi
+    local cname
+    for cname in llama-toolchest-caddy llama-toolchest llamactl; do
+        if container_exists "$cname"; then
+            log "Removing existing container so the new one can bind its ports: $cname"
+            $CONTAINER_CMD stop "$cname" 2>/dev/null || true
+            $CONTAINER_CMD rm "$cname" 2>/dev/null || true
+        fi
+    done
+}
+
 container_install() {
     migrate_legacy_volume
+    stop_existing_containers
+    preflight_port_check
+    ensure_unprivileged_ports
     write_env_file
     $(compose_cmd) up -d --build
 }
@@ -950,13 +1314,14 @@ container_rebuild() {
 
     migrate_legacy_volume
     container_down
-    $CONTAINER_CMD rm llama-toolchest 2>/dev/null || true
+    stop_existing_containers
+    preflight_port_check
+    ensure_unprivileged_ports
     write_env_file
     $(compose_cmd) build --no-cache
 
     if [[ "$quadlet_active" == true ]]; then
-        log "Starting via systemd (Quadlet)..."
-        systemctl_cmd start "${PODMAN_SERVICE_NAME}.service"
+        container_up
     else
         $(compose_cmd) up -d
     fi
@@ -992,7 +1357,12 @@ container_quick_rebuild() {
 
 container_logs() {
     if has_quadlet; then
-        journalctl --user -u "${PODMAN_SERVICE_NAME}.service" -n 100 -f
+        local journal_args=()
+        local svc
+        while read -r svc; do
+            journal_args+=(-u "$svc")
+        done < <(quadlet_services)
+        journalctl --user "${journal_args[@]}" -n 100 -f
     else
         $(compose_cmd) logs -f
     fi
@@ -1003,6 +1373,9 @@ container_logs() {
 readonly QUADLET_USER_DIR="${HOME}/.config/containers/systemd"
 readonly QUADLET_SYSTEM_DIR="/etc/containers/systemd"
 readonly PODMAN_SERVICE_NAME="llama-toolchest"
+# Fully-qualified so it resolves under Podman hosts with no unqualified-search
+# registries configured (Docker ignores the docker.io/library/ prefix).
+readonly CADDY_IMAGE="docker.io/library/caddy:2"
 
 quadlet_dir() {
     if [[ $EUID -eq 0 ]]; then
@@ -1050,7 +1423,21 @@ get_volume_name() {
         || echo "llama-toolchest-data"
 }
 
-generate_quadlet() {
+# quadlet_services echoes the systemd service names for the active mode, in
+# START order (app first, then Caddy). Reverse for stop. The .network unit is
+# pulled in automatically by the containers' Network= dependency, so it isn't
+# listed here.
+quadlet_services() {
+    echo "${PODMAN_SERVICE_NAME}.service"
+    if [[ "$SECURE" == true ]]; then
+        echo "${PODMAN_SERVICE_NAME}-caddy.service"
+    fi
+}
+
+# generate_quadlet_app emits the app .container unit. In secure mode it joins
+# the shared network and publishes NOTHING (Caddy fronts it); otherwise it
+# publishes the UI/inference ports to the host as before.
+generate_quadlet_app() {
     local image_name="localhost/llama-toolchest:latest"
     local volume_name
     volume_name="$(get_volume_name)"
@@ -1072,10 +1459,20 @@ GroupAdd=${HOST_RENDER_GID:-render}
 ${hsa_env}"
     fi
 
+    # Secure mode: no published ports (Caddy is the only network-facing
+    # container), join the shared network, and set ExternalURL so links render
+    # with the externally reachable https URL.
+    local net_args="" ext_url_arg=""
+    if [[ "$SECURE" == true ]]; then
+        net_args="Network=${PODMAN_SERVICE_NAME}.network"
+        ext_url_arg="Environment=LLAMA_TOOLCHEST_EXTERNAL_URL=${SECURE_EXTERNAL_URL:-https://localhost}"
+    fi
+
     cat <<EOF
 # Auto-generated by llama-toolchest setup.sh
 # GPU backend: ${GPU_VENDOR}
 # Runtime: ${CONTAINER_CMD}
+# Mode: $([[ "$SECURE" == true ]] && echo "secure (behind Caddy)" || echo "direct")
 
 [Unit]
 Description=llama-toolchest - local LLM management
@@ -1084,8 +1481,15 @@ After=network-online.target
 [Container]
 Image=${image_name}
 ContainerName=llama-toolchest
-PublishPort=${LLAMA_TOOLCHEST_PORT}:3000
-PublishPort=${LLAMA_TOOLCHEST_INFERENCE_PORT}:8080
+$(if [[ "$SECURE" == true ]]; then
+    echo "PublishPort=127.0.0.1:${LLAMA_TOOLCHEST_PORT}:3000"
+    echo "PublishPort=127.0.0.1:${SECURE_APP_DEBUG_INF_PORT:-8081}:8080"
+else
+    echo "PublishPort=${LLAMA_TOOLCHEST_PORT}:3000"
+    echo "PublishPort=${LLAMA_TOOLCHEST_INFERENCE_PORT}:8080"
+fi)
+${net_args}
+${ext_url_arg}
 Volume=${volume_name}:/data:z
 ${gpu_args}
 
@@ -1098,51 +1502,119 @@ WantedBy=default.target
 EOF
 }
 
+# generate_quadlet_network emits the shared network for the secure two-container
+# stack, giving Caddy name-based DNS to reach the app (matches compose).
+generate_quadlet_network() {
+    cat <<EOF
+# Auto-generated by llama-toolchest setup.sh
+[Unit]
+Description=llama-toolchest reverse-proxy network
+
+[Network]
+NetworkName=llama-toolchest
+EOF
+}
+
+# generate_quadlet_caddy emits the Caddy .container unit (secure mode only).
+# Ordered after the app so the upstream is up first.
+generate_quadlet_caddy() {
+    cat <<EOF
+# Auto-generated by llama-toolchest setup.sh
+[Unit]
+Description=llama-toolchest Caddy reverse proxy (HTTPS + admin login)
+After=${PODMAN_SERVICE_NAME}.service
+Requires=${PODMAN_SERVICE_NAME}.service
+
+[Container]
+Image=${CADDY_IMAGE}
+ContainerName=${PODMAN_SERVICE_NAME}-caddy
+Network=${PODMAN_SERVICE_NAME}.network
+PublishPort=${CADDY_HTTP_PORT:-80}:80
+PublishPort=${CADDY_HTTPS_PORT:-443}:443
+PublishPort=${CADDY_CHAT_PORT:-8080}:8080
+Volume=${SCRIPT_DIR}/Caddyfile:/etc/caddy/Caddyfile:ro,z
+Volume=${PODMAN_SERVICE_NAME}-caddy-data:/data:z
+Volume=${PODMAN_SERVICE_NAME}-caddy-config:/config:z
+
+[Service]
+Restart=on-failure
+TimeoutStartSec=300
+
+[Install]
+WantedBy=default.target
+EOF
+}
+
+# quadlet_write_units (re)writes all unit files for the active mode into the
+# Quadlet dir, removing any stale ones from the other mode first.
+quadlet_write_units() {
+    local qdir="$1"
+    mkdir -p "$qdir"
+    quadlet_remove_unit_files "$qdir"   # clear stale caddy/network when toggling off
+    generate_quadlet_app > "${qdir}/${PODMAN_SERVICE_NAME}.container"
+    if [[ "$SECURE" == true ]]; then
+        generate_quadlet_network > "${qdir}/${PODMAN_SERVICE_NAME}.network"
+        generate_quadlet_caddy   > "${qdir}/${PODMAN_SERVICE_NAME}-caddy.container"
+    fi
+}
+
+# quadlet_remove_unit_files deletes every unit file this script may have written
+# (app + caddy + network), regardless of the current mode, so toggling secure
+# off doesn't leave orphaned units behind.
+quadlet_remove_unit_files() {
+    local qdir="$1"
+    rm -f "${qdir}/${PODMAN_SERVICE_NAME}.container" \
+          "${qdir}/${PODMAN_SERVICE_NAME}-caddy.container" \
+          "${qdir}/${PODMAN_SERVICE_NAME}.network"
+}
+
 autostart_enable() {
     if is_autostart_enabled; then
         ok "Auto-start is already enabled"
         return
     fi
 
-    if [[ "$CONTAINER_CMD" == "docker" ]]; then
-        # Docker: set restart policy on the container
-        if ! docker container exists llama-toolchest 2>/dev/null; then
-            # docker doesn't have "container exists" — check via inspect
-            if ! docker inspect llama-toolchest &>/dev/null; then
-                fatal "Container 'llama-toolchest' not found. Run './setup.sh install' first."
-            fi
-        fi
-        log "Setting restart policy to 'unless-stopped'..."
-        docker update --restart unless-stopped llama-toolchest
-        ok "Auto-start enabled"
-    elif [[ $EUID -eq 0 ]]; then
-        # Podman rootful: restart policy works like Docker
-        if ! podman container exists llama-toolchest 2>/dev/null; then
+    if [[ "$CONTAINER_CMD" == "docker" || $EUID -eq 0 ]]; then
+        # Docker (any user) or rootful Podman: restart policy on the container(s).
+        if ! $CONTAINER_CMD inspect llama-toolchest &>/dev/null; then
             fatal "Container 'llama-toolchest' not found. Run './setup.sh install' first."
         fi
         log "Setting restart policy to 'unless-stopped'..."
-        podman update --restart unless-stopped llama-toolchest
+        $CONTAINER_CMD update --restart unless-stopped llama-toolchest
+        if [[ "$SECURE" == true ]] && $CONTAINER_CMD inspect llama-toolchest-caddy &>/dev/null; then
+            $CONTAINER_CMD update --restart unless-stopped llama-toolchest-caddy
+        fi
         ok "Auto-start enabled"
     else
-        # Podman rootless: need Quadlet + linger to survive reboot
+        # Podman rootless: need Quadlet + linger to survive reboot. In secure
+        # mode this writes the app, Caddy, and network units together.
         local qdir
         qdir="$(quadlet_dir)"
 
-        # If the container is already running outside of systemd, stop it first
-        # so the Quadlet service can take over without a name conflict.
-        local was_running=false
-        if podman container exists llama-toolchest 2>/dev/null; then
-            was_running=true
-            log "Stopping existing container so systemd can take over..."
-            podman stop llama-toolchest 2>/dev/null || true
-            podman rm llama-toolchest 2>/dev/null || true
+        if [[ "$SECURE" == true && ! -f "${SCRIPT_DIR}/Caddyfile" ]]; then
+            fatal "Secure mode but ./Caddyfile is missing — run './setup.sh install --secure' first."
         fi
 
-        log "Installing Quadlet unit: ${qdir}/${PODMAN_SERVICE_NAME}.container"
+        # Stop any containers running outside systemd so the units can take over
+        # without a name conflict.
+        local was_running=false cname
+        for cname in llama-toolchest llama-toolchest-caddy; do
+            if podman container exists "$cname" 2>/dev/null; then
+                was_running=true
+                log "Stopping existing container $cname so systemd can take over..."
+                podman stop "$cname" 2>/dev/null || true
+                podman rm "$cname" 2>/dev/null || true
+            fi
+        done
 
-        mkdir -p "$qdir"
-        generate_quadlet > "${qdir}/${PODMAN_SERVICE_NAME}.container"
+        if [[ "$SECURE" == true ]]; then
+            log "Pulling caddy image..."
+            podman pull "$CADDY_IMAGE" >/dev/null 2>&1 \
+                || warn "Could not pre-pull $CADDY_IMAGE; the unit will pull on first start."
+        fi
 
+        log "Installing Quadlet units in ${qdir}..."
+        quadlet_write_units "$qdir"
         systemctl_cmd daemon-reload
 
         # Enable lingering so user services run without an active login session
@@ -1155,19 +1627,20 @@ autostart_enable() {
             fi
         fi
 
-        # Start the service now if the container was previously running
+        # Start now if something was already running; otherwise the units
+        # auto-activate on boot via WantedBy= (no explicit enable needed).
         if [[ "$was_running" == true ]]; then
-            log "Starting llama-toolchest via systemd..."
-            systemctl_cmd start "${PODMAN_SERVICE_NAME}.service"
+            container_up
         fi
 
-        # Quadlet units are auto-activated by systemd's generator via
-        # WantedBy= in the [Install] section — no explicit enable needed.
         ok "Auto-start enabled via Podman Quadlet"
-
         echo ""
         echo "  llama-toolchest will auto-start on boot."
-        echo "  Manage with: systemctl --user {start,stop,status} ${PODMAN_SERVICE_NAME}"
+        if [[ "$SECURE" == true ]]; then
+            echo "  Manage with: systemctl --user {start,stop,status} ${PODMAN_SERVICE_NAME} ${PODMAN_SERVICE_NAME}-caddy"
+        else
+            echo "  Manage with: systemctl --user {start,stop,status} ${PODMAN_SERVICE_NAME}"
+        fi
     fi
 }
 
@@ -1177,24 +1650,22 @@ autostart_disable() {
         return
     fi
 
-    if [[ "$CONTAINER_CMD" == "docker" ]]; then
+    if [[ "$CONTAINER_CMD" == "docker" || $EUID -eq 0 ]]; then
         log "Setting restart policy to 'no'..."
-        docker update --restart no llama-toolchest
-        ok "Auto-start disabled"
-    elif [[ $EUID -eq 0 ]]; then
-        log "Setting restart policy to 'no'..."
-        podman update --restart no llama-toolchest
+        $CONTAINER_CMD update --restart no llama-toolchest 2>/dev/null || true
+        $CONTAINER_CMD update --restart no llama-toolchest-caddy 2>/dev/null || true
         ok "Auto-start disabled"
     else
         local qdir
         qdir="$(quadlet_dir)"
 
-        log "Removing Quadlet unit: ${qdir}/${PODMAN_SERVICE_NAME}.container"
-
-        # Stop the service, remove the Quadlet file, then reload so
-        # systemd's generator drops the unit entirely.
-        systemctl_cmd stop "${PODMAN_SERVICE_NAME}.service" 2>/dev/null || true
-        rm -f "${qdir}/${PODMAN_SERVICE_NAME}.container"
+        log "Removing Quadlet units from ${qdir}..."
+        # Stop services (Caddy first, then app), drop the unit files, reload.
+        local svc
+        while read -r svc; do
+            systemctl_cmd stop "$svc" 2>/dev/null || true
+        done < <(quadlet_services | tac)
+        quadlet_remove_unit_files "$qdir"
         systemctl_cmd daemon-reload
         ok "Auto-start disabled"
     fi
@@ -1218,6 +1689,13 @@ container_uninstall() {
     if container_exists llama-toolchest; then
         has_container=true
         actions+=("Stop and remove container 'llama-toolchest'")
+    fi
+
+    # Secure installs also have a Caddy sidecar.
+    local has_caddy=false
+    if container_exists llama-toolchest-caddy; then
+        has_caddy=true
+        actions+=("Stop and remove container 'llama-toolchest-caddy'")
     fi
 
     # `image exists` is podman-specific; on Docker we use inspect.
@@ -1251,6 +1729,9 @@ container_uninstall() {
     volume_name="$($CONTAINER_CMD inspect --format '{{range .Mounts}}{{.Name}}{{end}}' llama-toolchest 2>/dev/null || echo "llama-toolchest-data")"
     echo -e "  ${YELLOW}Note:${NC} The data volume (models, builds, config) will be kept."
     echo -e "        To remove it: ${CONTAINER_CMD} volume rm ${volume_name}"
+    if [[ "$has_caddy" == true ]]; then
+        echo -e "        Caddy certs/state are kept too: ${CONTAINER_CMD} volume rm llama-toolchest-caddy-data llama-toolchest-caddy-config"
+    fi
     echo ""
 
     if ! prompt_confirm "Proceed with uninstall?"; then
@@ -1262,6 +1743,13 @@ container_uninstall() {
 
     if [[ "$has_autostart" == true ]]; then
         autostart_disable
+    fi
+
+    if [[ "$has_caddy" == true ]]; then
+        log "Stopping and removing Caddy container..."
+        $CONTAINER_CMD stop llama-toolchest-caddy 2>/dev/null || true
+        $CONTAINER_CMD rm llama-toolchest-caddy 2>/dev/null || true
+        ok "Caddy container removed"
     fi
 
     if [[ "$has_container" == true ]]; then
@@ -1341,8 +1829,26 @@ print_summary() {
     fi
 }
 
+# require_value validates that a value-bearing flag actually got a value (and
+# not the next flag). Echoes the value so callers can capture it.
+require_value() {
+    local flag="$1" val="${2:-}"
+    if [[ -z "$val" || "$val" == -* ]]; then
+        fatal "Flag $flag requires a value"
+    fi
+    printf '%s' "$val"
+}
+
 prompt_confirm() {
     local prompt="$1"
+    # --yes auto-confirms; a non-TTY without --yes can't answer, so fail loudly
+    # rather than block or silently assume.
+    if [[ "$ASSUME_YES" == true ]]; then
+        return 0
+    fi
+    if [[ "$INTERACTIVE" != true ]]; then
+        fatal "Non-interactive shell and --yes not given; cannot answer: '${prompt}'. Re-run with --yes (and any required flags)."
+    fi
     local answer
     read -rp "$(echo -e "${BOLD}${prompt}${NC} [Y/n] ")" answer
     case "${answer:-Y}" in
@@ -1421,10 +1927,34 @@ SDKs in a single run; each implies --host):
                   you a portable fallback alongside the vendor backend.
 
 If no backend flag and no GPU= env is set, setup.sh auto-detects the
-primary GPU and asks whether to add Vulkan as a secondary SDK.
+primary GPU and asks whether to add Vulkan as a secondary SDK. With no
+--host/--container flag, `install` asks interactively which mode to use.
 
 Pin a specific released version with `LT_VERSION=1.0.0 ./setup.sh
 install --host` to avoid hitting the GH API for the latest tag.
+
+Secure install (container only — Caddy reverse proxy for HTTPS + a single
+admin login in front of the UI/API):
+  --secure / --no-secure   Enable/disable the Caddy reverse proxy. Without
+                           either flag, `install` asks interactively.
+  --tls self-signed|letsencrypt   Cert strategy (default self-signed).
+  --domain <fqdn>          Public domain (required for Let's Encrypt).
+  --acme-email <email>     ACME account email (Let's Encrypt; recommended).
+  --auth-user <name>       Admin username (default "admin").
+  --auth-hash <bcrypt>     Precomputed bcrypt hash (from `caddy hash-password`).
+                           Preferred for non-interactive installs.
+  --auth-pass-file <path>  Read the admin password from a file (hashed during
+                           install). The plaintext is NEVER accepted on argv;
+                           use this, AUTH_PASS=… in the env, or --auth-hash.
+
+  ⚠  BEST-EFFORT SECURITY: the bundled Caddy config is a convenience starting
+     point, AS-IS and not hardened for any specific threat model. You are
+     responsible for auditing it before relying on it. See docs/secure.md.
+
+Non-interactive:
+  -y, --yes                Skip confirmation prompts; required when stdin is
+                           not a TTY. Combine with the flags above (and
+                           --host/--container) for a fully scripted install.
 
 Lifecycle:
   install     Detect, install prerequisites, build, and start
@@ -1476,16 +2006,27 @@ Environment variables:
                                 use --cuda/--rocm/--vulkan flags instead)
   RUNTIME=docker|podman         Override container runtime auto-detection
   INSTALL_MODE=host|container   Same as --host / --container
+  ASSUME_YES=1                  Same as --yes
+  SECURE=1                      Same as --secure
+  AUTH_PASS=…                   Admin password for a scripted secure install
+                                (hashed during install; keeps it off argv)
 
 Port configuration is stored in .env (see .env.example for details).
 You can edit .env directly instead of using the interactive setup.
 
 Examples:
-  ./setup.sh install                    # detect, install prereqs, build & run (container)
+  ./setup.sh install                    # detect, install prereqs, build & run (asks mode)
   ./setup.sh install --host             # install latest released package on the host
   ./setup.sh install --rocm --vulkan    # host install, install both ROCm and Vulkan SDKs
   ./setup.sh install --vulkan           # host install, Vulkan SDK only (cross-vendor)
   ./setup.sh install --from-source      # host install, build from local source
+  ./setup.sh install --secure           # container install behind Caddy (asks TLS/login)
+  ./setup.sh install --secure --tls self-signed \
+      --auth-user admin --auth-hash "$(caddy hash-password --plaintext s3cret)" --yes
+                                        # fully scripted self-signed secure install
+  AUTH_PASS="$(cat ~/pw)" ./setup.sh install --secure --tls letsencrypt \
+      --domain llm.example.com --acme-email me@example.com --yes
+                                        # fully scripted Let's Encrypt secure install
   ./setup.sh migrate --to-host          # snapshot container state, install on host
   ./setup.sh migrate --to-container     # opposite direction
   ./setup.sh status --host              # show host install status
@@ -1526,6 +2067,23 @@ main() {
             --to-container)
                 [[ -n "$MIGRATE_DIRECTION" ]] && { err "--to-host and --to-container are mutually exclusive"; exit 1; }
                 MIGRATE_DIRECTION="to-container" ;;
+            # ── Non-interactive ──
+            -y|--yes)       ASSUME_YES=true ;;
+            # ── Secure (Caddy reverse proxy) install ──
+            --secure)       SECURE=true;  SECURE_EXPLICIT=true ;;
+            --no-secure)    SECURE=false; SECURE_EXPLICIT=true ;;
+            --tls)          TLS_MODE="$(require_value "$1" "${2:-}")"; shift ;;
+            --tls=*)        TLS_MODE="${1#*=}" ;;
+            --domain)       DOMAIN="$(require_value "$1" "${2:-}")"; shift ;;
+            --domain=*)     DOMAIN="${1#*=}" ;;
+            --acme-email)   ACME_EMAIL="$(require_value "$1" "${2:-}")"; shift ;;
+            --acme-email=*) ACME_EMAIL="${1#*=}" ;;
+            --auth-user)    AUTH_USER="$(require_value "$1" "${2:-}")"; shift ;;
+            --auth-user=*)  AUTH_USER="${1#*=}" ;;
+            --auth-hash)    AUTH_HASH="$(require_value "$1" "${2:-}")"; shift ;;
+            --auth-hash=*)  AUTH_HASH="${1#*=}" ;;
+            --auth-pass-file)   AUTH_PASS_FILE="$(require_value "$1" "${2:-}")"; shift ;;
+            --auth-pass-file=*) AUTH_PASS_FILE="${1#*=}" ;;
             -h|--help)      usage; exit 0 ;;
             *)
                 err "Unknown flag: $1"
@@ -1534,8 +2092,20 @@ main() {
                 exit 1
                 ;;
         esac
-        shift
+        shift || true
     done
+
+    # --secure implies container mode; reject an explicit host combo.
+    if [[ "$SECURE" == true ]]; then
+        if [[ "$INSTALL_MODE" == "host" ]]; then
+            fatal "--secure (Caddy reverse proxy) is container-only; it can't be combined with --host."
+        fi
+        INSTALL_MODE="container"
+    fi
+
+    # Interactivity: a non-TTY stdin means we can't prompt. Prompts then either
+    # use flag/env values or fail fast asking for --yes (see prompt_confirm).
+    [[ -t 0 ]] || INTERACTIVE=false
 
     # ── Validate flag/command combinations ──
     if [[ -n "$MIGRATE_DIRECTION" && "$command" != "migrate" ]]; then
@@ -1557,6 +2127,13 @@ main() {
             exit 1
             ;;
     esac
+
+    # ── Interactive install: offer host vs container when not chosen ──
+    # Only `install` prompts; stateful commands auto-detect below. A --secure
+    # run already forced container mode (and INSTALL_MODE_EXPLICIT), so it skips.
+    if [[ "$command" == "install" && "$INSTALL_MODE_EXPLICIT" != true && "$INTERACTIVE" == true && "$ASSUME_YES" != true ]]; then
+        prompt_install_mode
+    fi
 
     # ── Auto-route stateful commands by detecting which install is present ──
     # up/down/logs are mode-agnostic from the user's POV: they want to start,
@@ -1580,6 +2157,32 @@ main() {
                         exit 1
                         ;;
                 esac
+                ;;
+        esac
+    fi
+
+    # ── uninstall: detect and remove whatever is installed (both, if present) ──
+    # Without an explicit --host/--container, uninstall used to assume container
+    # and silently leave a host install behind. Detect and route instead.
+    if [[ "$command" == "uninstall" && "$INSTALL_MODE_EXPLICIT" != "true" ]]; then
+        local detected
+        detected="$(detect_install_mode)"
+        case "$detected" in
+            none)
+                ok "Nothing to uninstall — llama-toolchest is not installed."
+                exit 0
+                ;;
+            host)      INSTALL_MODE="host" ;;       # handled by the host short-circuit
+            container) INSTALL_MODE="container" ;;  # handled by the container path
+            both)
+                log "Both host and container installs detected — removing both."
+                detect_container_runtime
+                detect_distro
+                load_env_ports
+                container_uninstall
+                echo ""
+                host_uninstall
+                exit 0
                 ;;
         esac
     fi
@@ -1763,6 +2366,11 @@ main() {
     prompt_ports
     prompt_models_dir
 
+    # ── Secure (Caddy reverse proxy) — install only; rebuild reuses .env ──
+    if [[ "$command" == "install" ]]; then
+        configure_secure
+    fi
+
     # ── Install prerequisites if needed ──
     if [[ ${#PREREQS[@]} -gt 0 ]]; then
         if ! prompt_confirm "Install prerequisites?"; then
@@ -1789,9 +2397,20 @@ main() {
     echo ""
     ok "llama-toolchest is running"
     echo ""
-    echo "  Web UI:     http://localhost:${LLAMA_TOOLCHEST_PORT}"
-    echo "  Inference:  http://localhost:${LLAMA_TOOLCHEST_INFERENCE_PORT}"
-    echo ""
+    if [[ "$SECURE" == true ]]; then
+        echo "  Web UI:     ${SECURE_EXTERNAL_URL:-https://<host>}      (login required)"
+        echo "  Chat UI:    ${SECURE_EXTERNAL_URL:-https://<host>}:${CADDY_CHAT_PORT:-8080}"
+        echo "  API:        ${SECURE_EXTERNAL_URL:-https://<host>}/v1   (Bearer api_key)"
+        if [[ "${TLS_MODE:-}" == "self-signed" ]]; then
+            echo ""
+            echo "  Note: self-signed TLS — your browser will warn until you trust"
+            echo "        Caddy's root CA. See docs/secure.md."
+        fi
+        print_secure_disclaimer
+    else
+        echo "  Web UI:     http://localhost:${LLAMA_TOOLCHEST_PORT}"
+        echo "  Inference:  http://localhost:${LLAMA_TOOLCHEST_INFERENCE_PORT}"
+    fi
     echo "  Logs:       ./setup.sh logs"
     echo "  Stop:       ./setup.sh down"
     echo "  Auto-start: ./setup.sh enable"


### PR DESCRIPTION
## Summary

Adds an **opt-in secure container deploy** that puts a [Caddy](https://caddyserver.com) reverse proxy in front of llama-toolchest for **HTTPS + a single admin login**, for anyone exposing the server beyond a trusted LAN. By default the UI, `/api`, and inference ports are plain HTTP with no auth; `./setup.sh install --secure` changes that. The app binds to loopback in secure mode so only Caddy faces the network — which also closes the unauthenticated `:8080` router bypass.

Implements `plan/secure-caddy-deploy.md`. No app behavior changes by default; the only Go change is a small, general env-override hook.

## What's included

**Compose / Caddy**
- `docker-compose.secure.yml` — Caddy sidecar publishing `80/443/8080`.
- `Caddyfile.template` (committed, auditable) → rendered to `./Caddyfile` (gitignored; contains the bcrypt hash). Basic Auth on UI + `/api`, `/v1` left on Bearer, chat UI fronted, `tls internal { on_demand }` for self-signed so a bare `:443` presents a cert.
- Base compose files get a **no-op** `${LLAMA_TOOLCHEST_BIND:-}` prefix (loopback binding in secure mode; identical behavior otherwise).

**Go**
- `config.Load` honors `LLAMA_TOOLCHEST_EXTERNAL_URL` / `LLAMA_TOOLCHEST_LLAMA_PORT` env overrides, so the overlay can set `ExternalURL` (https links) without editing the volume config. Unit-tested.

**setup.sh**
- Non-interactive foundation: `--yes`/`-y` + `ASSUME_YES`, TTY guard, `--flag value` / `--flag=value` parsing.
- Interactive **host-vs-container** prompt on `install`.
- Secure flags: `--secure/--no-secure`, `--tls`, `--domain`, `--acme-email`, `--auth-user`, `--auth-hash` / `--auth-pass-file` (+ `AUTH_PASS`). Password hashed via the caddy image; **never passed on argv**.
- **Dual-container Quadlet** (rootless Podman): `.network` + app + caddy units; `up`/`down`/`logs`/`enable`/`disable`/`uninstall` are set-aware; boot ordering via `Requires=`/`After=`.
- Install robustness: `stop_existing_containers`, `preflight_port_check` (names the port holder *before* the build; offers to **uninstall** a conflicting host install rather than just stopping it), `ensure_unprivileged_ports` (offers to lower `net.ipv4.ip_unprivileged_port_start` for rootless 80/443).
- `uninstall` with no flag now detects and removes whatever's installed (host, container, or both).

**Docs**: `docs/secure.md` (with an explicit best-effort-security disclaimer — users must audit the Caddy config for their own threat model), README pointer, `.env.example` entries, plan doc.

## Test plan
- `go build`, `go vet`, `go test ./...` clean (incl. new config env-override test).
- `bash -n setup.sh` clean; flag validations exercised.
- Caddyfile renders + `caddy validate`s for both self-signed and Let's Encrypt; bcrypt hash with `$`/`/` survives rendering.
- Quadlet units generate correctly for secure (network + app + caddy) and plain.
- Merged compose validates; ports correct (Caddy `80/443/8080`, app loopback `3000`/`8081`); plain path byte-identical.
- **Manually verified live on rootless Podman (ROCm/CachyOS):** built and ran the secure stack; `80`→308→https, `443`/`8080`→401 (auth enforced on all paths incl `/server`, `/api/*`, `/static`), `/v1`→200, self-signed cert served by Caddy's internal CA.

## Notes / follow-ups (not in this PR)
- The mid-install port prompt still shows `UI port 3000` even in secure mode (those become loopback-internal; you actually access `https://<host>`). Worth reordering the secure question before the port prompt.
- Let's Encrypt requires a public domain + reachable 80/443; DNS-01 (behind-NAT) would need a custom Caddy image with a DNS plugin — possible future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)