### PR TITLE
feat(builder): add HIP Fast Math toggle to ROCm build options

### DIFF
--- a/internal/api/build.go
+++ b/internal/api/build.go
@@ -112,7 +112,7 @@ func effectiveCMakeFlags(prof builder.BuildProfile, options []builder.BuildOptio
 			}
 		}
 		if enabled {
-			flags[opt.Flag] = "ON"
+			flags[opt.Flag] = opt.CMakeValue()
 		}
 	}
 	var parts []string

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -254,14 +254,14 @@ func (b *Builder) Build(ctx context.Context, profile string, gitRef string, tag 
 		options := ProfileOptions(profile)
 		for _, opt := range options {
 			if enabled, ok := optionOverrides[opt.Flag]; ok && enabled {
-				prof.CMakeFlags[opt.Flag] = "ON"
+				prof.CMakeFlags[opt.Flag] = opt.CMakeValue()
 			}
 		}
 	} else {
 		// Apply defaults when no overrides specified (e.g. JSON API)
 		for _, opt := range ProfileOptions(profile) {
 			if opt.Default {
-				prof.CMakeFlags[opt.Flag] = "ON"
+				prof.CMakeFlags[opt.Flag] = opt.CMakeValue()
 			}
 		}
 	}

--- a/internal/builder/profiles.go
+++ b/internal/builder/profiles.go
@@ -8,11 +8,21 @@ type BuildProfile struct {
 }
 
 // BuildOption describes a toggleable cmake flag for a profile.
+// Value is the cmake value set when the option is enabled; empty means "ON".
 type BuildOption struct {
 	Flag        string `json:"flag"`
 	Label       string `json:"label"`
 	Description string `json:"description"`
 	Default     bool   `json:"default"`
+	Value       string `json:"value,omitempty"`
+}
+
+// CMakeValue returns the value assigned to Flag when the option is enabled.
+func (o BuildOption) CMakeValue() string {
+	if o.Value != "" {
+		return o.Value
+	}
+	return "ON"
 }
 
 // ProfileOptions returns the toggleable build options for a given profile.
@@ -78,6 +88,13 @@ func ProfileOptions(profile string) []BuildOption {
 				Flag:        "GGML_HIP_ROCWMMA_FATTN",
 				Label:       "rocWMMA FlashAttention",
 				Description: "Build the FlashAttention kernel against rocWMMA so attention dispatches through the AI matrix accelerators (FP16 WMMA). Recommended for RDNA3+ (gfx1100/1101/1151) and RDNA4 (gfx1200/1201) on ROCm 7.x — speeds up prefill noticeably. Requires --flash-attn at runtime to take effect. Needs rocwmma-devel installed.",
+				Default:     false,
+			},
+			{
+				Flag:        "CMAKE_HIP_FLAGS",
+				Value:       "-funsafe-math-optimizations",
+				Label:       "HIP Fast Math",
+				Description: "Compile HIP kernels with -funsafe-math-optimizations, matching CUDA's fast-math behavior. Noticeable speedup with minor accuracy tradeoff. Built into llama.cpp after 2026-07-09 (commit ccb0c34), so this toggle only matters for older refs; enabling it on newer refs is harmless.",
 				Default:     false,
 			},
 			{


### PR DESCRIPTION
## Summary

llama.cpp commit [ccb0c34](https://github.com/ggml-org/llama.cpp/commit/ccb0c3422394fbbfc28fd91f8c77111b748cfa09) (2026-07-09) compiles HIP kernels with `-funsafe-math-optimizations` to match CUDA's fast-math behavior. Upstream applies it unconditionally, but it only just landed and no tagged release includes it yet — so this adds a **HIP Fast Math** toggle to the ROCm profile in the Builds tab that injects the flag via `-DCMAKE_HIP_FLAGS`.

- `BuildOption` gains an optional `Value` field (empty still means `ON`) with a `CMakeValue()` helper — this is the first toggle that sets a string-valued cmake flag rather than a boolean one.
- The two places that turn enabled options into cmake flags (`builder.Build` and `effectiveCMakeFlags`) now use `opt.CMakeValue()` instead of hardcoded `"ON"`.
- No template changes needed — the build tab renders profile options generically, so the checkbox, tooltip, and effective-flags preview pick it up automatically.

Defaults to **off**, matching the other perf toggles (speed for a small accuracy tradeoff). On refs that already include the upstream commit, enabling it is harmless (the flag just appears twice); unchecking it cannot disable fast math on those refs since upstream hardcodes it — the tooltip notes this.

## Test plan

- `go build ./...` passes; `go test ./internal/api/` passes
- Verified via a scratch test that the rocm profile exposes `CMAKE_HIP_FLAGS` with value `-funsafe-math-optimizations` and all other options still resolve to `ON`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRjBs8mAQVtvaDVMT8PA85