### PR TITLE
refactor: eliminate code duplication found by the duplication audit

### DIFF
--- a/audits/Duplication_META_AUDIT.md
+++ b/audits/Duplication_META_AUDIT.md
@@ -1,0 +1,223 @@
+# Audit report: Code Duplication Audit (cleaned)
+
+Line numbers below were re-validated against the current source and corrected. Overlapping
+findings from the original 10-run sample were merged (original #7→#1, #21→#12, #22→#4, #25→#24,
+#26/#27→#13), and refuted sub-claims were struck out. **23 distinct verified findings.**
+
+> Every citation was re-checked against HEAD. Where the original audit's line numbers were stale
+> they have been replaced with the current ranges. Sub-claims that did not survive re-verification
+> are marked ~~struck through~~ with a correction.
+
+## Remediation (2026-07-03, branch `refactor/dedup-audit-fixes`)
+
+All findings below were fixed except #21 (see note). Note: the cited line numbers in the
+findings describe the code **before** remediation.
+
+| # | Fix |
+|---|-----|
+| 1, 2 | `specDecodingParams()` in new `internal/models/specflags.go` returns structured name/value pairs; `writeConfigParams` formats them as INI, `EffectiveFlagsFor` as `--flags`. Draft-resource and draft-sampling blocks are shared sub-helpers. |
+| 3 | `handleDashboard` now calls `routerKnownStates()` + new `routerStateFor()` lookup helper instead of its inline block. |
+| 4, 12, 14, 15 | New `(*Model).IsEmbedding()`, `(*Model).HasVision(cfg)`, `(*Model).Capabilities(cfg)` in the models package; all nine double-call sites and both capability-list builders now delegate. `filterModels()` unifies the two list-filter loops. |
+| 5 | New generic `internal/broadcast.Broadcaster[T]` (ring history, non-blocking fan-out, race-tested); adopted by `builder.Builder` (per-build log streams), `process.Manager` (router logs), and `huggingface.download` (status, history size 1 replaces `lastStatus`). |
+| 6 | `builder.ApplyOptionOverrides()` shared by `Builder.Build` and api `effectiveCMakeFlags`. Intentional behavior fix: a partial non-nil overrides map now applies option defaults for unspecified options, so the built flags always match the UI preview. |
+| 7 | `downloadProgressHTML()` shared by the SSE progress stream and active-downloads panel. |
+| 8 | `parseEnumParam()`; both normalizers are now one-liners. |
+| 9 | `(*Server).resolveActiveBuild()` shared by `startRouter` and `handleStartBenchmark`; the benchmark path now also validates `Status == BuildStatusSuccess` (closing the failed-build hole the audit flagged). |
+| 10 | `(*Builder).Find(id)`; all five linear-search sites delegate. |
+| 11 | `huggingface.SafeModelID()` / `SafeFileID()` in new `names.go`; all six sites delegate. |
+| 13 | `cssID` template func now delegates to `domID`. |
+| 16, 17 | `(*Server).resolveRouterModel(rm)` shared by `handlePS` and `renderLoadedModelsJSON` (handlePS now matches by public name/router name too, not just registry ID). `renderLoadedModelsHTML` and `lookupRouterState` left as-is: different direction/output, no shared body to extract. |
+| 18 | New `respondJSONStatus()`; `writeProxyError` (now code-parameterized) and the v1models 404 path delegate. `writeJSONExport` left as-is (needs `SetIndent` + `Content-Disposition`). |
+| 19 | `parseTensorAssign()` shared by `ResolveGPUAssign` and `resolveModelGPUs`. |
+| 20 | `listAMDGPUDirs()` + `readVRAMFromDir()`; `collectSysfs` no longer re-globs per GPU. |
+| 21 | **Not fixed (intentional).** The two HTTP clients differ in timeout (5s vs 5min) and method (Get vs Do); a shared client isn't clearly right. Low value, per the audit itself. |
+| 22 | `models.ShortModelName()` exported; api `shortenModelName` delegates. |
+| 23 | `platformAppDirs()` shared by `DefaultDataDir` and `configSearchPaths`; the `/etc` candidate is still appended unconditionally on Linux (preserves the issue #61 fix). |
+
+## Verified findings
+
+### 1. Identical speculative-decoding flag emission block in preset.go and registry.go
+
+`internal/models/preset.go:145-226 (writeConfigParams spec-type switch); internal/models/registry.go:229-322 (EffectiveFlagsFor spec-type switch)` · severity: high
+
+The spec-type switch (draft, draft-mtp, ngram-mod, ngram-simple/ngram-map-k/ngram-map-k4v, ngram-cache) is duplicated across two files. `writeConfigParams` (preset.go, func starts line 100) writes INI lines to a `*strings.Builder`; `EffectiveFlagsFor` (registry.go, func starts line 179) appends `--flag value` pairs to a `[]string`. Both cover the identical case set and emit the same logical flag set per spec type (`--spec-type`, `--model-draft`, `--ctx-size-draft`, `--gpu-layers-draft`, `--device-draft`, `--n-cpu-moe-draft`, `--cache-type-{k,v}-draft`, `--spec-draft-n-{max,min}`, `--spec-draft-p-min`, `--spec-ngram-mod-n-{max,min}`). Only the output medium differs. The blocks are ~82 (preset) and ~94 (registry) lines — larger than the "~40 line" original estimate. Unify behind a shared helper returning structured flag data (`[]struct{Flag, Value string}`) that each caller formats. _(Original finding #7 reported this same duplication and is merged here.)_
+
+### 2. Draft resource override block copied for two spec types in registry.go
+
+`internal/models/registry.go:252-266 ("draft" case) and 278-292 ("draft-mtp" case)` · severity: high
+
+Inside `EffectiveFlagsFor`, the 5-field draft-resource override sequence (DraftCtxSize, DraftGPULayers, DraftDevice, DraftCPUMoE, DraftKVCacheQuant) appears in both the `"draft"` case and the `"draft-mtp"` case:
+
+    if c.DraftCtxSize > 0    { parts = append(parts, "--ctx-size-draft", ...) }
+    if c.DraftGPULayers > 0  { parts = append(parts, "--gpu-layers-draft", ...) }
+    if c.DraftDevice != ""   { ... }
+    if c.DraftCPUMoE > 0     { ... }
+    if c.DraftKVCacheQuant != "" { ... }
+
+The `draft-mtp` copy is nested one level deeper (inside `if c.MtpPath != "" && !c.MtpDisabled`), so it is the same logic with extra indentation rather than byte-identical. Extract `appendDraftFlags(parts *[]string, c *ModelConfig)`.
+
+### 3. routerKnown state-building block in handleDashboard vs routerKnownStates()
+
+`internal/api/server.go:490-504 (handleDashboard inline block); internal/api/models.go:330-348 (routerKnownStates())` · severity: high
+
+Both query `s.process.ListModels()` and iterate ID/Model/Aliases to build a name→status map, filtered by enabled registry models. ~~The inline block is a copy of routerKnownStates().~~ **Correction: not a literal copy.** The `handleDashboard` block builds *two* maps — `routerKnown map[string]bool` (name/model/alias → true) and `loadedState map[string]string` (only "loaded"/"loading") — whereas `routerKnownStates()` returns a single `map[string]string` of all name→status. The duplication is thematic (same source, same iteration), not verbatim; unifying would require `routerKnownStates()` to also return the `loadedState` sub-map.
+
+### 4. Capabilities logic in openAIModel() vs buildCapabilities()
+
+`internal/api/v1models.go:13-25 (openAIModel); internal/api/capabilities.go:37 + 49-51 (buildCapabilities)` · severity: high
+
+Both derive the same three predicates: serving mode via `models.IsEmbeddingModel(...)`, `tools` via `m.SupportsTools`, and `vision` via `m.HasBuiltinVision || (cfg != nil && cfg.MmprojPath != "")`. ~~Same ~10 lines verbatim.~~ **Correction: same predicates, different output contract.** `openAIModel` appends strings (chat/embedding/tools/vision) to a `[]string`; `buildCapabilities` emits discrete boolean map keys (line 37 embedding check; lines 49-51 vision/tools). A new capability must be added in both, but they are not drop-in shareable — a shared helper would need to expose the predicates, with each caller formatting its own output. _(Closely related to #15, the openAIModel↔handleModelInfo duplication, which IS a true copy.)_
+
+### 5. Broadcast pattern (subscribe/broadcast/unsubscribe) across three packages
+
+`internal/builder/builder.go (SubscribeLogs 148-173, UnsubscribeLogs 176-182, broadcastLog 184-200); internal/process/manager.go (Subscribe 318-330, Unsubscribe 333-337, broadcast 346-361); internal/huggingface/downloader.go (broadcast 37-47, subscribe 49-62, unsubscribe 64-68)` · severity: high
+
+All three implement the same mutex + `map[chan T]struct{}` + non-blocking `select`-send fan-out. Builder uses `logHistory map[string][]string` (ring size 2000, const at builder.go:48); Manager uses `logHistory []string` (ring size 500, const at manager.go:59). **Correction to original "ring buffer in all three":** the `download` struct has *no* ring buffer — it replays a single `lastStatus` value on subscribe (downloader.go:39, 54-59). So the ring-buffer history is shared by two of three; the broadcast/subscribe skeleton is shared by all three. Unify behind a generic `Broadcaster[T]` with optional history size. _(Original finding #22 reported the broadcast methods specifically and is merged here.)_
+
+### 6. Option-override + CMake flag assembly loop in builder.Build vs api.effectiveCMakeFlags
+
+`internal/builder/builder.go:252-267 (Build method); internal/api/build.go:102-125 (effectiveCMakeFlags)` · severity: high
+
+Both iterate `ProfileOptions(profile)`/options and fold override-or-default into a flags map: for each opt, use `optionOverrides[opt.Flag]` if set, else `opt.Default`, then set the flag "ON". ~~Cited builder.go:205-222 (wrong — that region is DuplicateBuildError).~~ **Correction:** the real Build loop is 252-267. Not a literal copy: `Build` mutates a copy of `prof.CMakeFlags` in place with no string output; `effectiveCMakeFlags` builds a fresh map and returns a sorted `-D…` string. The enable-resolution logic is the duplicated part.
+
+### 7. Download-progress HTML rendering block in two hf.go handlers
+
+`internal/api/hf.go:176-198 (handleHFDownloadProgress); internal/api/hf.go:219-230 (handleHFActiveDownloads)` · severity: medium
+
+Both handlers compute `pct`, `speedMB`, `downloadedGB`, `totalGB` with byte-identical arithmetic (compute at 176-182 and 219-225 respectively), then emit the same `<progress>`-bar HTML. The only semantic difference is SSE wrapping (download-progress) vs. raw HTML (active-downloads). Extract `renderDownloadProgress(status DownloadStatus) string`.
+
+### 8. parseExportFormat and parseExportScope are near-identical switch normalizers
+
+`internal/api/bench_export.go:229-239 (parseExportFormat); internal/api/bench_export.go:241-251 (parseExportScope)` · severity: medium
+
+Both are three-case switches: empty→default value, valid value→pass-through, default→`fmt.Errorf`. They differ only in the query-param name (`"format"` vs `"scope"`), the two valid literals, and the error text. A shared `parseEnumParam(r, key, emptyDefault string, valid []string) (string, error)` would eliminate the divergence risk.
+
+### 9. Active-build fallback in handleStartBenchmark duplicates startRouter (not EnsureBuildActive)
+
+`internal/api/bench.go:267-272 (handleStartBenchmark); internal/api/service.go:403-415 (startRouter)` · severity: medium
+
+~~Original finding #10 paired handleStartBenchmark with jobs_env.go EnsureBuildActive — REFUTED.~~ `EnsureBuildActive` (jobs_env.go:82-101) takes a `buildID` parameter, does a List()-scan-by-ID, validates `Status == BuildStatusSuccess`, and never calls `LatestSuccessfulBuild()`. **Correction:** the actual twin of `handleStartBenchmark`'s "check cfg.ActiveBuild, else fall back to `builder.LatestSuccessfulBuild()`" logic is `startRouter` in service.go:403-415 — and the code comment at bench.go:266 even says "the same way startRouter does." The `handleStartBenchmark` path lacks the `Status == BuildStatusSuccess` validation that startRouter/EnsureBuildActive have, so it could launch a failed build if ActiveBuild points to one. Centralize build resolution (e.g. `registry.ActiveBuildOrLatest()`).
+
+### 10. builder.List() search-by-ID repeated across 5 sites
+
+`internal/api/build.go:291-297 (handleBuildInfo); internal/api/service.go:404-409 (startRouter); internal/api/jobs_env.go:37-42 (CheckBuildRunnable); internal/api/jobs_env.go:89-95 (EnsureBuildActive); internal/api/bench.go:26-39 (builderResolver)` · severity: medium
+
+Five sites run essentially identical `for _, b := range s.builder.List() { if b.ID == … }` linear searches (startRouter adds `&& b.Status == success`). ~~Original finding #11 listed a sixth site, bench_jobs.go handleJobForm (~278-283) — REFUTED as a match:~~ that loop iterates all builds filtering `b.Status != "success"` to populate a dropdown; it is a List() iteration but not a search-by-ID. A `(*Builder).Find(id) (*BuildResult, bool)` helper would eliminate the five duplicate loops.
+
+### 11. `strings.ReplaceAll(modelID, "/", "--")` copy-pasted across api and huggingface
+
+`internal/huggingface/downloader.go:105, 254 (modelID); internal/huggingface/downloader.go:106 (filename variant); internal/api/hf.go:313, 347 (modelID); internal/api/hf.go:369 (filename variant)` · severity: medium
+
+The HF-repo→dirname sanitization `strings.ReplaceAll(modelID, "/", "--")` appears at downloader.go:105,254 and hf.go:313,347. The filename variant `strings.ReplaceAll(strings.TrimSuffix(filename, ".gguf"), "/", "--")` appears at downloader.go:106 and hf.go:369. ~~(Original cited 107, 255, 371 — corrected to 106, —, 369.)~~ A shared `SafeModelID(modelID string) string` helper would provide the single canonical definition.
+
+### 12. IsEmbeddingModel double-call idiom repeated across api/ files
+
+`internal/api/v1models.go:14; internal/api/capabilities.go:37; internal/api/models.go:17; internal/api/models.go:39 (negated); internal/api/models.go:175; internal/api/server.go:509; internal/api/service.go:589` · severity: medium
+
+The expression `models.IsEmbeddingModel(m.ModelID) || models.IsEmbeddingModel(m.ID)` (checking both the HF repo ID and the internal registry ID, because legacy records may have only one populated) appears at all seven sites — models.go:39 is the negated `!… && !…` form, and service.go:589 uses the variable `model` rather than `m` but is otherwise identical. All cited lines are accurate against current source. A single `IsEmbeddingModelFor(m *Model) bool` helper would eliminate the copies. _(Original finding #21 reported a 6-site subset of this and is merged here.)_
+
+### 13. domID and cssID are identical character-whitelisting functions
+
+`internal/api/hf.go:239-248 (domID, package-level func); internal/api/server.go:129-138 (cssID, anonymous func in the template FuncMap)` · severity: medium
+
+Both use `strings.Map` keeping `[a-z A-Z 0-9 - _]` and returning `'_'` for every other rune. The character sets are byte-for-byte identical (both explicitly permit `'-'`). `cssID` is registered under key `"cssID"` in `parseTemplates`; `domID` is a standalone func. Unify behind a single shared `makeIdentifier(s string)` helper. ~~Original finding #27 claimed "domID additionally allows '-' but cssID does not" — REFUTED: both permit '-' (server.go:132 and hf.go:242 both list `r == '-'`).~~ _(Original findings #26 and #27 reported this same pair and are merged here.)_
+
+### 14. Model-filter loop duplicated in handleListModels and handleListEmbeddingModels
+
+`internal/api/models.go:14-20 (handleListEmbeddingModels); internal/api/models.go:35-42 (handleListModels)` · severity: medium
+
+Both call `s.registry.List()` then a for-range that builds an embedding/chat split. The loops are De Morgan negations of each other (line 17 `IsEmbeddingModel(ModelID) || IsEmbeddingModel(ID)` to collect embedding vs. line 39 `!… && !…` to collect non-embedding); otherwise structurally identical. Unify into a single filter helper.
+
+### 15. Capabilities []string builder duplicated in handleModelInfo and openAIModel
+
+`internal/api/models.go:173-185 (handleModelInfo); internal/api/v1models.go:13-25 (openAIModel)` · severity: medium
+
+Both build a capabilities `[]string`: embedding/chat via `IsEmbeddingModel`, then `tools` via `SupportsTools`, then `vision` via `HasBuiltinVision || (cfg != nil && cfg.MmprojPath != "")`. This is a near-verbatim copy (unlike #4, which shares only the predicates). ~~Original cited models.go:160-171 and v1models.go:17-33 — corrected.~~ Extract `models.Capabilities(m *Model, cfg *ModelConfig) []string`.
+
+### 16. Router model listing logic across handlePS, renderLoadedModelsJSON, renderLoadedModelsHTML
+
+`internal/api/service.go:104-146 (handlePS); internal/api/service.go:239-296 (renderLoadedModelsJSON); internal/api/service.go:299-327 (renderLoadedModelsHTML)` · severity: medium
+
+All three guard on `process.IsRunning()`, call `process.ListModels()`, and iterate per router model, matching each by ID/alias to registry model/config. ~~Original cited 75-120 / 167-213 / 227-255 — all wrong; corrected above.~~ Each builds a different payload (psModel with VRAM at 118-141; loadedModel with capabilities at 268-293; HTML fragment at 315-325), so this is a repeated skeleton rather than copy-paste bodies. A shared helper returning a unified `[]loadedModel` would collapse the common lookup.
+
+### 17. Auto-load / router-state lookup near-duplicate
+
+`internal/api/service.go:104-146 (handlePS, alias loop 118-141); internal/api/proxy.go:170-189 (lookupRouterState, loop 178-187)` · severity: medium
+
+Both range over `process.ListModels()` and match on ID / Model / Aliases. `handlePS` resolves via `registry.Get` per alias; `lookupRouterState` compares against routerName/m.ID/PublicName and returns a `knownToRouter` bool alongside the state. ~~Original claimed the pattern appears "~3 times in proxy.go" — REFUTED: proxy.go has it once (lookupRouterState); the other ListModels+alias iterations are in service.go (renderLoadedModelsJSON 268-291, renderLoadedModelsHTML 315-325), i.e. finding #16.~~ Unify the alias-lookup as a helper on `process.Manager`.
+
+### 18. JSON+Content-Type response idiom inlined instead of using respondJSON
+
+`internal/api/respond.go:14-17 (respondJSON def); internal/api/proxy.go:41-49 (ErrorHandler inline); internal/api/proxy.go:214-224 (writeProxyError); internal/api/bench_export.go:49-55 (writeJSONExport); internal/api/v1models.go:83-85 (redundant Content-Type before respondJSON)` · severity: medium
+
+`respondJSON` sets `Content-Type: application/json` and encodes. Four callers reimplement or partially duplicate it: the proxy ErrorHandler and `writeProxyError` set the header and call `json.NewEncoder(...).Encode` directly; `v1models.go:83` redundantly sets Content-Type immediately before calling `respondJSON` at 85 (which sets it again). `bench_export.go` `writeJSONExport` is a weaker candidate — it also sets `Content-Disposition` and uses `SetIndent`, so it can't simply delegate. A dedicated `writeError(w, status, msg)` helper would consolidate the error paths.
+
+### 19. tensor-N parse prefix duplicated in gpu_assign.go
+
+`internal/models/gpu_assign.go:119-136 (ResolveGPUAssign); internal/models/gpu_assign.go:235-247 (resolveModelGPUs)` · severity: medium
+
+Both share the parse prefix: `strings.HasPrefix(assign, "tensor-")` + `fmt.Sscanf(assign, "tensor-%d", &n)` + `n > 0` guard. ~~Original claimed the `make([]int, n); for i := range gpus { gpus[i] = i }` slice construction is also shared — partially REFUTED:~~ that slice body appears only in `resolveModelGPUs` (241-244). `ResolveGPUAssign` instead builds a `[]string` tensor-split of length `numGPUs` and uses different overflow handling (`n >= numGPUs` → no split, vs `n > numGPUs` → clamp). Only the parse prefix is duplicated; extract `parseTensorAssign(assign string) (n int, ok bool)`.
+
+### 20. readVRAMSysfs duplicates the sysfs card-enumeration loop from collectSysfs
+
+`internal/monitor/rocm.go:106-147 (collectSysfs enumeration; glob 106, loop 108-147); internal/monitor/rocm.go:155-181 (readVRAMSysfs; glob 157, loop 159-179)` · severity: medium
+
+Both call `filepath.Glob("/sys/class/drm/card[0-9]*/device/vendor")`, read the vendor file, filter for AMD (`"0x1002"`), and index-walk to the target GPU. Critically, `readVRAMSysfs(idx)` is **called from inside collectSysfs's own loop at line 123** (and from `collectROCmSMI` at line 90), so collectSysfs enumerates AMD cards and then re-enumerates them from scratch per GPU — redundant work. ~~Original finding #25 additionally claimed readVRAMSysfs "starts idx from 0 each call so returns wrong results for non-zero gpuIdx" — REFUTED:~~ the index-walk (`if idx != gpuIdx { idx++; continue }`) correctly reaches the Nth AMD GPU; the duplication is wasteful but not incorrect. Extract `listAMDGPUBuses() ([]string, error)` so enumeration runs once. _(Original finding #25 is merged here.)_
+
+### 21. Connection-test HTTP client instantiated similarly in settings and benchmark runner
+
+`internal/api/settings.go:121-123 (handleTestConnection); internal/benchmark/runner.go:211-212 (ensureModelLoaded)` · severity: low
+
+Both create an inline `&http.Client{Timeout: …}`. ~~Original cited runner.go:219-223 and claimed a matching `client.Get`;~~ **correction:** settings.go uses `Timeout: 5 * time.Second` + `client.Get(url)` (lines 121, 123); runner.go uses `Timeout: 5 * time.Minute` + `client.Do(req)` on a POST (lines 211, 212). The shared part is only the `&http.Client{Timeout}` idiom; timeouts and methods differ. Note additional instances exist (runner.go:363 10min, downloader.go:305 30s, downloader.go:367 no timeout), so a single shared client is not obviously appropriate — this is a low-value cleanup.
+
+### 22. Model-name shortening duplicated in two packages
+
+`internal/api/jobs_env.go:184-192 (shortenModelName); internal/models/gpu_assign.go:264-273 (shortModelName)` · severity: medium
+
+Both strip the org prefix via `strings.LastIndex(name, "/")`, then `TrimSuffix("-GGUF")` and `TrimSuffix("-gguf")` in that order — logically identical. ~~Original claimed jobs_env uses `strings.Index` (first) while gpu_assign uses `LastIndex` — REFUTED: both use `LastIndex` (jobs_env.go:186). (The `strings.Index` usage the auditor likely saw is in `Model.OrgAndBase`, preset.go:21, a different function.)~~ Unify behind `models.ShortModelName`.
+
+### 23. OS-specific env-var lookups in DefaultDataDir and configSearchPaths
+
+`internal/config/paths.go:14-30 (DefaultDataDir switch); internal/config/paths.go:66-87 (configSearchPaths switch)` · severity: low
+
+Both switch on `runtime.GOOS` with the same three-arm shape (darwin → `Library/Application Support`; windows → `LOCALAPPDATA`; default → XDG env var then `UserHomeDir` fallback), differing in the env var consulted (`XDG_DATA_HOME` vs `XDG_CONFIG_HOME`) and per-arm return type (`string` vs `[]string`; the config version also appends a system `/etc` path). A looser structural parallel than a verbatim copy; a shared helper taking the divergent var as an argument could consolidate it.
+
+## Refuted / mispaired (removed from the verified set)
+
+Re-verification removed or corrected the following from the original report:
+
+- **Original #10** (handleStartBenchmark ↔ EnsureBuildActive active-build resolution) — mispaired; the real twin is `startRouter`. Re-pointed as finding #9 above.
+- **Original #7 = #1, #21 ⊂ #12, #22 ⊂ #4, #25 ⊂ #20 (rocm), #26/#27 = #13** — duplicate reports of the same duplication, merged.
+- Sub-claims struck out in-place: #3 "literal copy" (it isn't), #4 "ring buffer in all three" (only two), #10/now-#9 pairing, #10/now-#10 sixth site (bench_jobs.go), #13 "'-' discrepancy", #16 "3× in proxy.go", #19 slice-body sharing, #20/#25 "wrong for non-zero idx" bug, #21 `client.Get` match, #22 `Index` vs `LastIndex`.
+
+## Filtered out (not verified — from original report, unchanged)
+
+_Reported by at least one run but not confirmed against the source. Listed for transparency._
+
+- `internal/api/bench.go:271-278` — shortenModelName defined inline in bench.go, duplicated in jobs_env.go _(refuted)_
+- `internal/api/hf.go:248-289` — handleIncompleteDownloads mirrors handleHFActiveDownloads structure _(refuted)_
+- `internal/api/middleware.go:19-27` — API key check blocks duplicated verbatim in middleware and handler _(refuted)_
+- `internal/api/models.go` — Router model name→status map rebuilt inline in handleDashboard _(refuted)_
+- `internal/api/server.go` — Identical SVG icon constant groups copy-pasted in server.go and service.go _(refuted)_
+- `internal/api/v1models.go` — Same embedding+capabilities block copy-pasted in v1models.go and capabilities.go _(refuted; the real pair is v1models.go↔models.go — see finding #15)_
+- `internal/benchmark/runner.go:208-213` — Model load/unload HTTP POST pattern duplicated across runner, process manager, proxy _(refuted)_
+- `internal/builder/builder.go:398-400` — `sendLog` defined as both a closure and a package-level function _(refuted)_
+- `internal/models/gpu_assign.go:109-120` — parseGPURange body duplicated inside ResolveGPUAssign _(refuted)_
+- `internal/models/gpu_assign.go` — Router-name lookup chain repeated across three locations _(refuted)_
+- `internal/api/bench_export.go:175-195` — parseExportFormat / parseExportScope copied to bench_jobs.go _(refuted)_
+- `internal/api/bench_jobs.go:39-47` — jobInTerminalState duplicated by switch in renderJobList _(refuted)_
+- `internal/api/bench.go` — Three SVG icon constants duplicated verbatim _(refuted)_
+- `internal/api/hf.go:505-510` — SVG icon string constants defined inline in both server.go and hf.go _(refuted)_
+- `internal/api/jobs_env.go:184-191` — shortenModelName and autoDiscoveryName both extract suffix after final '/' _(refuted)_
+- `internal/api/jobs_env.go:456-460` — newJobID definition copied into bench_jobs.go _(refuted)_
+- `internal/api/models.go:334-342` — routerKnownStates() body near-identical to handleDashboard's inline loop _(refuted; but see finding #3 for the thematic overlap)_
+- `internal/api/server.go:155-158` — safeShortSHA and shortSHA template func are the same logic _(refuted)_
+- `internal/builder/detect.go` — GPU-name extraction loop copy-pasted in detectCUDA and monitor.nvidia.Collect _(refuted)_
+- `internal/builder/profiles.go:1-30` — Flag equality/copying logic duplicated between builder and models _(refuted)_
+- `internal/models/gpu_assign.go` — Single-char digit check + range parse idiom duplicated _(refuted)_
+- `internal/models/gpu_assign.go` — GPU assignment value formatting duplicated across packages _(uncertain — not re-verified)_
+- `internal/models/vram.go:183-194` — formatFloat and trimTrailingZeros implement the same rounding twice _(uncertain — not re-verified)_
+- `internal/models/vram.go` — trimTrailingZeros private helper duplicated within same file _(uncertain — not re-verified)_
+- `internal/models/gpu_assign.go:1-30` — Color array constant duplicated between GPU allocation and benchmark _(uncertain — not re-verified)_
+- `internal/models/registry.go` — "model not found" error literal duplicated _(uncertain — not re-verified)_
+- `internal/models/vram.go:117-136` — VRAMFitLabel duplicates a branch inside server.go's "vramFit" template func _(uncertain — not re-verified)_

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -23,21 +23,20 @@ import (
 // fields."
 func builderResolver(b *builder.Builder) benchmark.BuildResolver {
 	return func(buildID string) benchmark.BuildSnapshot {
-		for _, br := range b.List() {
-			if br.ID == buildID {
-				return benchmark.BuildSnapshot{
-					ID:         br.ID,
-					Tag:        br.Tag,
-					Profile:    br.Profile,
-					Vendor:     br.Profile,
-					GitSHA:     br.GitSHA,
-					GitRef:     br.GitRef,
-					CMakeFlags: br.CMakeFlags,
-					BinaryPath: br.BinaryPath,
-				}
-			}
+		br, ok := b.Find(buildID)
+		if !ok {
+			return benchmark.BuildSnapshot{}
 		}
-		return benchmark.BuildSnapshot{}
+		return benchmark.BuildSnapshot{
+			ID:         br.ID,
+			Tag:        br.Tag,
+			Profile:    br.Profile,
+			Vendor:     br.Profile,
+			GitSHA:     br.GitSHA,
+			GitRef:     br.GitRef,
+			CMakeFlags: br.CMakeFlags,
+			BinaryPath: br.BinaryPath,
+		}
 	}
 }
 
@@ -263,12 +262,12 @@ func (s *Server) handleStartBenchmark(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve active build the same way startRouter does.
-	buildID := s.cfg.ActiveBuild
-	if buildID == "" {
-		if b := s.builder.LatestSuccessfulBuild(); b != nil {
-			buildID = b.ID
-		}
+	// Resolve active build the same way startRouter does. resolveActiveBuild
+	// also validates the selected build actually succeeded, falling back to
+	// the latest successful one otherwise.
+	buildID := ""
+	if b := s.resolveActiveBuild(); b != nil {
+		buildID = b.ID
 	}
 	if buildID == "" {
 		http.Error(w, "no compiled build available — build llama.cpp first", http.StatusBadRequest)

--- a/internal/api/bench_export.go
+++ b/internal/api/bench_export.go
@@ -224,28 +224,26 @@ func metricStd(m *benchmark.LlamaBenchyMetric) string {
 	return ftoa(m.Std)
 }
 
-// parseExportFormat normalizes the format query param. Defaults to csv
-// because the typical browser flow downloads a spreadsheet-friendly file.
-func parseExportFormat(r *http.Request) (string, error) {
-	v := strings.ToLower(r.URL.Query().Get("format"))
-	switch v {
+// parseEnumParam normalizes a two-valued enum query param: empty → the
+// first valid value, either valid value → itself (lowercased), anything
+// else → an error naming the valid values.
+func parseEnumParam(r *http.Request, key, valid1, valid2 string) (string, error) {
+	switch v := strings.ToLower(r.URL.Query().Get(key)); v {
 	case "":
-		return exportFormatCSV, nil
-	case exportFormatCSV, exportFormatJSON:
+		return valid1, nil
+	case valid1, valid2:
 		return v, nil
 	default:
-		return "", fmt.Errorf("format must be %q or %q", exportFormatCSV, exportFormatJSON)
+		return "", fmt.Errorf("%s must be %q or %q", key, valid1, valid2)
 	}
 }
 
+// parseExportFormat normalizes the format query param. Defaults to csv
+// because the typical browser flow downloads a spreadsheet-friendly file.
+func parseExportFormat(r *http.Request) (string, error) {
+	return parseEnumParam(r, "format", exportFormatCSV, exportFormatJSON)
+}
+
 func parseExportScope(r *http.Request) (string, error) {
-	v := strings.ToLower(r.URL.Query().Get("scope"))
-	switch v {
-	case "":
-		return exportScopeCells, nil
-	case exportScopeCells, exportScopeSum:
-		return v, nil
-	default:
-		return "", fmt.Errorf("scope must be %q or %q", exportScopeCells, exportScopeSum)
-	}
+	return parseEnumParam(r, "scope", exportScopeCells, exportScopeSum)
 }

--- a/internal/api/build.go
+++ b/internal/api/build.go
@@ -104,17 +104,7 @@ func effectiveCMakeFlags(prof builder.BuildProfile, options []builder.BuildOptio
 	for k, v := range prof.CMakeFlags {
 		flags[k] = v
 	}
-	for _, opt := range options {
-		enabled := opt.Default
-		if overrides != nil {
-			if v, ok := overrides[opt.Flag]; ok {
-				enabled = v
-			}
-		}
-		if enabled {
-			flags[opt.Flag] = "ON"
-		}
-	}
+	builder.ApplyOptionOverrides(flags, options, overrides)
 	var parts []string
 	for k, v := range flags {
 		parts = append(parts, fmt.Sprintf("-D%s=%s", k, v))
@@ -285,17 +275,23 @@ func (s *Server) handleActiveBuildLog(w http.ResponseWriter, r *http.Request) {
 	s.renderPartial(w, "build_log", &builder.BuildResult{ID: lastID, Status: status})
 }
 
-func (s *Server) handleBuildInfo(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	var found *builder.BuildResult
-	for _, b := range s.builder.List() {
-		if b.ID == id {
-			bb := b
-			found = &bb
-			break
+// resolveActiveBuild returns the build the router should run: the explicitly
+// selected cfg.ActiveBuild when it exists and built successfully, otherwise
+// the successful build with the newest GitRef. Returns nil when no runnable
+// build exists.
+func (s *Server) resolveActiveBuild() *builder.BuildResult {
+	if s.cfg.ActiveBuild != "" {
+		if b, ok := s.builder.Find(s.cfg.ActiveBuild); ok && b.Status == builder.BuildStatusSuccess {
+			return b
 		}
 	}
-	if found == nil {
+	return s.builder.LatestSuccessfulBuild()
+}
+
+func (s *Server) handleBuildInfo(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	found, ok := s.builder.Find(id)
+	if !ok {
 		http.Error(w, "build not found", http.StatusNotFound)
 		return
 	}

--- a/internal/api/capabilities.go
+++ b/internal/api/capabilities.go
@@ -34,8 +34,6 @@ func (s *Server) buildCapabilities(m *models.Model, cfg *models.ModelConfig) map
 		}
 	}
 
-	isEmbedding := models.IsEmbeddingModel(m.ModelID) || models.IsEmbeddingModel(m.ID)
-
 	return map[string]any{
 		"schema_version": CapabilitiesSchemaVersion,
 
@@ -46,9 +44,9 @@ func (s *Server) buildCapabilities(m *models.Model, cfg *models.ModelConfig) map
 		"context_per_request": servedCtx / parallel,
 
 		// modalities / tools
-		"vision":    m.HasBuiltinVision || (cfg != nil && cfg.MmprojPath != ""),
+		"vision":    m.HasVision(cfg),
 		"tools":     m.SupportsTools,
-		"embedding": isEmbedding,
+		"embedding": m.IsEmbedding(),
 
 		// reasoning / thinking
 		"reasoning": m.EffectiveReasoning(cfg),

--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -153,6 +153,22 @@ func (s *Server) handleHFDownload(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, map[string]string{"download_id": downloadID})
 }
 
+// downloadProgressHTML renders the progress-bar + stats fragment shared by
+// the SSE progress stream and the active-downloads panel. progressStyle is
+// an optional style attribute for the <progress> element.
+func downloadProgressHTML(status huggingface.DownloadStatus, progressStyle string) string {
+	pct := float64(0)
+	if status.TotalBytes > 0 {
+		pct = float64(status.BytesDownloaded) / float64(status.TotalBytes) * 100
+	}
+	speedMB := float64(status.SpeedBPS) / (1024 * 1024)
+	downloadedGB := models.BytesToGB(status.BytesDownloaded)
+	totalGB := models.BytesToGB(status.TotalBytes)
+	return fmt.Sprintf(
+		`<progress value="%.0f" max="100"%s></progress><small>%.1f / %.1f GB (%.1f MB/s) — %.0f%%</small>`,
+		pct, progressStyle, downloadedGB, totalGB, speedMB, pct)
+}
+
 func (s *Server) handleHFDownloadProgress(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	ch, ok := s.downloader.Subscribe(id)
@@ -173,20 +189,10 @@ func (s *Server) handleHFDownloadProgress(w http.ResponseWriter, r *http.Request
 		case status := <-ch:
 			data, _ := json.Marshal(status)
 			// Send HTML progress update
-			pct := float64(0)
-			if status.TotalBytes > 0 {
-				pct = float64(status.BytesDownloaded) / float64(status.TotalBytes) * 100
-			}
-			speedMB := float64(status.SpeedBPS) / (1024 * 1024)
-			downloadedGB := models.BytesToGB(status.BytesDownloaded)
-			totalGB := models.BytesToGB(status.TotalBytes)
-
 			var html string
 			switch status.Status {
 			case "downloading":
-				html = fmt.Sprintf(
-					`<progress value="%.0f" max="100"></progress><small>%.1f / %.1f GB (%.1f MB/s) — %.0f%%</small>`,
-					pct, downloadedGB, totalGB, speedMB, pct)
+				html = downloadProgressHTML(status, "")
 			case "complete":
 				html = `<p>Download complete!</p>`
 			case "failed":
@@ -216,18 +222,11 @@ func (s *Server) handleHFActiveDownloads(w http.ResponseWriter, r *http.Request)
 			return // empty response — nothing to show
 		}
 		for _, dl := range active {
-			pct := float64(0)
-			if dl.TotalBytes > 0 {
-				pct = float64(dl.BytesDownloaded) / float64(dl.TotalBytes) * 100
-			}
-			speedMB := float64(dl.SpeedBPS) / (1024 * 1024)
-			downloadedGB := models.BytesToGB(dl.BytesDownloaded)
-			totalGB := models.BytesToGB(dl.TotalBytes)
 			fmt.Fprintf(w, `<div style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">
 				<strong>%s</strong> — <small>%s</small>
-				<progress value="%.0f" max="100" style="margin: 0.25rem 0;"></progress>
-				<small>%.1f / %.1f GB (%.1f MB/s) — %.0f%%</small>
-			</div>`, dl.ModelID, dl.Filename, pct, downloadedGB, totalGB, speedMB, pct)
+				%s
+			</div>`, dl.ModelID, dl.Filename,
+				downloadProgressHTML(dl, ` style="margin: 0.25rem 0;"`))
 		}
 		return
 	}
@@ -235,7 +234,9 @@ func (s *Server) handleHFActiveDownloads(w http.ResponseWriter, r *http.Request)
 	respondJSON(w, active)
 }
 
-// domID sanitizes a string for use as an HTML id / CSS selector fragment.
+// domID sanitizes a string for use as an HTML id attribute or CSS selector
+// fragment. Model IDs can contain '.' (e.g. "Qwen3.6"), which CSS parses as
+// a class separator and errors on. Also exposed to templates as "cssID".
 func domID(s string) string {
 	return strings.Map(func(r rune) rune {
 		switch {
@@ -310,7 +311,7 @@ func (s *Server) handleIncompleteDiscard(w http.ResponseWriter, r *http.Request)
 	}
 
 	root := s.cfg.ModelsPath()
-	safeName := strings.ReplaceAll(modelID, "/", "--")
+	safeName := huggingface.SafeModelID(modelID)
 	modelDir := filepath.Join(root, safeName)
 
 	removed := 0
@@ -344,7 +345,7 @@ func (s *Server) handleHFDownloadCancel(w http.ResponseWriter, r *http.Request) 
 
 // onDownloadComplete is called by the downloader when a file finishes.
 func (s *Server) onDownloadComplete(downloadID, modelID, filename string, sizeBytes int64) {
-	safeName := strings.ReplaceAll(modelID, "/", "--")
+	safeName := huggingface.SafeModelID(modelID)
 	filePath := filepath.Join(s.cfg.ModelsPath(), safeName, filename)
 
 	// mmproj files are vision projectors — don't register as models.
@@ -366,7 +367,7 @@ func (s *Server) onDownloadComplete(downloadID, modelID, filename string, sizeBy
 		return
 	}
 
-	safeFilename := strings.ReplaceAll(strings.TrimSuffix(filename, ".gguf"), "/", "--")
+	safeFilename := huggingface.SafeFileID(filename)
 	m := &models.Model{
 		ID:           fmt.Sprintf("%s--%s", safeName, safeFilename),
 		ModelID:      modelID,

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -34,11 +34,8 @@ func (e *jobEnv) CheckBuildRunnable(ctx context.Context, buildID string) error {
 		return nil
 	}
 	var binary string
-	for _, b := range e.s.builder.List() {
-		if b.ID == buildID {
-			binary = b.BinaryPath
-			break
-		}
+	if b, ok := e.s.builder.Find(buildID); ok {
+		binary = b.BinaryPath
 	}
 	if binary == "" {
 		return fmt.Errorf("build %s not found", buildID)
@@ -85,15 +82,8 @@ func (e *jobEnv) EnsureBuildActive(ctx context.Context, buildID string) error {
 	}
 
 	// Find the build and verify it's a successful one we can run.
-	var target *builder.BuildResult
-	for _, b := range e.s.builder.List() {
-		if b.ID == buildID {
-			b := b
-			target = &b
-			break
-		}
-	}
-	if target == nil {
+	target, ok := e.s.builder.Find(buildID)
+	if !ok {
 		return fmt.Errorf("build %s not found", buildID)
 	}
 	if target.Status != builder.BuildStatusSuccess {
@@ -182,11 +172,5 @@ func (e *jobEnv) HFCacheDir() string {
 // shortenModelName mirrors the trim done in handleStartBenchmark so cell
 // runs label the same way as the existing single-run path.
 func shortenModelName(modelID string) string {
-	name := modelID
-	if idx := strings.LastIndex(name, "/"); idx >= 0 {
-		name = name[idx+1:]
-	}
-	name = strings.TrimSuffix(name, "-GGUF")
-	name = strings.TrimSuffix(name, "-gguf")
-	return name
+	return models.ShortModelName(modelID)
 }

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -11,13 +11,7 @@ import (
 )
 
 func (s *Server) handleListEmbeddingModels(w http.ResponseWriter, r *http.Request) {
-	all := s.registry.List()
-	var embeddingModels []*models.Model
-	for _, m := range all {
-		if models.IsEmbeddingModel(m.ModelID) || models.IsEmbeddingModel(m.ID) {
-			embeddingModels = append(embeddingModels, m)
-		}
-	}
+	embeddingModels := filterModels(s.registry.List(), true)
 
 	if isHTMX(r) {
 		respondHTML(w)
@@ -32,14 +26,8 @@ func (s *Server) handleListEmbeddingModels(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
-	all := s.registry.List()
 	// Filter out embedding models — they have their own section
-	var modelList []*models.Model
-	for _, m := range all {
-		if !models.IsEmbeddingModel(m.ModelID) && !models.IsEmbeddingModel(m.ID) {
-			modelList = append(modelList, m)
-		}
-	}
+	modelList := filterModels(s.registry.List(), false)
 
 	if isHTMX(r) {
 		respondHTML(w)
@@ -53,6 +41,18 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respondJSON(w, withPublicNames(modelList))
+}
+
+// filterModels splits the registry list by model kind: embedding=true keeps
+// only embedding models, embedding=false keeps only chat models.
+func filterModels(all []*models.Model, embedding bool) []*models.Model {
+	var out []*models.Model
+	for _, m := range all {
+		if m.IsEmbedding() == embedding {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // withPublicNames wraps each model with its OpenAI-style public name so
@@ -170,20 +170,6 @@ func (s *Server) handleModelInfo(w http.ResponseWriter, r *http.Request) {
 
 	cfg, _ := s.registry.GetConfig(id)
 
-	// Build capabilities list
-	var capabilities []string
-	if models.IsEmbeddingModel(m.ModelID) || models.IsEmbeddingModel(m.ID) {
-		capabilities = append(capabilities, "embedding")
-	} else {
-		capabilities = append(capabilities, "chat")
-	}
-	if m.SupportsTools {
-		capabilities = append(capabilities, "tools")
-	}
-	if m.HasBuiltinVision || (cfg != nil && cfg.MmprojPath != "") {
-		capabilities = append(capabilities, "vision")
-	}
-
 	info := map[string]any{
 		"id":             m.ID,
 		"public_name":    m.PublicName(),
@@ -194,7 +180,7 @@ func (s *Server) handleModelInfo(w http.ResponseWriter, r *http.Request) {
 		"context_length": m.ContextLength,
 		"size_bytes":     m.SizeBytes,
 		"vram_est_gb":    m.VRAMEstGB,
-		"capabilities":   capabilities,
+		"capabilities":   m.Capabilities(cfg),
 		"downloaded_at":  m.DownloadedAt,
 	}
 
@@ -345,6 +331,17 @@ func (s *Server) routerKnownStates() map[string]string {
 		}
 	}
 	return routerKnown
+}
+
+// routerStateFor returns the status for the first of names present in a
+// routerKnownStates() map, and whether any of the names was found.
+func routerStateFor(states map[string]string, names ...string) (string, bool) {
+	for _, n := range names {
+		if st, ok := states[n]; ok {
+			return st, true
+		}
+	}
+	return "", false
 }
 
 // renderModelCard writes one model_card partial.

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -38,15 +38,8 @@ func (s *Server) newProxyHandler() http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.FlushInterval = 50 * time.Millisecond
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusServiceUnavailable)
-		json.NewEncoder(w).Encode(map[string]any{
-			"error": map[string]any{
-				"message": "llama-server router is not running",
-				"type":    "server_error",
-				"code":    "service_unavailable",
-			},
-		})
+		writeProxyError(w, http.StatusServiceUnavailable, "service_unavailable",
+			"llama-server router is not running")
 	}
 
 	// Capture timings from chat completion responses — both JSON and SSE streams.
@@ -94,7 +87,7 @@ func (s *Server) newProxyHandler() http.Handler {
 			r.Body.Close()
 			if err == nil {
 				if loadErr := s.ensureModelLoadedForRequest(r.Context(), body); loadErr != nil {
-					writeProxyError(w, http.StatusServiceUnavailable, loadErr.Error())
+					writeProxyError(w, http.StatusServiceUnavailable, "auto_load_failed", loadErr.Error())
 					return
 				}
 				if strings.HasSuffix(r.URL.Path, "/chat/completions") {
@@ -211,14 +204,13 @@ func (s *Server) waitForModelLoaded(ctx context.Context, routerName string, m *m
 	}
 }
 
-func writeProxyError(w http.ResponseWriter, status int, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(map[string]any{
+// writeProxyError writes an OpenAI-shaped error object with the given code.
+func writeProxyError(w http.ResponseWriter, status int, code, message string) {
+	respondJSONStatus(w, status, map[string]any{
 		"error": map[string]any{
 			"message": message,
 			"type":    "server_error",
-			"code":    "auto_load_failed",
+			"code":    code,
 		},
 	})
 }

--- a/internal/api/respond.go
+++ b/internal/api/respond.go
@@ -16,6 +16,15 @@ func respondJSON(w http.ResponseWriter, v any) {
 	json.NewEncoder(w).Encode(v)
 }
 
+// respondJSONStatus writes v as JSON with an explicit HTTP status. The
+// Content-Type header must be set before WriteHeader, so callers can't
+// compose this from respondJSON themselves.
+func respondJSONStatus(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
 // respondHTML sets the Content-Type header for HTML responses.
 func respondHTML(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -124,18 +124,8 @@ func (s *Server) parseTemplates() map[string]*template.Template {
 	funcMap := template.FuncMap{
 		"divGB": models.BytesToGB,
 		// cssID sanitizes a string so it's safe to use as both an HTML id
-		// attribute and a CSS selector. Model IDs can contain '.' (e.g.
-		// "Qwen3.6"), which CSS parses as a class separator and errors on.
-		"cssID": func(s string) string {
-			return strings.Map(func(r rune) rune {
-				switch {
-				case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
-					return r
-				default:
-					return '_'
-				}
-			}, s)
-		},
+		// attribute and a CSS selector (see domID in hf.go).
+		"cssID": domID,
 		// deref turns a pointer like *int / *bool / *string / *float64
 		// into its underlying value for templates. Non-pointers pass
 		// through; nil pointers return empty string.
@@ -479,34 +469,18 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	// a load icon and a loaded/loading tag when the router has them resident.
 	availableHTML := "<p>None</p>"
 	if routerStatus.State == process.StateRunning {
-		// Build two lookups from the running router's /models endpoint:
-		//   routerKnown — every model the router actually serves (i.e. is in
-		//                 its current preset), regardless of load state.
-		//   loadedState — those currently loaded/loading, for the status tag.
-		// The router reads preset.ini only at startup, so a model enabled in
-		// config but absent from routerKnown isn't truly available yet — it
-		// needs a restart. Such models are excluded below so "Available"
-		// reflects what the running server can actually serve.
-		routerKnown := map[string]bool{}
-		loadedState := map[string]string{}
-		if loaded, err := s.process.ListModels(); err == nil {
-			for _, lm := range loaded {
-				for _, name := range append([]string{lm.ID, lm.Model}, lm.Aliases...) {
-					if name == "" {
-						continue
-					}
-					routerKnown[name] = true
-					if lm.Status.Value == "loaded" || lm.Status.Value == "loading" {
-						loadedState[name] = lm.Status.Value
-					}
-				}
-			}
-		}
+		// routerKnownStates maps every name the running router serves (i.e.
+		// is in its current preset) to its status. The router reads
+		// preset.ini only at startup, so a model enabled in config but
+		// absent from the map isn't truly available yet — it needs a
+		// restart. Such models are excluded below so "Available" reflects
+		// what the running server can actually serve.
+		routerStates := s.routerKnownStates()
 
 		var buf strings.Builder
 		shown := 0
 		for _, m := range registeredModels {
-			if models.IsEmbeddingModel(m.ModelID) || models.IsEmbeddingModel(m.ID) {
+			if m.IsEmbedding() {
 				continue
 			}
 			cfg, err := s.registry.GetConfig(m.ID)
@@ -515,17 +489,15 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			}
 
 			routerName := s.registry.RouterName(m.ID)
-			if !routerKnown[routerName] && !routerKnown[m.ID] && !routerKnown[m.PublicName()] {
+			state, known := routerStateFor(routerStates, routerName, m.ID, m.PublicName())
+			if !known {
 				// Enabled in config but not in the running router's preset:
 				// not available until the router is restarted. Don't list it.
 				continue
 			}
-			state := loadedState[routerName]
-			if state == "" {
-				state = loadedState[m.ID]
-			}
-			if state == "" {
-				state = loadedState[m.PublicName()]
+			if state != "loaded" && state != "loading" {
+				// Idle states render no tag and offer the load button.
+				state = ""
 			}
 
 			tag := ""

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tmlabonte/llamactl/internal/builder"
 	"github.com/tmlabonte/llamactl/internal/models"
 	"github.com/tmlabonte/llamactl/internal/process"
 )
@@ -100,6 +99,22 @@ func countNonZeroSplit(s string) int {
 	return n
 }
 
+// resolveRouterModel finds the registry model (and config) behind a router
+// entry, matching the router-section ID first, then each alias. The router's
+// primary ID may not equal the registry ID, so both are tried. Shared by
+// handlePS and renderLoadedModelsJSON.
+func (s *Server) resolveRouterModel(rm process.ModelStatus) (*models.Model, *models.ModelConfig) {
+	reg, cfg := s.findModelByAny(rm.ID)
+	if reg == nil {
+		for _, a := range rm.Aliases {
+			if reg, cfg = s.findModelByAny(a); reg != nil {
+				break
+			}
+		}
+	}
+	return reg, cfg
+}
+
 // handlePS returns currently loaded models with resource info, similar to Ollama's /api/ps.
 func (s *Server) handlePS(w http.ResponseWriter, r *http.Request) {
 	type psModel struct {
@@ -121,18 +136,10 @@ func (s *Server) handlePS(w http.ResponseWriter, r *http.Request) {
 					Status: rm.Status.Value,
 				}
 				// Enrich with registry metadata if available
-				// Try matching by router ID, then by aliases
-				var regModel *models.Model
-				for _, alias := range append([]string{rm.ID}, rm.Aliases...) {
-					if m, err := s.registry.Get(alias); err == nil {
-						regModel = m
-						break
-					}
-				}
-				if regModel != nil {
+				if regModel, cfg := s.resolveRouterModel(rm); regModel != nil {
 					pm.Arch = regModel.Arch
 					pm.VRAMEstGB = regModel.VRAMEstGB
-					if cfg, err := s.registry.GetConfig(regModel.ID); err == nil {
+					if cfg != nil {
 						pm.ContextSize = cfg.ContextSize
 						pm.VRAMEstGB = models.VRAMEstimateForConfig(regModel, cfg)
 					}
@@ -272,18 +279,10 @@ func (s *Server) renderLoadedModelsJSON(w http.ResponseWriter) {
 			Aliases: rm.Aliases,
 		}
 		// Find the registry model behind this router entry so we can surface
-		// its canonical IDs and capability block. Match by router-section name
-		// first, then by alias (the router's primary ID may not equal m.ID).
-		// Folding capabilities in here lets a client auto-configure from this
-		// single request instead of fanning out to /info per model.
-		reg, cfg := s.findModelByAny(rm.ID)
-		if reg == nil {
-			for _, a := range rm.Aliases {
-				if reg, cfg = s.findModelByAny(a); reg != nil {
-					break
-				}
-			}
-		}
+		// its canonical IDs and capability block. Folding capabilities in
+		// here lets a client auto-configure from this single request instead
+		// of fanning out to /info per model.
+		reg, cfg := s.resolveRouterModel(rm)
 		if reg != nil {
 			entry.RegistryID = reg.ID
 			entry.PublicName = reg.PublicName()
@@ -399,23 +398,11 @@ func (s *Server) handleDeactivateModel(w http.ResponseWriter, r *http.Request) {
 func (s *Server) startRouter() error {
 	// Find the build binary. Explicit selection wins; otherwise fall back
 	// to the successful build with the newest GitRef.
-	binaryPath := ""
-	if s.cfg.ActiveBuild != "" {
-		for _, b := range s.builder.List() {
-			if b.ID == s.cfg.ActiveBuild && b.Status == builder.BuildStatusSuccess {
-				binaryPath = b.BinaryPath
-				break
-			}
-		}
-	}
-	if binaryPath == "" {
-		if b := s.builder.LatestSuccessfulBuild(); b != nil {
-			binaryPath = b.BinaryPath
-		}
-	}
-	if binaryPath == "" {
+	build := s.resolveActiveBuild()
+	if build == nil || build.BinaryPath == "" {
 		return fmt.Errorf("no compiled build available — build llama.cpp first")
 	}
+	binaryPath := build.BinaryPath
 
 	// Generate preset INI from model configs
 	presetPath, err := s.registry.WritePresetINI()
@@ -586,7 +573,7 @@ func (s *Server) handleGetModelConfig(w http.ResponseWriter, r *http.Request) {
 			maxContext = model.ContextLength
 			detectedMMProj = models.FindMMProj(model.FilePath)
 			detectedMTP = models.FindMTP(model.FilePath)
-			isEmbedding = models.IsEmbeddingModel(model.ModelID) || models.IsEmbeddingModel(model.ID)
+			isEmbedding = model.IsEmbedding()
 			if !isEmbedding {
 				draftCandidates = s.registry.FindDraftCandidates(id)
 			}

--- a/internal/api/v1models.go
+++ b/internal/api/v1models.go
@@ -9,21 +9,6 @@ import (
 
 // openAIModel builds an OpenAI-compatible Model object with a meta extension.
 func (s *Server) openAIModel(m *models.Model, cfg *models.ModelConfig) map[string]any {
-	// Capabilities
-	var capabilities []string
-	isEmbedding := models.IsEmbeddingModel(m.ModelID) || models.IsEmbeddingModel(m.ID)
-	if isEmbedding {
-		capabilities = append(capabilities, "embedding")
-	} else {
-		capabilities = append(capabilities, "chat")
-	}
-	if m.SupportsTools {
-		capabilities = append(capabilities, "tools")
-	}
-	if m.HasBuiltinVision || (cfg != nil && cfg.MmprojPath != "") {
-		capabilities = append(capabilities, "vision")
-	}
-
 	meta := map[string]any{
 		"arch":         m.Arch,
 		"quant":        m.Quant,
@@ -31,7 +16,7 @@ func (s *Server) openAIModel(m *models.Model, cfg *models.ModelConfig) map[strin
 		"n_embd":       m.NEmbd,
 		"n_ctx_train":  m.ContextLength,
 		"size":         m.SizeBytes,
-		"capabilities": capabilities,
+		"capabilities": m.Capabilities(cfg),
 	}
 	if cfg != nil {
 		// 0 means "use model default" (n_ctx_train)
@@ -80,9 +65,7 @@ func (s *Server) handleV1Model(w http.ResponseWriter, r *http.Request) {
 
 	m, cfg := s.findModelByAny(id)
 	if m == nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		respondJSON(w, map[string]any{
+		respondJSONStatus(w, http.StatusNotFound, map[string]any{
 			"error": map[string]any{
 				"message": "model not found: " + id,
 				"type":    "invalid_request_error",

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -1,0 +1,99 @@
+// Package broadcast provides the mutex-protected fan-out primitive shared
+// by the build-log, router-log, and download-progress streams: subscribers
+// are channels, recent values are retained and replayed to new subscribers,
+// and sends never block (a subscriber that falls behind misses values
+// rather than stalling the producer).
+package broadcast
+
+import "sync"
+
+// Broadcaster fans values out to subscriber channels.
+type Broadcaster[T any] struct {
+	mu       sync.Mutex
+	history  []T
+	histSize int
+	chanCap  int
+	subs     map[chan T]struct{}
+}
+
+// New creates a Broadcaster retaining up to histSize values as replayable
+// history (0 = no history). Subscriber channels are buffered to chanCap.
+func New[T any](histSize, chanCap int) *Broadcaster[T] {
+	return &Broadcaster[T]{
+		histSize: histSize,
+		chanCap:  chanCap,
+		subs:     make(map[chan T]struct{}),
+	}
+}
+
+// Subscribe registers a new subscriber channel, replaying retained history
+// into it first.
+func (b *Broadcaster[T]) Subscribe() chan T {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := make(chan T, b.chanCap)
+	for _, v := range b.history {
+		select {
+		case ch <- v:
+		default:
+		}
+	}
+	b.subs[ch] = struct{}{}
+	return ch
+}
+
+// Unsubscribe removes a subscriber. The channel is not closed.
+func (b *Broadcaster[T]) Unsubscribe(ch chan T) {
+	b.mu.Lock()
+	delete(b.subs, ch)
+	b.mu.Unlock()
+}
+
+// Broadcast retains v in history (dropping the oldest value when full) and
+// sends it to all subscribers without blocking.
+func (b *Broadcaster[T]) Broadcast(v T) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.histSize > 0 {
+		if len(b.history) >= b.histSize {
+			b.history = b.history[1:]
+		}
+		b.history = append(b.history, v)
+	}
+	for ch := range b.subs {
+		select {
+		case ch <- v:
+		default:
+		}
+	}
+}
+
+// Last returns the most recently broadcast value, if any is retained.
+func (b *Broadcaster[T]) Last() (T, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.history) == 0 {
+		var zero T
+		return zero, false
+	}
+	return b.history[len(b.history)-1], true
+}
+
+// ClearHistory discards retained history so it won't replay to new
+// subscribers. Existing subscribers are unaffected.
+func (b *Broadcaster[T]) ClearHistory() {
+	b.mu.Lock()
+	b.history = nil
+	b.mu.Unlock()
+}
+
+// CloseSubscribers closes and drops all subscriber channels, signalling
+// end-of-stream. History is kept so later subscribers still get a replay.
+func (b *Broadcaster[T]) CloseSubscribers() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subs {
+		close(ch)
+	}
+	b.subs = make(map[chan T]struct{})
+}

--- a/internal/broadcast/broadcast_test.go
+++ b/internal/broadcast/broadcast_test.go
@@ -1,0 +1,111 @@
+package broadcast
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestHistoryReplayAndRing(t *testing.T) {
+	b := New[int](3, 8)
+	for i := 1; i <= 5; i++ {
+		b.Broadcast(i)
+	}
+	ch := b.Subscribe()
+	// Ring size 3 → only 3, 4, 5 retained.
+	for _, want := range []int{3, 4, 5} {
+		if got := <-ch; got != want {
+			t.Fatalf("replay = %d, want %d", got, want)
+		}
+	}
+	if last, ok := b.Last(); !ok || last != 5 {
+		t.Fatalf("Last() = %d, %v; want 5, true", last, ok)
+	}
+}
+
+func TestSubscribeReceivesNewValues(t *testing.T) {
+	b := New[string](0, 4)
+	ch := b.Subscribe()
+	b.Broadcast("a")
+	if got := <-ch; got != "a" {
+		t.Fatalf("got %q, want %q", got, "a")
+	}
+	b.Unsubscribe(ch)
+	b.Broadcast("b")
+	select {
+	case v := <-ch:
+		t.Fatalf("received %q after unsubscribe", v)
+	default:
+	}
+}
+
+func TestNonBlockingSendDropsWhenFull(t *testing.T) {
+	b := New[int](0, 1)
+	ch := b.Subscribe()
+	b.Broadcast(1)
+	b.Broadcast(2) // dropped: subscriber buffer full
+	if got := <-ch; got != 1 {
+		t.Fatalf("got %d, want 1", got)
+	}
+	select {
+	case v := <-ch:
+		t.Fatalf("expected drop, received %d", v)
+	default:
+	}
+}
+
+func TestCloseSubscribersKeepsHistory(t *testing.T) {
+	b := New[int](2, 4)
+	ch := b.Subscribe()
+	b.Broadcast(7)
+	b.CloseSubscribers()
+	// Drain the value, then confirm the channel is closed.
+	if got := <-ch; got != 7 {
+		t.Fatalf("got %d, want 7", got)
+	}
+	if _, open := <-ch; open {
+		t.Fatal("channel still open after CloseSubscribers")
+	}
+	// History survives for later subscribers.
+	ch2 := b.Subscribe()
+	if got := <-ch2; got != 7 {
+		t.Fatalf("replay after close = %d, want 7", got)
+	}
+}
+
+func TestClearHistory(t *testing.T) {
+	b := New[int](4, 4)
+	b.Broadcast(1)
+	b.ClearHistory()
+	ch := b.Subscribe()
+	select {
+	case v := <-ch:
+		t.Fatalf("unexpected replay %d after ClearHistory", v)
+	default:
+	}
+}
+
+func TestConcurrentUse(t *testing.T) {
+	b := New[int](16, 16)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				b.Broadcast(j)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			ch := b.Subscribe()
+			for j := 0; j < 50; j++ {
+				select {
+				case <-ch:
+				default:
+				}
+			}
+			b.Unsubscribe(ch)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/tmlabonte/llamactl/internal/broadcast"
 )
 
 const (
@@ -56,22 +58,20 @@ type Builder struct {
 	logChs map[string]chan string
 
 	// Log history and broadcasting per build
-	logMu         sync.Mutex
-	logHistory    map[string][]string              // build ID → log lines
-	logSubs       map[string]map[chan string]struct{} // build ID → subscribers
-	lastBuildID   string                           // most recent build ID
+	logMu       sync.Mutex
+	logBcasts   map[string]*broadcast.Broadcaster[string] // build ID → log stream
+	lastBuildID string                                    // most recent build ID
 
-	refsMu    sync.Mutex
+	refsMu     sync.Mutex
 	cachedRefs []string
 }
 
 // NewBuilder creates a Builder and loads persisted build state.
 func NewBuilder(dataDir string) *Builder {
 	b := &Builder{
-		dataDir:    dataDir,
-		logChs:     make(map[string]chan string),
-		logHistory: make(map[string][]string),
-		logSubs:    make(map[string]map[chan string]struct{}),
+		dataDir:   dataDir,
+		logChs:    make(map[string]chan string),
+		logBcasts: make(map[string]*broadcast.Broadcaster[string]),
 	}
 	b.loadBuilds()
 	return b
@@ -84,6 +84,19 @@ func (b *Builder) List() []BuildResult {
 	out := make([]BuildResult, len(b.builds))
 	copy(out, b.builds)
 	return out
+}
+
+// Find returns a copy of the build with the given ID, or false if unknown.
+func (b *Builder) Find(id string) (*BuildResult, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, br := range b.builds {
+		if br.ID == id {
+			out := br
+			return &out, true
+		}
+	}
+	return nil, false
 }
 
 // LatestSuccessfulBuild returns the successful build with the newest GitRef
@@ -143,59 +156,35 @@ func (b *Builder) LogChannel(buildID string) (<-chan string, bool) {
 	return ch, ok
 }
 
+// logBcast returns the log broadcaster for a build, or nil if the build has
+// no logs this process run.
+func (b *Builder) logBcast(buildID string) *broadcast.Broadcaster[string] {
+	b.logMu.Lock()
+	defer b.logMu.Unlock()
+	return b.logBcasts[buildID]
+}
+
 // SubscribeLogs returns a channel that receives log lines for a build,
 // starting with any existing history. Returns nil if the build has no logs.
 func (b *Builder) SubscribeLogs(buildID string) chan string {
-	b.logMu.Lock()
-	defer b.logMu.Unlock()
-
-	history := b.logHistory[buildID]
-	if history == nil {
-		// No log history — check if build is still running with old channel
+	bc := b.logBcast(buildID)
+	if bc == nil {
 		return nil
 	}
-
-	ch := make(chan string, buildLogHistorySize)
-	// Replay history
-	for _, line := range history {
-		select {
-		case ch <- line:
-		default:
-		}
-	}
-
-	// Register as subscriber for new lines
-	if b.logSubs[buildID] == nil {
-		b.logSubs[buildID] = make(map[chan string]struct{})
-	}
-	b.logSubs[buildID][ch] = struct{}{}
-	return ch
+	return bc.Subscribe()
 }
 
 // UnsubscribeLogs removes a log subscriber.
 func (b *Builder) UnsubscribeLogs(buildID string, ch chan string) {
-	b.logMu.Lock()
-	defer b.logMu.Unlock()
-	if subs := b.logSubs[buildID]; subs != nil {
-		delete(subs, ch)
+	if bc := b.logBcast(buildID); bc != nil {
+		bc.Unsubscribe(ch)
 	}
 }
 
 // broadcastLog stores a log line and sends it to all subscribers.
 func (b *Builder) broadcastLog(buildID, line string) {
-	b.logMu.Lock()
-	defer b.logMu.Unlock()
-
-	if len(b.logHistory[buildID]) >= buildLogHistorySize {
-		b.logHistory[buildID] = b.logHistory[buildID][1:]
-	}
-	b.logHistory[buildID] = append(b.logHistory[buildID], line)
-
-	for ch := range b.logSubs[buildID] {
-		select {
-		case ch <- line:
-		default:
-		}
+	if bc := b.logBcast(buildID); bc != nil {
+		bc.Broadcast(line)
 	}
 }
 
@@ -249,22 +238,9 @@ func (b *Builder) Build(ctx context.Context, profile string, gitRef string, tag 
 		return nil, fmt.Errorf("invalid tag %q: only lowercase letters, digits, and hyphens are allowed", tag)
 	}
 
-	// Apply option overrides to the profile's cmake flags
-	if optionOverrides != nil {
-		options := ProfileOptions(profile)
-		for _, opt := range options {
-			if enabled, ok := optionOverrides[opt.Flag]; ok && enabled {
-				prof.CMakeFlags[opt.Flag] = "ON"
-			}
-		}
-	} else {
-		// Apply defaults when no overrides specified (e.g. JSON API)
-		for _, opt := range ProfileOptions(profile) {
-			if opt.Default {
-				prof.CMakeFlags[opt.Flag] = "ON"
-			}
-		}
-	}
+	// Apply option overrides (or defaults) to the profile's cmake flags,
+	// using the same resolution as the API's flag preview.
+	ApplyOptionOverrides(prof.CMakeFlags, ProfileOptions(profile), optionOverrides)
 
 	// Parse extra cmake flags (e.g. "-DFOO=BAR -DBAZ=ON")
 	if extraCMake != "" {
@@ -347,9 +323,10 @@ func (b *Builder) Build(ctx context.Context, profile string, gitRef string, tag 
 	b.lastBuildID = result.ID
 	b.mu.Unlock()
 
-	// Initialize log history for this build
+	// (Re)create the log stream for this build, discarding any history
+	// from a previous build with the same ID.
 	b.logMu.Lock()
-	b.logHistory[result.ID] = nil
+	b.logBcasts[result.ID] = broadcast.New[string](buildLogHistorySize, buildLogHistorySize)
 	b.logMu.Unlock()
 
 	// Run the actual build asynchronously
@@ -386,13 +363,11 @@ func (b *Builder) Delete(id string) error {
 func (b *Builder) runBuild(ctx context.Context, prof BuildProfile, srcDir string, result *BuildResult, logCh chan string) {
 	defer func() {
 		close(logCh)
-		// Close all subscriber channels for this build
-		b.logMu.Lock()
-		for ch := range b.logSubs[result.ID] {
-			close(ch)
+		// Close all subscriber channels for this build; history is kept so
+		// later subscribers still get a replay.
+		if bc := b.logBcast(result.ID); bc != nil {
+			bc.CloseSubscribers()
 		}
-		delete(b.logSubs, result.ID)
-		b.logMu.Unlock()
 	}()
 
 	sendLog := func(msg string) {

--- a/internal/builder/profiles.go
+++ b/internal/builder/profiles.go
@@ -168,6 +168,25 @@ func DefaultProfiles() []BuildProfile {
 	}
 }
 
+// ApplyOptionOverrides folds a profile's build options into flags: each
+// option is enabled per its Default unless toggled in overrides, and
+// enabled options are set to "ON". Single source of truth shared by the
+// actual build (Builder.Build) and the flag preview (api effectiveCMakeFlags)
+// so the two can't diverge.
+func ApplyOptionOverrides(flags map[string]string, options []BuildOption, overrides map[string]bool) {
+	for _, opt := range options {
+		enabled := opt.Default
+		if overrides != nil {
+			if v, ok := overrides[opt.Flag]; ok {
+				enabled = v
+			}
+		}
+		if enabled {
+			flags[opt.Flag] = "ON"
+		}
+	}
+}
+
 // FindProfile returns the profile matching the given name.
 func FindProfile(name string) (BuildProfile, bool) {
 	for _, p := range DefaultProfiles() {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -8,25 +8,41 @@ import (
 
 const appName = "llama-toolchest"
 
-// DefaultDataDir returns the platform-appropriate data directory for a host
-// install. Containers override this via the YAML's data_dir field.
-func DefaultDataDir() string {
+// platformAppDirs returns the candidate app-scoped directories for the
+// current OS in priority order: ~/Library/Application Support on darwin,
+// %LOCALAPPDATA% on windows, and on other systems the given XDG env var
+// followed by the home-relative fallback (e.g. ".local/share"). Empty when
+// neither the env var nor a home directory is resolvable. Shared by
+// DefaultDataDir and configSearchPaths so the per-OS resolution lives in
+// one place.
+func platformAppDirs(xdgVar, homeRel string) []string {
 	switch runtime.GOOS {
 	case "darwin":
 		if home, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(home, "Library", "Application Support", appName)
+			return []string{filepath.Join(home, "Library", "Application Support", appName)}
 		}
 	case "windows":
 		if dir := os.Getenv("LOCALAPPDATA"); dir != "" {
-			return filepath.Join(dir, appName)
+			return []string{filepath.Join(dir, appName)}
 		}
 	default:
-		if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
-			return filepath.Join(dir, appName)
+		var dirs []string
+		if dir := os.Getenv(xdgVar); dir != "" {
+			dirs = append(dirs, filepath.Join(dir, appName))
 		}
 		if home, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(home, ".local", "share", appName)
+			dirs = append(dirs, filepath.Join(home, homeRel, appName))
 		}
+		return dirs
+	}
+	return nil
+}
+
+// DefaultDataDir returns the platform-appropriate data directory for a host
+// install. Containers override this via the YAML's data_dir field.
+func DefaultDataDir() string {
+	if dirs := platformAppDirs("XDG_DATA_HOME", filepath.Join(".local", "share")); len(dirs) > 0 {
+		return dirs[0]
 	}
 	return "/data"
 }
@@ -63,27 +79,21 @@ func DefaultConfigPath() string {
 // in priority order. The first existing one wins in DefaultConfigPath.
 func configSearchPaths() []string {
 	const file = "llama-toolchest.yaml"
+	var paths []string
+	for _, dir := range platformAppDirs("XDG_CONFIG_HOME", ".config") {
+		paths = append(paths, filepath.Join(dir, file))
+	}
 	switch runtime.GOOS {
-	case "darwin":
-		if home, err := os.UserHomeDir(); err == nil {
-			return []string{filepath.Join(home, "Library", "Application Support", appName, file)}
-		}
-	case "windows":
-		if dir := os.Getenv("LOCALAPPDATA"); dir != "" {
-			return []string{filepath.Join(dir, appName, file)}
+	case "darwin", "windows":
+		if len(paths) == 0 {
+			return []string{"/data/config/llama-toolchest.yaml"}
 		}
 	default:
-		var paths []string
-		if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-			paths = append(paths, filepath.Join(dir, appName, file))
-		}
-		if home, err := os.UserHomeDir(); err == nil {
-			paths = append(paths, filepath.Join(home, ".config", appName, file))
-		}
 		// System-scope install location, checked after the per-user paths so a
-		// user config still takes precedence when both are present.
+		// user config still takes precedence when both are present. Appended
+		// even when no per-user dir resolves (e.g. a root service without
+		// HOME), so /etc configs are still found — see issue #61.
 		paths = append(paths, filepath.Join("/etc", appName, file))
-		return paths
 	}
-	return []string{"/data/config/llama-toolchest.yaml"}
+	return paths
 }

--- a/internal/huggingface/downloader.go
+++ b/internal/huggingface/downloader.go
@@ -8,9 +8,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
+
+	"github.com/tmlabonte/llamactl/internal/broadcast"
 )
 
 // DownloadStatus tracks progress of a model download.
@@ -26,45 +27,30 @@ type DownloadStatus struct {
 }
 
 type download struct {
-	cancel     context.CancelFunc
-	lastStatus DownloadStatus
+	cancel context.CancelFunc
 
-	// Fan-out to multiple subscribers
-	subMu sync.Mutex
-	subs  map[chan DownloadStatus]struct{}
+	// Fan-out to multiple subscribers. History size 1 means the current
+	// state is retained: replayed to new subscribers (so they see where we
+	// are immediately) and queryable via last() for ListActive/PendingBytes.
+	bc *broadcast.Broadcaster[DownloadStatus]
 }
 
 func (dl *download) broadcast(status DownloadStatus) {
-	dl.subMu.Lock()
-	dl.lastStatus = status
-	for ch := range dl.subs {
-		select {
-		case ch <- status:
-		default:
-		}
-	}
-	dl.subMu.Unlock()
+	dl.bc.Broadcast(status)
 }
 
 func (dl *download) subscribe() chan DownloadStatus {
-	ch := make(chan DownloadStatus, 16)
-	dl.subMu.Lock()
-	dl.subs[ch] = struct{}{}
-	// Send current state immediately so subscriber sees where we are
-	if dl.lastStatus.Status != "" {
-		select {
-		case ch <- dl.lastStatus:
-		default:
-		}
-	}
-	dl.subMu.Unlock()
-	return ch
+	return dl.bc.Subscribe()
 }
 
 func (dl *download) unsubscribe(ch chan DownloadStatus) {
-	dl.subMu.Lock()
-	delete(dl.subs, ch)
-	dl.subMu.Unlock()
+	dl.bc.Unsubscribe(ch)
+}
+
+// last returns the most recent status (zero value before the first broadcast).
+func (dl *download) last() DownloadStatus {
+	s, _ := dl.bc.Last()
+	return s
 }
 
 // CompletionFunc is called when a download finishes successfully.
@@ -102,8 +88,8 @@ func (d *Downloader) SetOnComplete(fn CompletionFunc) {
 // when the size is unknown.
 func (d *Downloader) Start(ctx context.Context, modelID, filename string, expectedBytes int64) (string, error) {
 	// Create a stable download ID — replace all slashes to keep it URL-safe
-	safeName := strings.ReplaceAll(modelID, "/", "--")
-	safeFilename := strings.ReplaceAll(strings.TrimSuffix(filename, ".gguf"), "/", "--")
+	safeName := SafeModelID(modelID)
+	safeFilename := SafeFileID(filename)
 	downloadID := fmt.Sprintf("%s--%s", safeName, safeFilename)
 
 	d.mu.Lock()
@@ -115,17 +101,17 @@ func (d *Downloader) Start(ctx context.Context, modelID, filename string, expect
 	dlCtx, cancel := context.WithCancel(context.Background())
 	dl := &download{
 		cancel: cancel,
-		subs:   make(map[chan DownloadStatus]struct{}),
-		// Seed lastStatus so PendingBytes counts this download immediately,
-		// before run() reports its first progress tick.
-		lastStatus: DownloadStatus{
-			ID:         downloadID,
-			ModelID:    modelID,
-			Filename:   filename,
-			TotalBytes: expectedBytes,
-			Status:     "downloading",
-		},
+		bc:     broadcast.New[DownloadStatus](1, 16),
 	}
+	// Seed the status so PendingBytes counts this download immediately,
+	// before run() reports its first progress tick.
+	dl.broadcast(DownloadStatus{
+		ID:         downloadID,
+		ModelID:    modelID,
+		Filename:   filename,
+		TotalBytes: expectedBytes,
+		Status:     "downloading",
+	})
 	d.active[downloadID] = dl
 	d.mu.Unlock()
 
@@ -162,11 +148,9 @@ func (d *Downloader) ListActive() []DownloadStatus {
 	defer d.mu.Unlock()
 	var out []DownloadStatus
 	for _, dl := range d.active {
-		dl.subMu.Lock()
-		if dl.lastStatus.Status == "downloading" {
-			out = append(out, dl.lastStatus)
+		if s := dl.last(); s.Status == "downloading" {
+			out = append(out, s)
 		}
-		dl.subMu.Unlock()
 	}
 	return out
 }
@@ -180,9 +164,7 @@ func (d *Downloader) PendingBytes() int64 {
 	defer d.mu.Unlock()
 	var pending int64
 	for _, dl := range d.active {
-		dl.subMu.Lock()
-		s := dl.lastStatus
-		dl.subMu.Unlock()
+		s := dl.last()
 		if s.Status != "downloading" {
 			continue
 		}
@@ -251,7 +233,7 @@ func (d *Downloader) run(ctx context.Context, downloadID, modelID, filename stri
 
 	// Setup directory under the configured models dir (which may live
 	// outside dataDir if ModelsDir is set).
-	safeName := strings.ReplaceAll(modelID, "/", "--")
+	safeName := SafeModelID(modelID)
 	modelDir := filepath.Join(d.modelsDir, safeName)
 	os.MkdirAll(modelDir, 0o755)
 

--- a/internal/huggingface/names.go
+++ b/internal/huggingface/names.go
@@ -1,0 +1,17 @@
+package huggingface
+
+import "strings"
+
+// SafeModelID returns the URL/filesystem-safe form of an HF model ID:
+// slashes become "--". It names the per-model download directory and
+// prefixes download and registry IDs — the single canonical definition
+// of the transformation.
+func SafeModelID(modelID string) string {
+	return strings.ReplaceAll(modelID, "/", "--")
+}
+
+// SafeFileID returns the URL-safe ID fragment for a GGUF filename: the
+// ".gguf" suffix is dropped and slashes become "--".
+func SafeFileID(filename string) string {
+	return strings.ReplaceAll(strings.TrimSuffix(filename, ".gguf"), "/", "--")
+}

--- a/internal/models/gpu_assign.go
+++ b/internal/models/gpu_assign.go
@@ -117,8 +117,7 @@ func ResolveGPUAssign(assign string, numGPUs int) (tensorSplit, splitMode string
 
 	// "tensor-N" — tensor parallelism on first N GPUs
 	if strings.HasPrefix(assign, "tensor-") {
-		var n int
-		if _, err := fmt.Sscanf(assign, "tensor-%d", &n); err == nil && n > 0 {
+		if n, ok := parseTensorAssign(assign); ok {
 			if n >= numGPUs {
 				return "", "tensor", 0
 			}
@@ -153,6 +152,16 @@ func ResolveGPUAssign(assign string, numGPUs int) (tensorSplit, splitMode string
 	}
 
 	return strings.Join(parts, ","), "layer", gpus[0]
+}
+
+// parseTensorAssign parses a "tensor-N" GPU assignment, returning N and
+// whether the value was a valid tensor assignment (N > 0).
+func parseTensorAssign(assign string) (int, bool) {
+	var n int
+	if _, err := fmt.Sscanf(assign, "tensor-%d", &n); err == nil && n > 0 {
+		return n, true
+	}
+	return 0, false
 }
 
 // parseGPURange parses GPU assignment values like "0", "0-1", "2-3" into indices.
@@ -218,7 +227,7 @@ func ComputeAllocations(modelList []*Model, configs map[string]*ModelConfig, num
 
 		allocs = append(allocs, GPUAllocation{
 			ModelID:   m.ID,
-			ModelName: shortModelName(m.ModelID),
+			ModelName: ShortModelName(m.ModelID),
 			GPUs:      gpus,
 			PerGPUGB:  perGPU,
 			TotalGB:   totalGB,
@@ -233,8 +242,7 @@ func ComputeAllocations(modelList []*Model, configs map[string]*ModelConfig, num
 // resolveModelGPUs determines which GPUs a model is assigned to.
 func resolveModelGPUs(cfg *ModelConfig, numGPUs int) []int {
 	if strings.HasPrefix(cfg.GPUAssign, "tensor-") {
-		var n int
-		if _, err := fmt.Sscanf(cfg.GPUAssign, "tensor-%d", &n); err == nil && n > 0 {
+		if n, ok := parseTensorAssign(cfg.GPUAssign); ok {
 			if n > numGPUs {
 				n = numGPUs
 			}
@@ -260,8 +268,9 @@ func resolveModelGPUs(cfg *ModelConfig, numGPUs int) []int {
 	return all
 }
 
-// shortModelName extracts a short display name from a model ID like "org/repo-GGUF".
-func shortModelName(modelID string) string {
+// ShortModelName extracts a short display name from a model ID like
+// "org/repo-GGUF": strips the org prefix and common GGUF suffixes.
+func ShortModelName(modelID string) string {
 	// Strip org prefix
 	if idx := strings.LastIndex(modelID, "/"); idx >= 0 {
 		modelID = modelID[idx+1:]

--- a/internal/models/preset.go
+++ b/internal/models/preset.go
@@ -73,7 +73,7 @@ func GeneratePresetINI(modelsDir string, models []*Model, configs map[string]*Mo
 		}
 		b.WriteString(fmt.Sprintf("alias = %s\n", strings.Join(aliasList, ",")))
 
-		isEmbed := IsEmbeddingModel(m.ModelID) || IsEmbeddingModel(m.ID)
+		isEmbed := m.IsEmbedding()
 		writeConfigParams(&b, cfg, isEmbed)
 		b.WriteString("\n")
 	}
@@ -139,90 +139,9 @@ func writeConfigParams(b *strings.Builder, cfg *ModelConfig, isEmbedding bool) {
 		if cfg.MmprojPath != "" && !cfg.MmprojDisabled {
 			b.WriteString(fmt.Sprintf("mmproj = %s\n", cfg.MmprojPath))
 		}
-		// Speculative decoding. llama.cpp split the legacy mode-agnostic
-		// flags (--draft-max, --draft-min, --spec-ngram-size-n/m) into
-		// mode-specific flags. Emit the right name based on SpecType.
-		switch cfg.SpecType {
-		case "draft":
-			b.WriteString("spec-type = draft-simple\n")
-			if cfg.DraftModelPath != "" {
-				b.WriteString(fmt.Sprintf("model-draft = %s\n", cfg.DraftModelPath))
-			}
-			if cfg.DraftMax > 0 {
-				b.WriteString(fmt.Sprintf("spec-draft-n-max = %d\n", cfg.DraftMax))
-			}
-			if cfg.DraftMin > 0 {
-				b.WriteString(fmt.Sprintf("spec-draft-n-min = %d\n", cfg.DraftMin))
-			}
-			if cfg.DraftPMin != "" {
-				b.WriteString(fmt.Sprintf("spec-draft-p-min = %s\n", cfg.DraftPMin))
-			}
-			if cfg.DraftCtxSize > 0 {
-				b.WriteString(fmt.Sprintf("ctx-size-draft = %d\n", cfg.DraftCtxSize))
-			}
-			if cfg.DraftGPULayers > 0 {
-				b.WriteString(fmt.Sprintf("gpu-layers-draft = %d\n", cfg.DraftGPULayers))
-			}
-			if cfg.DraftDevice != "" {
-				b.WriteString(fmt.Sprintf("device-draft = %s\n", cfg.DraftDevice))
-			}
-			if cfg.DraftCPUMoE > 0 {
-				b.WriteString(fmt.Sprintf("n-cpu-moe-draft = %d\n", cfg.DraftCPUMoE))
-			}
-			if cfg.DraftKVCacheQuant != "" {
-				b.WriteString(fmt.Sprintf("cache-type-k-draft = %s\n", cfg.DraftKVCacheQuant))
-				b.WriteString(fmt.Sprintf("cache-type-v-draft = %s\n", cfg.DraftKVCacheQuant))
-			}
-		case "draft-mtp":
-			b.WriteString("spec-type = draft-mtp\n")
-			// Separate drafter head (gemma-4); empty for self-speculation MTP.
-			if cfg.MtpPath != "" && !cfg.MtpDisabled {
-				b.WriteString(fmt.Sprintf("model-draft = %s\n", cfg.MtpPath))
-				if cfg.DraftCtxSize > 0 {
-					b.WriteString(fmt.Sprintf("ctx-size-draft = %d\n", cfg.DraftCtxSize))
-				}
-				if cfg.DraftGPULayers > 0 {
-					b.WriteString(fmt.Sprintf("gpu-layers-draft = %d\n", cfg.DraftGPULayers))
-				}
-				if cfg.DraftDevice != "" {
-					b.WriteString(fmt.Sprintf("device-draft = %s\n", cfg.DraftDevice))
-				}
-				if cfg.DraftCPUMoE > 0 {
-					b.WriteString(fmt.Sprintf("n-cpu-moe-draft = %d\n", cfg.DraftCPUMoE))
-				}
-				if cfg.DraftKVCacheQuant != "" {
-					b.WriteString(fmt.Sprintf("cache-type-k-draft = %s\n", cfg.DraftKVCacheQuant))
-					b.WriteString(fmt.Sprintf("cache-type-v-draft = %s\n", cfg.DraftKVCacheQuant))
-				}
-			}
-			if cfg.DraftMax > 0 {
-				b.WriteString(fmt.Sprintf("spec-draft-n-max = %d\n", cfg.DraftMax))
-			}
-			if cfg.DraftMin > 0 {
-				b.WriteString(fmt.Sprintf("spec-draft-n-min = %d\n", cfg.DraftMin))
-			}
-			if cfg.DraftPMin != "" {
-				b.WriteString(fmt.Sprintf("spec-draft-p-min = %s\n", cfg.DraftPMin))
-			}
-		case "ngram-mod":
-			b.WriteString(fmt.Sprintf("spec-type = %s\n", cfg.SpecType))
-			if cfg.DraftMax > 0 {
-				b.WriteString(fmt.Sprintf("spec-ngram-mod-n-max = %d\n", cfg.DraftMax))
-			}
-			if cfg.DraftMin > 0 {
-				b.WriteString(fmt.Sprintf("spec-ngram-mod-n-min = %d\n", cfg.DraftMin))
-			}
-		case "ngram-simple", "ngram-map-k", "ngram-map-k4v":
-			b.WriteString(fmt.Sprintf("spec-type = %s\n", cfg.SpecType))
-			prefix := "spec-" + cfg.SpecType
-			if cfg.NgramSizeN > 0 {
-				b.WriteString(fmt.Sprintf("%s-size-n = %d\n", prefix, cfg.NgramSizeN))
-			}
-			if cfg.NgramSizeM > 0 {
-				b.WriteString(fmt.Sprintf("%s-size-m = %d\n", prefix, cfg.NgramSizeM))
-			}
-		case "ngram-cache":
-			b.WriteString(fmt.Sprintf("spec-type = %s\n", cfg.SpecType))
+		// Speculative decoding (see specDecodingParams for the SpecType rules).
+		for _, p := range specDecodingParams(cfg) {
+			b.WriteString(fmt.Sprintf("%s = %s\n", p.Name, p.Value))
 		}
 	}
 

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -223,102 +223,9 @@ func (c *ModelConfig) EffectiveFlagsFor(isEmbedding bool) string {
 		if c.MmprojPath != "" && !c.MmprojDisabled {
 			parts = append(parts, "--mmproj", c.MmprojPath)
 		}
-		// Speculative decoding. llama.cpp split the legacy mode-agnostic
-		// flags (--draft-max, --draft-min, --spec-ngram-size-n/m) into
-		// mode-specific flags. Emit the right name based on SpecType.
-		switch c.SpecType {
-		case "draft":
-			// Internal value is still "draft" (legacy config compat) but
-			// llama.cpp renamed the spec-type enum value to "draft-simple"
-			// alongside the introduction of "draft-mtp" and "draft-eagle3".
-			// Without --spec-type, the draft model loads but isn't used —
-			// the default is "none".
-			parts = append(parts, "--spec-type", "draft-simple")
-			if c.DraftModelPath != "" {
-				parts = append(parts, "--model-draft", c.DraftModelPath)
-			}
-			if c.DraftMax > 0 {
-				parts = append(parts, "--spec-draft-n-max", strconv.Itoa(c.DraftMax))
-			}
-			if c.DraftMin > 0 {
-				parts = append(parts, "--spec-draft-n-min", strconv.Itoa(c.DraftMin))
-			}
-			if c.DraftPMin != "" {
-				parts = append(parts, "--spec-draft-p-min", c.DraftPMin)
-			}
-			// Draft model resource overrides. Without these, the draft model
-			// inherits llama-server defaults — which on a large MoE main
-			// model often means no GPU offload for the draft.
-			if c.DraftCtxSize > 0 {
-				parts = append(parts, "--ctx-size-draft", strconv.Itoa(c.DraftCtxSize))
-			}
-			if c.DraftGPULayers > 0 {
-				parts = append(parts, "--gpu-layers-draft", strconv.Itoa(c.DraftGPULayers))
-			}
-			if c.DraftDevice != "" {
-				parts = append(parts, "--device-draft", c.DraftDevice)
-			}
-			if c.DraftCPUMoE > 0 {
-				parts = append(parts, "--n-cpu-moe-draft", strconv.Itoa(c.DraftCPUMoE))
-			}
-			if c.DraftKVCacheQuant != "" {
-				parts = append(parts, "--cache-type-k-draft", c.DraftKVCacheQuant, "--cache-type-v-draft", c.DraftKVCacheQuant)
-			}
-		case "draft-mtp":
-			// Two MTP flavors share this spec-type:
-			//   • Self-speculation (Qwen3.6, DeepSeek-V3): the MTP head is baked
-			//     into the main GGUF, so MtpPath is empty — no --model-draft and
-			//     the draft-resource flags don't apply. Only the sampling knobs do.
-			//   • Separate drafter (gemma-4's "gemma4-assistant" head): the head
-			//     ships as its own GGUF in MtpPath, loaded via --model-draft just
-			//     like a draft-simple model, including the draft-resource overrides.
-			parts = append(parts, "--spec-type", "draft-mtp")
-			if c.MtpPath != "" && !c.MtpDisabled {
-				parts = append(parts, "--model-draft", c.MtpPath)
-				if c.DraftCtxSize > 0 {
-					parts = append(parts, "--ctx-size-draft", strconv.Itoa(c.DraftCtxSize))
-				}
-				if c.DraftGPULayers > 0 {
-					parts = append(parts, "--gpu-layers-draft", strconv.Itoa(c.DraftGPULayers))
-				}
-				if c.DraftDevice != "" {
-					parts = append(parts, "--device-draft", c.DraftDevice)
-				}
-				if c.DraftCPUMoE > 0 {
-					parts = append(parts, "--n-cpu-moe-draft", strconv.Itoa(c.DraftCPUMoE))
-				}
-				if c.DraftKVCacheQuant != "" {
-					parts = append(parts, "--cache-type-k-draft", c.DraftKVCacheQuant, "--cache-type-v-draft", c.DraftKVCacheQuant)
-				}
-			}
-			if c.DraftMax > 0 {
-				parts = append(parts, "--spec-draft-n-max", strconv.Itoa(c.DraftMax))
-			}
-			if c.DraftMin > 0 {
-				parts = append(parts, "--spec-draft-n-min", strconv.Itoa(c.DraftMin))
-			}
-			if c.DraftPMin != "" {
-				parts = append(parts, "--spec-draft-p-min", c.DraftPMin)
-			}
-		case "ngram-mod":
-			parts = append(parts, "--spec-type", c.SpecType)
-			if c.DraftMax > 0 {
-				parts = append(parts, "--spec-ngram-mod-n-max", strconv.Itoa(c.DraftMax))
-			}
-			if c.DraftMin > 0 {
-				parts = append(parts, "--spec-ngram-mod-n-min", strconv.Itoa(c.DraftMin))
-			}
-		case "ngram-simple", "ngram-map-k", "ngram-map-k4v":
-			parts = append(parts, "--spec-type", c.SpecType)
-			prefix := "--spec-" + c.SpecType
-			if c.NgramSizeN > 0 {
-				parts = append(parts, prefix+"-size-n", strconv.Itoa(c.NgramSizeN))
-			}
-			if c.NgramSizeM > 0 {
-				parts = append(parts, prefix+"-size-m", strconv.Itoa(c.NgramSizeM))
-			}
-		case "ngram-cache":
-			parts = append(parts, "--spec-type", c.SpecType)
+		// Speculative decoding (see specDecodingParams for the SpecType rules).
+		for _, p := range specDecodingParams(c) {
+			parts = append(parts, "--"+p.Name, p.Value)
 		}
 	}
 	if c.ExtraFlags != "" {
@@ -942,6 +849,37 @@ func IsEmbeddingModel(name string) bool {
 	return embeddingPattern.MatchString(name)
 }
 
+// IsEmbedding reports whether the model looks like an embedding model.
+// It checks both the HF repo ID and the registry ID because legacy records
+// may have only one populated.
+func (m *Model) IsEmbedding() bool {
+	return IsEmbeddingModel(m.ModelID) || IsEmbeddingModel(m.ID)
+}
+
+// HasVision reports whether the model can accept images — either built-in
+// or via a configured mmproj projector.
+func (m *Model) HasVision(cfg *ModelConfig) bool {
+	return m.HasBuiltinVision || (cfg != nil && cfg.MmprojPath != "")
+}
+
+// Capabilities returns the capability list for a model: "chat" or
+// "embedding", plus "tools" and "vision" when supported.
+func (m *Model) Capabilities(cfg *ModelConfig) []string {
+	var caps []string
+	if m.IsEmbedding() {
+		caps = append(caps, "embedding")
+	} else {
+		caps = append(caps, "chat")
+	}
+	if m.SupportsTools {
+		caps = append(caps, "tools")
+	}
+	if m.HasVision(cfg) {
+		caps = append(caps, "vision")
+	}
+	return caps
+}
+
 // FindMMProj looks for mmproj GGUF files in the same directory as the model,
 // then checks the parent directory (for repos where mmproj is at the root
 // and model GGUFs are in subdirectories, e.g. Mistral-Small-4-119B).
@@ -1130,7 +1068,7 @@ func (r *Registry) FindDraftCandidates(id string) []DraftCandidate {
 			continue
 		}
 		// Skip embedding models
-		if IsEmbeddingModel(m.ModelID) || IsEmbeddingModel(m.ID) {
+		if m.IsEmbedding() {
 			continue
 		}
 		candidates = append(candidates, DraftCandidate{

--- a/internal/models/specflags.go
+++ b/internal/models/specflags.go
@@ -1,0 +1,107 @@
+package models
+
+import "strconv"
+
+// specParam is a launch parameter name (without the "--" prefix) and its
+// value. Callers format params as CLI flags (EffectiveFlagsFor) or INI
+// lines (writeConfigParams).
+type specParam struct {
+	Name  string
+	Value string
+}
+
+// appendDraftResourceParams appends the draft-model resource overrides
+// shared by the "draft" and "draft-mtp" spec types. Without these, the
+// draft model inherits llama-server defaults — which on a large MoE main
+// model often means no GPU offload for the draft.
+func appendDraftResourceParams(params []specParam, c *ModelConfig) []specParam {
+	if c.DraftCtxSize > 0 {
+		params = append(params, specParam{"ctx-size-draft", strconv.Itoa(c.DraftCtxSize)})
+	}
+	if c.DraftGPULayers > 0 {
+		params = append(params, specParam{"gpu-layers-draft", strconv.Itoa(c.DraftGPULayers)})
+	}
+	if c.DraftDevice != "" {
+		params = append(params, specParam{"device-draft", c.DraftDevice})
+	}
+	if c.DraftCPUMoE > 0 {
+		params = append(params, specParam{"n-cpu-moe-draft", strconv.Itoa(c.DraftCPUMoE)})
+	}
+	if c.DraftKVCacheQuant != "" {
+		params = append(params,
+			specParam{"cache-type-k-draft", c.DraftKVCacheQuant},
+			specParam{"cache-type-v-draft", c.DraftKVCacheQuant})
+	}
+	return params
+}
+
+// appendDraftSamplingParams appends the drafting sampling knobs shared by
+// the "draft" and "draft-mtp" spec types.
+func appendDraftSamplingParams(params []specParam, c *ModelConfig) []specParam {
+	if c.DraftMax > 0 {
+		params = append(params, specParam{"spec-draft-n-max", strconv.Itoa(c.DraftMax)})
+	}
+	if c.DraftMin > 0 {
+		params = append(params, specParam{"spec-draft-n-min", strconv.Itoa(c.DraftMin)})
+	}
+	if c.DraftPMin != "" {
+		params = append(params, specParam{"spec-draft-p-min", c.DraftPMin})
+	}
+	return params
+}
+
+// specDecodingParams returns the speculative-decoding launch parameters for
+// the config. llama.cpp split the legacy mode-agnostic flags (--draft-max,
+// --draft-min, --spec-ngram-size-n/m) into mode-specific flags; emit the
+// right name based on SpecType.
+func specDecodingParams(c *ModelConfig) []specParam {
+	var params []specParam
+	switch c.SpecType {
+	case "draft":
+		// Internal value is still "draft" (legacy config compat) but
+		// llama.cpp renamed the spec-type enum value to "draft-simple"
+		// alongside the introduction of "draft-mtp" and "draft-eagle3".
+		// Without --spec-type, the draft model loads but isn't used —
+		// the default is "none".
+		params = append(params, specParam{"spec-type", "draft-simple"})
+		if c.DraftModelPath != "" {
+			params = append(params, specParam{"model-draft", c.DraftModelPath})
+		}
+		params = appendDraftSamplingParams(params, c)
+		params = appendDraftResourceParams(params, c)
+	case "draft-mtp":
+		// Two MTP flavors share this spec-type:
+		//   • Self-speculation (Qwen3.6, DeepSeek-V3): the MTP head is baked
+		//     into the main GGUF, so MtpPath is empty — no --model-draft and
+		//     the draft-resource flags don't apply. Only the sampling knobs do.
+		//   • Separate drafter (gemma-4's "gemma4-assistant" head): the head
+		//     ships as its own GGUF in MtpPath, loaded via --model-draft just
+		//     like a draft-simple model, including the draft-resource overrides.
+		params = append(params, specParam{"spec-type", "draft-mtp"})
+		if c.MtpPath != "" && !c.MtpDisabled {
+			params = append(params, specParam{"model-draft", c.MtpPath})
+			params = appendDraftResourceParams(params, c)
+		}
+		params = appendDraftSamplingParams(params, c)
+	case "ngram-mod":
+		params = append(params, specParam{"spec-type", c.SpecType})
+		if c.DraftMax > 0 {
+			params = append(params, specParam{"spec-ngram-mod-n-max", strconv.Itoa(c.DraftMax)})
+		}
+		if c.DraftMin > 0 {
+			params = append(params, specParam{"spec-ngram-mod-n-min", strconv.Itoa(c.DraftMin)})
+		}
+	case "ngram-simple", "ngram-map-k", "ngram-map-k4v":
+		params = append(params, specParam{"spec-type", c.SpecType})
+		prefix := "spec-" + c.SpecType
+		if c.NgramSizeN > 0 {
+			params = append(params, specParam{prefix + "-size-n", strconv.Itoa(c.NgramSizeN)})
+		}
+		if c.NgramSizeM > 0 {
+			params = append(params, specParam{prefix + "-size-m", strconv.Itoa(c.NgramSizeM)})
+		}
+	case "ngram-cache":
+		params = append(params, specParam{"spec-type", c.SpecType})
+	}
+	return params
+}

--- a/internal/monitor/rocm.go
+++ b/internal/monitor/rocm.go
@@ -99,19 +99,26 @@ func (r *rocmBackend) collectROCmSMI() ([]GPUInfo, error) {
 	return gpus, nil
 }
 
-func (r *rocmBackend) collectSysfs() ([]GPUInfo, error) {
-	var gpus []GPUInfo
-
-	// Iterate over render nodes
+// listAMDGPUDirs returns the sysfs device directories of AMD GPUs
+// (vendor 0x1002) in card order. Shared by collectSysfs and readVRAMSysfs
+// so the card enumeration lives in one place.
+func listAMDGPUDirs() []string {
 	cards, _ := filepath.Glob("/sys/class/drm/card[0-9]*/device/vendor")
-	idx := 0
+	var dirs []string
 	for _, vendorFile := range cards {
 		vendor, _ := os.ReadFile(vendorFile)
 		if strings.TrimSpace(string(vendor)) != "0x1002" {
 			continue
 		}
+		dirs = append(dirs, filepath.Dir(vendorFile))
+	}
+	return dirs
+}
 
-		deviceDir := filepath.Dir(vendorFile)
+func (r *rocmBackend) collectSysfs() ([]GPUInfo, error) {
+	var gpus []GPUInfo
+
+	for idx, deviceDir := range listAMDGPUDirs() {
 		gpu := GPUInfo{Index: idx}
 
 		// GPU utilization
@@ -120,7 +127,7 @@ func (r *rocmBackend) collectSysfs() ([]GPUInfo, error) {
 		}
 
 		// VRAM
-		gpu.VRAMUsedMB, gpu.VRAMTotalMB = readVRAMSysfs(idx)
+		gpu.VRAMUsedMB, gpu.VRAMTotalMB = readVRAMFromDir(deviceDir)
 
 		// Temperature from hwmon
 		hwmonDirs, _ := filepath.Glob(filepath.Join(deviceDir, "hwmon", "hwmon*"))
@@ -143,7 +150,6 @@ func (r *rocmBackend) collectSysfs() ([]GPUInfo, error) {
 
 		gpu.Name = readGPUNameSysfs(idx)
 		gpus = append(gpus, gpu)
-		idx++
 	}
 
 	if len(gpus) == 0 {
@@ -152,32 +158,28 @@ func (r *rocmBackend) collectSysfs() ([]GPUInfo, error) {
 	return gpus, nil
 }
 
+// readVRAMSysfs reads VRAM usage for the Nth AMD GPU. Used by the rocm-smi
+// path, which only knows the GPU index.
 func readVRAMSysfs(gpuIdx int) (usedMB, totalMB int) {
-	// Try /sys/class/drm/card*/device/mem_info_vram_*
-	cards, _ := filepath.Glob("/sys/class/drm/card[0-9]*/device/vendor")
-	idx := 0
-	for _, vendorFile := range cards {
-		vendor, _ := os.ReadFile(vendorFile)
-		if strings.TrimSpace(string(vendor)) != "0x1002" {
-			continue
-		}
-		if idx != gpuIdx {
-			idx++
-			continue
-		}
-
-		deviceDir := filepath.Dir(vendorFile)
-		if data, err := os.ReadFile(filepath.Join(deviceDir, "mem_info_vram_used")); err == nil {
-			bytes, _ := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
-			usedMB = int(bytes / (1024 * 1024))
-		}
-		if data, err := os.ReadFile(filepath.Join(deviceDir, "mem_info_vram_total")); err == nil {
-			bytes, _ := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
-			totalMB = int(bytes / (1024 * 1024))
-		}
-		return
+	dirs := listAMDGPUDirs()
+	if gpuIdx < 0 || gpuIdx >= len(dirs) {
+		return 0, 0
 	}
-	return 0, 0
+	return readVRAMFromDir(dirs[gpuIdx])
+}
+
+// readVRAMFromDir reads /sys/class/drm/card*/device/mem_info_vram_* from an
+// already-resolved device directory.
+func readVRAMFromDir(deviceDir string) (usedMB, totalMB int) {
+	if data, err := os.ReadFile(filepath.Join(deviceDir, "mem_info_vram_used")); err == nil {
+		bytes, _ := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+		usedMB = int(bytes / (1024 * 1024))
+	}
+	if data, err := os.ReadFile(filepath.Join(deviceDir, "mem_info_vram_total")); err == nil {
+		bytes, _ := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+		totalMB = int(bytes / (1024 * 1024))
+	}
+	return
 }
 
 func readGPUNameSysfs(gpuIdx int) string {

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/tmlabonte/llamactl/internal/broadcast"
 )
 
 // ModelStatus represents the state of a model in the router.
@@ -69,15 +71,13 @@ type Manager struct {
 	done      chan struct{}
 
 	// Log broadcasting
-	logMu       sync.Mutex
-	subscribers map[chan string]struct{}
-	logHistory  []string
+	logs *broadcast.Broadcaster[string]
 }
 
 func NewManager() *Manager {
 	return &Manager{
-		status:      Status{State: StateStopped},
-		subscribers: make(map[chan string]struct{}),
+		status: Status{State: StateStopped},
+		logs:   broadcast.New[string](logHistorySize, 256),
 	}
 }
 
@@ -91,9 +91,7 @@ func (m *Manager) Start(cfg RouterConfig) error {
 	}
 
 	// Clear log history
-	m.logMu.Lock()
-	m.logHistory = nil
-	m.logMu.Unlock()
+	m.logs.ClearHistory()
 
 	if cfg.Host == "" {
 		cfg.Host = "0.0.0.0"
@@ -314,50 +312,24 @@ func (m *Manager) ListModels() ([]ModelStatus, error) {
 	return result.Data, nil
 }
 
-// Subscribe returns a channel that receives log lines.
+// Subscribe returns a channel that receives log lines, starting with the
+// buffered history.
 func (m *Manager) Subscribe() chan string {
-	ch := make(chan string, 256)
-	m.logMu.Lock()
-	for _, line := range m.logHistory {
-		select {
-		case ch <- line:
-		default:
-		}
-	}
-	m.subscribers[ch] = struct{}{}
-	m.logMu.Unlock()
-	return ch
+	return m.logs.Subscribe()
 }
 
 // Unsubscribe removes a log subscriber.
 func (m *Manager) Unsubscribe(ch chan string) {
-	m.logMu.Lock()
-	delete(m.subscribers, ch)
-	m.logMu.Unlock()
+	m.logs.Unsubscribe(ch)
 }
 
 // ClearLogs discards the buffered log history so it won't be replayed to new subscribers.
 func (m *Manager) ClearLogs() {
-	m.logMu.Lock()
-	m.logHistory = nil
-	m.logMu.Unlock()
+	m.logs.ClearHistory()
 }
 
 func (m *Manager) broadcast(line string) {
-	m.logMu.Lock()
-	defer m.logMu.Unlock()
-
-	if len(m.logHistory) >= logHistorySize {
-		m.logHistory = m.logHistory[1:]
-	}
-	m.logHistory = append(m.logHistory, line)
-
-	for ch := range m.subscribers {
-		select {
-		case ch <- line:
-		default:
-		}
-	}
+	m.logs.Broadcast(line)
 }
 
 func (m *Manager) monitorProcess(cmd *exec.Cmd, done chan struct{}) {


### PR DESCRIPTION
## Summary

Fixes **22 of 23 verified findings** from a multi-agent code-duplication audit (validated against source and included as `audits/Duplication_META_AUDIT.md`, which contains a full finding→fix remediation table).

### New shared code
- **`internal/broadcast`** — generic `Broadcaster[T]` (ring history, non-blocking fan-out, race-tested) adopted by builder logs, router logs, and download status. Replaces three hand-rolled copies of the subscribe/broadcast/unsubscribe pattern.
- **`internal/models/specflags.go`** — `specDecodingParams()`: the ~90-line speculative-decoding switch previously copy-pasted between `preset.go` (INI output) and `registry.go` (CLI flags) now lives in one place; both callers just format the returned pairs.
- **`internal/huggingface/names.go`** — canonical `SafeModelID`/`SafeFileID` (`"/"` → `"--"`), previously inlined at 6 sites across two packages.

### Helpers replacing copy-paste
`Model.IsEmbedding()/HasVision()/Capabilities()` (9 sites), `Builder.Find()` (5 linear scans), `resolveActiveBuild()`, `builder.ApplyOptionOverrides()`, `parseEnumParam()`, `parseTensorAssign()`, `models.ShortModelName()`, `downloadProgressHTML()`, `listAMDGPUDirs()`, `platformAppDirs()`, `respondJSONStatus()`, `resolveRouterModel()`, `routerStateFor()`, and `cssID` → `domID`.

### Deliberate behavior improvements (all flagged by the audit)
1. **Benchmark build resolution**: `handleStartBenchmark` now validates the active build actually *succeeded* (falling back to the latest successful build) — previously it could benchmark against a failed build if `ActiveBuild` pointed at one.
2. **CMake option overrides**: a partial overrides map now applies option defaults for unspecified options, so the flags actually built always match the UI's flag preview (they could previously diverge).
3. **`/api/ps` enrichment**: matches models by public/router name too (via `findModelByAny`), consistent with `/api/service/loaded-models`.

### Intentionally not changed
Finding 21 (HTTP client instantiation in settings vs benchmark runner): the clients differ in timeout (5s vs 5min) and method (`Get` vs `Do`); a shared client isn't clearly right.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race -count=1 ./...` passes
- [x] New `internal/broadcast` package has dedicated unit tests (history replay, ring truncation, non-blocking drop, close-keeps-history, concurrent use)
- [x] No new gofmt violations (pre-existing ones left untouched to keep the diff focused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRgWrKyJr4NguCLBsae5UK