### PR TITLE
fix(dashboard): only list router-known models as available

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -479,19 +479,26 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	// a load icon and a loaded/loading tag when the router has them resident.
 	availableHTML := "<p>None</p>"
 	if routerStatus.State == process.StateRunning {
-		// Build lookup: router-known name → status
+		// Build two lookups from the running router's /models endpoint:
+		//   routerKnown — every model the router actually serves (i.e. is in
+		//                 its current preset), regardless of load state.
+		//   loadedState — those currently loaded/loading, for the status tag.
+		// The router reads preset.ini only at startup, so a model enabled in
+		// config but absent from routerKnown isn't truly available yet — it
+		// needs a restart. Such models are excluded below so "Available"
+		// reflects what the running server can actually serve.
+		routerKnown := map[string]bool{}
 		loadedState := map[string]string{}
 		if loaded, err := s.process.ListModels(); err == nil {
 			for _, lm := range loaded {
-				if lm.Status.Value != "loaded" && lm.Status.Value != "loading" {
-					continue
-				}
-				loadedState[lm.ID] = lm.Status.Value
-				if lm.Model != "" {
-					loadedState[lm.Model] = lm.Status.Value
-				}
-				for _, a := range lm.Aliases {
-					loadedState[a] = lm.Status.Value
+				for _, name := range append([]string{lm.ID, lm.Model}, lm.Aliases...) {
+					if name == "" {
+						continue
+					}
+					routerKnown[name] = true
+					if lm.Status.Value == "loaded" || lm.Status.Value == "loading" {
+						loadedState[name] = lm.Status.Value
+					}
 				}
 			}
 		}
@@ -508,6 +515,11 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			}
 
 			routerName := s.registry.RouterName(m.ID)
+			if !routerKnown[routerName] && !routerKnown[m.ID] && !routerKnown[m.PublicName()] {
+				// Enabled in config but not in the running router's preset:
+				// not available until the router is restarted. Don't list it.
+				continue
+			}
 			state := loadedState[routerName]
 			if state == "" {
 				state = loadedState[m.ID]


### PR DESCRIPTION
## Problem

A model toggled **on** in the Models tab showed up as **available** on the Server tab *before* llama-server was restarted. The router reads `preset.ini` only at startup, so the model isn't actually served until a restart — and the Server tab even offered a ▶ Load button that failed with *"model … is not in the router preset; restart the router to pick it up"*.

The Models tab handled this correctly (it shows a ↻ "restart needed" indicator), but the Server tab's "Available Models" card trusted only the config `Enabled` flag.

## Fix

In `handleDashboard` (`internal/api/server.go`):
- Build a `routerKnown` set from the running router's `/models` endpoint — every model it actually serves, regardless of load state.
- Skip config-enabled models that aren't in `routerKnown`, so "Available" reflects what the running server can serve.
- `loadedState` (loaded/loading badge) is now populated in the same pass.

### Behavior after fix
- In preset & loaded/loading → shown with badge (unchanged)
- In preset & unloaded → shown with ▶ Load button (genuinely loadable)
- Enabled in config but not yet in the running preset → no longer listed (was the bug); Models tab still shows its ↻ restart-pending indicator

## Verification
`make build` passes (Go 1.26.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)