### PR TITLE
fix(build): correct Go module path to github.com/tmac1973/llama-toolchest

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,9 +2,8 @@
 # Triggered by .github/workflows/release.yml; for local dev use:
 #   make package-snapshot
 #
-# Project: llama-toolchest. Module path is github.com/tmlabonte/llamactl
-# for legacy reasons; the binary, package, and brand name are
-# llama-toolchest.
+# Project: llama-toolchest. Module path, binary, package, and brand name
+# are all github.com/tmac1973/llama-toolchest.
 
 version: 2
 

--- a/cmd/llama-toolchest/main.go
+++ b/cmd/llama-toolchest/main.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/api"
-	"github.com/tmlabonte/llamactl/internal/config"
+	"github.com/tmac1973/llama-toolchest/internal/api"
+	"github.com/tmac1973/llama-toolchest/internal/config"
 )
 
 // Build info, populated via -ldflags by goreleaser.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tmlabonte/llamactl
+module github.com/tmac1973/llama-toolchest
 
 go 1.25.7
 

--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tmlabonte/llamactl/internal/benchmark"
-	"github.com/tmlabonte/llamactl/internal/builder"
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
+	"github.com/tmac1973/llama-toolchest/internal/builder"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 // builderResolver adapts the builder's List() into a benchmark.BuildResolver

--- a/internal/api/bench_about.go
+++ b/internal/api/bench_about.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/tmlabonte/llamactl/internal/benchmark"
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
 )
 
 // AboutBenchmarks is the JSON shape for /api/benchmarks/about. The HTMX

--- a/internal/api/bench_export.go
+++ b/internal/api/bench_export.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tmlabonte/llamactl/internal/benchmark"
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
 )
 
 // ExportEnvelope is the on-disk JSON shape for both per-job and

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tmlabonte/llamactl/internal/benchmark"
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 // handleListJobs returns all benchmark jobs.

--- a/internal/api/build.go
+++ b/internal/api/build.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tmlabonte/llamactl/internal/builder"
+	"github.com/tmac1973/llama-toolchest/internal/builder"
 )
 
 func (s *Server) handleListBackends(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/capabilities.go
+++ b/internal/api/capabilities.go
@@ -1,6 +1,6 @@
 package api
 
-import "github.com/tmlabonte/llamactl/internal/models"
+import "github.com/tmac1973/llama-toolchest/internal/models"
 
 // CapabilitiesSchemaVersion is the version of the capabilities object shape.
 // Clients branch on it; bump only on breaking changes to the schema.

--- a/internal/api/capabilities_test.go
+++ b/internal/api/capabilities_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 func ptrF(v float64) *float64 { return &v }

--- a/internal/api/gpu_map.go
+++ b/internal/api/gpu_map.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 // handleGPUMap renders the GPU allocation map partial.

--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tmlabonte/llamactl/internal/huggingface"
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/huggingface"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 // hfFileView decorates a HuggingFace ModelFile with local-state flags used

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/benchmark"
-	"github.com/tmlabonte/llamactl/internal/builder"
-	"github.com/tmlabonte/llamactl/internal/models"
-	"github.com/tmlabonte/llamactl/internal/monitor"
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
+	"github.com/tmac1973/llama-toolchest/internal/builder"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/monitor"
 )
 
 // jobEnv adapts *Server to benchmark.JobEnv. Created once at server

--- a/internal/api/model_card_render_test.go
+++ b/internal/api/model_card_render_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tmlabonte/llamactl/internal/models"
-	"github.com/tmlabonte/llamactl/web"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/web"
 )
 
 // modelCardData mirrors the anonymous struct renderModelCard builds, so the

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 func (s *Server) handleListEmbeddingModels(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/monitor.go
+++ b/internal/api/monitor.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/tmlabonte/llamactl/internal/monitor"
+	"github.com/tmac1973/llama-toolchest/internal/monitor"
 )
 
 func (s *Server) handleMonitorStream(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/proxy.go
+++ b/internal/api/proxy.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 // autoLoadTimeout caps how long an auto-load triggered by /v1/chat/completions

--- a/internal/api/sampling_presets_render_test.go
+++ b/internal/api/sampling_presets_render_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tmlabonte/llamactl/internal/models"
-	"github.com/tmlabonte/llamactl/web"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/web"
 )
 
 // testFuncMap mirrors the custom funcs registered in parseTemplates so the

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,14 +15,14 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/tmlabonte/llamactl/internal/benchmark"
-	"github.com/tmlabonte/llamactl/internal/builder"
-	"github.com/tmlabonte/llamactl/internal/config"
-	"github.com/tmlabonte/llamactl/internal/huggingface"
-	"github.com/tmlabonte/llamactl/internal/models"
-	"github.com/tmlabonte/llamactl/internal/monitor"
-	"github.com/tmlabonte/llamactl/internal/process"
-	"github.com/tmlabonte/llamactl/web"
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
+	"github.com/tmac1973/llama-toolchest/internal/builder"
+	"github.com/tmac1973/llama-toolchest/internal/config"
+	"github.com/tmac1973/llama-toolchest/internal/huggingface"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/monitor"
+	"github.com/tmac1973/llama-toolchest/internal/process"
+	"github.com/tmac1973/llama-toolchest/web"
 )
 
 type Server struct {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tmlabonte/llamactl/internal/models"
-	"github.com/tmlabonte/llamactl/internal/process"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/process"
 )
 
 // applySpecDefaults resets speculative decoding parameters to recommended

--- a/internal/api/v1models.go
+++ b/internal/api/v1models.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 // openAIModel builds an OpenAI-compatible Model object with a meta extension.

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/monitor"
+	"github.com/tmac1973/llama-toolchest/internal/monitor"
 )
 
 const (

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/monitor"
+	"github.com/tmac1973/llama-toolchest/internal/monitor"
 )
 
 // ErrJobAlreadyRunning is returned by Submit when a job is in flight.

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/broadcast"
+	"github.com/tmac1973/llama-toolchest/internal/broadcast"
 )
 
 const (

--- a/internal/huggingface/client.go
+++ b/internal/huggingface/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 const baseURL = "https://huggingface.co/api"

--- a/internal/huggingface/downloader.go
+++ b/internal/huggingface/downloader.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/broadcast"
+	"github.com/tmac1973/llama-toolchest/internal/broadcast"
 )
 
 // DownloadStatus tracks progress of a model download.

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tmlabonte/llamactl/internal/broadcast"
+	"github.com/tmac1973/llama-toolchest/internal/broadcast"
 )
 
 // ModelStatus represents the state of a model in the router.


### PR DESCRIPTION
## Problem

`go.mod` still declared `module github.com/tmlabonte/llamactl` — a leftover from the project's pre-rename name. The repo lives at `github.com/tmac1973/llama-toolchest`.

## Investigation

The concern going in was that some `tmlabonte/llamactl` references might be legitimate references to a *different* upstream module, and a blind find/replace would break them. They aren't:

- `go.sum` has **zero** llamactl entries — a real external dependency would require one.
- `go.mod`'s `require` blocks never mentioned it.
- All 42 Go references are `github.com/tmlabonte/llamactl/internal/...` or `.../web` — every one a self-import.

Go's `internal/` visibility rule makes this airtight: an external module's `internal/` packages are *unimportable* from here, so any `.../llamactl/internal/...` import is local by definition. Interaction with llama.cpp isn't via a Go module at all — it's process/HTTP-based (`internal/process`, `internal/builder`).

## Changes

- `go.mod` — module path updated (via `go mod edit -module`)
- 42 import lines across 25 `.go` files — exact-prefix rewrite of `github.com/tmlabonte/llamactl/` → `github.com/tmac1973/llama-toolchest/`. The **trailing slash** is the safety rail: it can only match import paths, never a bare mention of the old name.
- `.goreleaser.yaml` — the "module path is legacy" comment is no longer true; updated.

## Deliberately not changed: `setup.sh`

Its ~15 `llamactl` hits are **not import paths** — they're lookup keys for artifacts sitting on users' disks, created by the pre-rename software:

| Kind | Purpose |
|---|---|
| `llamactl-data` volume | copied into `llama-toolchest-data` so upgraders keep models/builds/configs |
| `llamactl` container name | stopped/removed; also recognized in port-conflict detection |
| `llamactl.container` Quadlet unit | removed so systemd doesn't resurrect the old container on reboot |
| `LLAMACTL_*` env vars | rewritten to `LLAMA_TOOLCHEST_*` in existing `.env` files |

Renaming these would fail **silently**. `migrate_legacy_volume` early-returns when the old volume isn't found, so a renamed key means the script reports a clean install while the user's models appear to vanish — no error, no warning.

The rule: rename the strings you *emit*, never the strings you *match against history*. (These were never at risk from this particular rewrite anyway — setup.sh contains no occurrences of the `github.com/...` prefix — but they're the reason a naive project-wide replace would have been dangerous.)

Also unchanged: `CHANGELOG.md`, `plan/archive/*.md`, `audit/*.md` — historical records.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all 6 packages with tests pass
- `grep -rn "tmlabonte" --include="*.go" .` — zero hits

## Notes for review

- `plan/archive/host-install.md` documents the old module path as "legacy, kept". That's now factually stale, but it's an archived doc so I left it. Happy to add a correction note.
- `gofmt -l` flags 13 files. I checked several against `HEAD` — they were **already** unformatted before this change. Left alone rather than mixing a formatting sweep into a rename commit; easy separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpLEG4D579Jn24aXErcVmv