### PR TITLE
fix(ui): drop sidebar brand badge, enlarge sidebar text

### DIFF
--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -53,33 +53,19 @@
             gap: 9px;
             margin-bottom: 22px;
         }
-        nav.sidebar .brand-badge {
-            width: 28px;
-            height: 28px;
-            min-width: 28px;
-            border-radius: 9px;
-            background: var(--accent-soft, var(--pico-primary-background));
-            border: 1px solid var(--pico-primary);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--pico-primary);
-            font-weight: 600;
-            font-size: 14px;
-        }
         nav.sidebar .brand hgroup { margin: 0; }
         nav.sidebar .brand hgroup h3 {
             margin: 0;
-            font-size: 16px;
+            font-size: 18px;
             font-weight: 700;
             letter-spacing: -0.01em;
             color: var(--pico-h3-color);
         }
         /* Two pseudo-classes give Pico's hgroup-subtitle rule (0,2,0); the
-           extra .brand class here makes this (0,2,3) so 11px actually wins. */
+           extra .brand class here makes this (0,2,3) so our size actually wins. */
         nav.sidebar .brand hgroup p {
             margin: 2px 0 0;
-            font-size: 11px;
+            font-size: 13px;
             line-height: 1.35;
             color: var(--pico-muted-color);
         }
@@ -97,7 +83,7 @@
             padding: 8px 11px;
             border-radius: 9px;
             text-decoration: none;
-            font-size: 15px;
+            font-size: 17px;
             color: var(--pico-color);
         }
         nav.sidebar a:hover { background: var(--pico-card-background-color); }
@@ -579,7 +565,6 @@
     <nav class="sidebar">
         <div class="sidebar-top">
             <div class="brand">
-                <span class="brand-badge">L</span>
                 <hgroup>
                     <h3>Llama Toolchest</h3>
                     <p>Inference Manager <small style="opacity:0.6;">{{ version }}</small></p>


### PR DESCRIPTION
Two sidebar tweaks from feedback:

- **Removed the "L" brand badge** (markup + its CSS). It was carried over from the Graphite design handoff as a logo mark; the "Llama Toolchest" title now sits at the sidebar's left edge.
- **Enlarged the sidebar text**, leaving the resource meters (monitor bar) at their compact size:
  - brand title 16px → 18px, subtitle 11px → 13px
  - nav links 15px → 17px

Theme-agnostic (applies under Dark and Graphite). CSS/markup only.

- `go build ./...` ✓ · `go test ./...` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)