### PR TITLE
feat(models): recognize FP4 quants (ROCmFP4, NVFP4, bare FP4)

### DIFF
--- a/internal/models/quant_test.go
+++ b/internal/models/quant_test.go
@@ -24,9 +24,16 @@ func TestParseQuant(t *testing.T) {
 		{"UD-Q5_K_XL/MiniMax-M2.5-UD-Q5_K_XL-00001-of-00005.gguf", "UD_Q5_K_XL"},
 		{"UD-Q6_K_XL/MiniMax-M2.5-UD-Q6_K_XL-00001-of-00005.gguf", "UD_Q6_K_XL"},
 
-		// MXFP4 — previously reported "unknown".
+		// MXFP4 — previously reported "unknown". The bare-FP4 alternative
+		// must not steal these: MXFP4 starts earlier, so leftmost-first wins.
 		{"gpt-oss-20b-MXFP4.gguf", "MXFP4"},
 		{"openai-gpt-oss-120b-UD-MXFP4.gguf", "UD_MXFP4"},
+
+		// FP4 family — vendor-prefixed and bare, previously "unknown".
+		{"Qwen3.5-122B-A10B-Heretic-ROCmFP4-iMatrix.gguf", "FP4"},
+		{"Qwen3.5-122B-A10B-Heretic-ROCmFP4-MTP.gguf", "FP4"},
+		{"model-NVFP4.gguf", "FP4"},
+		{"model-FP4.gguf", "FP4"},
 
 		// Plain (non-UD) quants.
 		{"model-Q4_K_M.gguf", "Q4_K_M"},

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -1125,8 +1125,9 @@ func findShards(dir, filename string) []string {
 // optional suffix groups absorb variants generically (e.g. Q2_K_XL, Q3_K_L),
 // which the previous hand-maintained list dropped. Ordering keeps longer
 // tokens ahead of their prefixes where alternation could otherwise short-cut
-// (e.g. BF16 before F16).
-var quantRe = regexp.MustCompile(`(UD_)?(MXFP4|BF16|F16|F32|TQ[1-4]_[01]|IQ[1-4]_(?:XXS|XS|NL|S|M|L)|Q[2-8]_K(?:_(?:XL|XS|S|M|L))?|Q[2-8]_[01])`)
+// (e.g. BF16 before F16, MXFP4 before the bare FP4 that also matches vendor
+// names like ROCmFP4 / NVFP4).
+var quantRe = regexp.MustCompile(`(UD_)?(MXFP4|FP4|BF16|F16|F32|TQ[1-4]_[01]|IQ[1-4]_(?:XXS|XS|NL|S|M|L)|Q[2-8]_K(?:_(?:XL|XS|S|M|L))?|Q[2-8]_[01])`)
 
 // ParseQuant extracts the quantization type from a GGUF filename. It preserves
 // the "UD_" (Unsloth ultra-dynamic) prefix when present so UD quants are


### PR DESCRIPTION
## Problem

FP4 GGUFs published with vendor-prefixed names render an `unknown` quant badge in the Search HF and Models tabs. Example: [`vmlinux/Qwen3.5-122B-A10B-Heretic-ROCmFP4-iMatrix-GGUF`](https://huggingface.co/vmlinux/Qwen3.5-122B-A10B-Heretic-ROCmFP4-iMatrix-GGUF), whose files are:

- `Qwen3.5-122B-A10B-Heretic-ROCmFP4-iMatrix.gguf`
- `Qwen3.5-122B-A10B-Heretic-ROCmFP4-MTP.gguf`

`ParseQuant` only matched `MXFP4`, so `ROCMFP4` (normalized) fell through to `"unknown"`.

## Why handle it

FP4 is an emerging quant *family*, not a one-off: `MXFP4` already ships for gpt-oss, and AMD (`ROCmFP4`) and NVIDIA (`NVFP4`) FP4 GGUFs are showing up. The `unknown` badge will keep recurring.

## Fix

Add a bare `FP4` alternative to `quantRe`, ordered **after** `MXFP4`. Go's regexp is leftmost-first and `MXFP4` starts earlier than the `FP4` inside it, so genuine `MXFP4` files still resolve to `"MXFP4"`; only standalone or vendor-prefixed FP4 tokens (`ROCmFP4`, `NVFP4`, `FP4`) resolve to `"FP4"`. The existing `load()` backfill re-derives the persisted `Quant` field, so already-registered models self-heal on next start.

This deliberately does **not** special-case `ROCM` — matching a bare `FP4` covers every vendor prefix generically and avoids whack-a-mole. The `-MTP` / `-iMatrix` files both land on `"FP4"`, which is correct: those tokens are not quant levels (multi-token-prediction / importance-matrix calibration).

Cosmetic only — nothing was gated on the quant string; this replaces `unknown` with `FP4` in the UI.

## Testing

Added `ParseQuant` cases for `ROCmFP4`, `NVFP4`, and bare `FP4` → `FP4`, plus a guard note that `MXFP4` still wins.

- `go test ./internal/models/` ✓
- `go build ./...` ✓
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)