### PR TITLE
fix(obs): report benchmark and live throughput per prompt size, matching llama-bench

### DIFF
--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -136,11 +136,59 @@ type BenchmarkResult struct {
 
 // BenchmarkSummary holds aggregated stats.
 type BenchmarkSummary struct {
+	// AvgPromptTokPerSec and AvgGenTokPerSec average across every result
+	// in the run, including different prompt sizes. Retained for stored
+	// data and backward compatibility, but they are not comparable to
+	// llama-bench or to runs using a different preset — use PerSize.
 	AvgPromptTokPerSec float64 `json:"avg_prompt_tok_per_sec"`
 	AvgGenTokPerSec    float64 `json:"avg_gen_tok_per_sec"`
 	AvgTTFTMs          float64 `json:"avg_ttft_ms"`
 	MinGenTokPerSec    float64 `json:"min_gen_tok_per_sec"`
 	MaxGenTokPerSec    float64 `json:"max_gen_tok_per_sec"`
+
+	// PerSize reports one figure per fixed prompt length, with standard
+	// deviation across repetitions — the shape llama-bench uses and the
+	// only form comparable to externally published numbers.
+	PerSize []SizeSummary `json:"per_size,omitempty"`
+}
+
+// SizeSummary is one prompt length's results, equivalent to a single
+// llama-bench row (pp512, pp2048, …).
+type SizeSummary struct {
+	PromptTokens int     `json:"prompt_tokens"`
+	GenTokens    int     `json:"gen_tokens"`
+	Count        int     `json:"count"`
+	PPMean       float64 `json:"pp_mean"`
+	PPStd        float64 `json:"pp_std"`
+	TGMean       float64 `json:"tg_mean"`
+	TGStd        float64 `json:"tg_std"`
+	AvgTTFTMs    float64 `json:"avg_ttft_ms"`
+}
+
+// Label renders the llama-bench-style name for this row, e.g. "pp6310".
+func (s SizeSummary) Label() string { return fmt.Sprintf("pp%d", s.PromptTokens) }
+
+// SizeRows returns the per-prompt-size rows for display, one per fixed
+// prompt length as llama-bench reports them.
+//
+// Falls back to a single row carrying the run's mixed average when there
+// is no per-size data — a legacy run, or one that failed before
+// producing results. That row has PromptTokens 0, which the templates
+// render as "mixed" rather than as a comparable figure.
+func (r BenchmarkRun) SizeRows() []SizeSummary {
+	if r.Summary == nil {
+		return nil
+	}
+	if len(r.Summary.PerSize) > 0 {
+		return r.Summary.PerSize
+	}
+	return []SizeSummary{{
+		PromptTokens: 0,
+		Count:        len(r.Results),
+		PPMean:       r.Summary.AvgPromptTokPerSec,
+		TGMean:       r.Summary.AvgGenTokPerSec,
+		AvgTTFTMs:    r.Summary.AvgTTFTMs,
+	}}
 }
 
 // LlamaBenchResult holds raw inference benchmark data.
@@ -911,6 +959,17 @@ func (s *Store) load() {
 		}
 		s.runs = runs
 		dirty = true // forces a v2 rewrite at end of load
+	}
+
+	// Backfill per-size summaries for runs stored before they existed.
+	// The raw per-result data already carries prompt_tokens, so this is a
+	// pure re-aggregation — no measurement is lost or invented.
+	for i := range s.runs {
+		r := &s.runs[i]
+		if r.Summary != nil && len(r.Summary.PerSize) == 0 && len(r.Results) > 0 {
+			r.Summary.PerSize = computePerSize(r.Results)
+			dirty = true
+		}
 	}
 
 	// v2→v3: flag runs whose config snapshot was never applied. Runs

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -736,31 +736,132 @@ func (s *Store) Timings(modelID string) []TimingSample {
 }
 
 // TimingSummary returns aggregated timing stats per model.
+// promptBuckets groups observed requests by prompt length. Prompt
+// processing throughput rises steeply with prompt size — a 72-token
+// prefill cannot reach the rate of a 6000-token one on any hardware,
+// because fixed per-request overhead dominates — so a single headline
+// number moves whenever the traffic mix moves, independently of how
+// fast the server actually is.
+var promptBuckets = []struct {
+	Label string
+	Min   int // inclusive
+	Max   int // exclusive; 0 = no upper bound
+}{
+	{"<512", 0, 512},
+	{"512–2k", 512, 2048},
+	{"2k–8k", 2048, 8192},
+	{"8k+", 8192, 0},
+}
+
+// TimingSummary aggregates passive timing samples per model.
+//
+// Rates are token-weighted (total tokens / total time), not a mean of
+// per-request rates. Averaging rates gave a 72-token request the same
+// weight as a 6000-token one, so the figure tracked how many short
+// requests happened to be in the window rather than how fast the server
+// was: an observed window of 14 requests, 11 of them sub-200-token
+// cache-hit continuations, averaged 351 t/s while the same server
+// measured 2400+ t/s on 6k prompts.
 func (s *Store) TimingSummary() []TimingModelSummary {
 	s.timingsMu.RLock()
 	defer s.timingsMu.RUnlock()
+
 	var out []TimingModelSummary
 	for modelID, samples := range s.timings {
 		if len(samples) == 0 {
 			continue
 		}
-		var sumGen, sumPrompt float64
-		for _, t := range samples {
-			sumGen += t.GenTokPerSec
-			sumPrompt += t.PromptTokPerSec
+		sum := newTimingAgg()
+		buckets := make([]*timingAgg, len(promptBuckets))
+		for i := range buckets {
+			buckets[i] = newTimingAgg()
 		}
-		n := float64(len(samples))
-		out = append(out, TimingModelSummary{
+
+		minTok, maxTok := 0, 0
+		for i, t := range samples {
+			sum.add(t)
+			if b := bucketFor(t.PromptTokens); b >= 0 {
+				buckets[b].add(t)
+			}
+			if i == 0 || t.PromptTokens < minTok {
+				minTok = t.PromptTokens
+			}
+			if t.PromptTokens > maxTok {
+				maxTok = t.PromptTokens
+			}
+		}
+
+		m := TimingModelSummary{
 			ModelID:            modelID,
 			Count:              len(samples),
-			AvgGenTokPerSec:    sumGen / n,
-			AvgPromptTokPerSec: sumPrompt / n,
-		})
+			AvgGenTokPerSec:    sum.genRate(),
+			AvgPromptTokPerSec: sum.promptRate(),
+			MinPromptTokens:    minTok,
+			MaxPromptTokens:    maxTok,
+		}
+		for i, b := range promptBuckets {
+			if buckets[i].count == 0 {
+				continue
+			}
+			m.Buckets = append(m.Buckets, TimingBucket{
+				Label:              b.Label,
+				Count:              buckets[i].count,
+				AvgPromptTokPerSec: buckets[i].promptRate(),
+				AvgGenTokPerSec:    buckets[i].genRate(),
+			})
+		}
+		out = append(out, m)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].ModelID < out[j].ModelID
 	})
 	return out
+}
+
+func bucketFor(promptTokens int) int {
+	for i, b := range promptBuckets {
+		if promptTokens >= b.Min && (b.Max == 0 || promptTokens < b.Max) {
+			return i
+		}
+	}
+	return -1
+}
+
+// timingAgg accumulates tokens and the time they took, reconstructing
+// each sample's duration from its recorded rate. Summing durations and
+// tokens separately is what makes the result token-weighted.
+type timingAgg struct {
+	count                   int
+	promptTokens, genTokens float64
+	promptSecs, genSecs     float64
+}
+
+func newTimingAgg() *timingAgg { return &timingAgg{} }
+
+func (a *timingAgg) add(t TimingSample) {
+	a.count++
+	if t.PromptTokPerSec > 0 && t.PromptTokens > 0 {
+		a.promptTokens += float64(t.PromptTokens)
+		a.promptSecs += float64(t.PromptTokens) / t.PromptTokPerSec
+	}
+	if t.GenTokPerSec > 0 && t.GenTokens > 0 {
+		a.genTokens += float64(t.GenTokens)
+		a.genSecs += float64(t.GenTokens) / t.GenTokPerSec
+	}
+}
+
+func (a *timingAgg) promptRate() float64 {
+	if a.promptSecs == 0 {
+		return 0
+	}
+	return a.promptTokens / a.promptSecs
+}
+
+func (a *timingAgg) genRate() float64 {
+	if a.genSecs == 0 {
+		return 0
+	}
+	return a.genTokens / a.genSecs
 }
 
 // TimingModelSummary is aggregated timing stats for one model.
@@ -769,6 +870,20 @@ type TimingModelSummary struct {
 	Count              int     `json:"count"`
 	AvgGenTokPerSec    float64 `json:"avg_gen_tok_per_sec"`
 	AvgPromptTokPerSec float64 `json:"avg_prompt_tok_per_sec"`
+	// Prompt-length range the rates were observed over, so a headline
+	// figure can't be mistaken for a hardware measurement.
+	MinPromptTokens int            `json:"min_prompt_tokens"`
+	MaxPromptTokens int            `json:"max_prompt_tokens"`
+	Buckets         []TimingBucket `json:"buckets,omitempty"`
+}
+
+// TimingBucket is the same stats restricted to one prompt-length range,
+// which is what makes two periods comparable when the traffic mix moved.
+type TimingBucket struct {
+	Label              string  `json:"label"`
+	Count              int     `json:"count"`
+	AvgPromptTokPerSec float64 `json:"avg_prompt_tok_per_sec"`
+	AvgGenTokPerSec    float64 `json:"avg_gen_tok_per_sec"`
 }
 
 func (s *Store) benchmarkPath() string {

--- a/internal/benchmark/stats.go
+++ b/internal/benchmark/stats.go
@@ -1,6 +1,9 @@
 package benchmark
 
-import "math"
+import (
+	"math"
+	"sort"
+)
 
 // ComputeSummary aggregates results into a summary.
 func ComputeSummary(results []BenchmarkResult) *BenchmarkSummary {
@@ -31,7 +34,75 @@ func ComputeSummary(results []BenchmarkResult) *BenchmarkSummary {
 		AvgTTFTMs:          sumTTFT / n,
 		MinGenTokPerSec:    minTG,
 		MaxGenTokPerSec:    maxTG,
+		PerSize:            computePerSize(results),
 	}
+}
+
+// computePerSize groups results by prompt length and reports mean and
+// standard deviation per group, which is how llama-bench and everything
+// that quotes it report: one figure per fixed prompt size (pp512,
+// pp2048), never averaged across sizes.
+//
+// Prompt-processing throughput rises steeply with prompt length, so an
+// average across sizes is comparable to nothing — not to llama-bench,
+// not to another run using a different preset, not to the same run if
+// its preset changes. The standard deviation matters too: llama-bench
+// reports ±10% at pp512 and ±0.1% at pp2048 on the same hardware, and a
+// bare mean hides which differences are real.
+func computePerSize(results []BenchmarkResult) []SizeSummary {
+	byTokens := map[int][]BenchmarkResult{}
+	var order []int
+	for _, r := range results {
+		if _, seen := byTokens[r.PromptTokens]; !seen {
+			order = append(order, r.PromptTokens)
+		}
+		byTokens[r.PromptTokens] = append(byTokens[r.PromptTokens], r)
+	}
+	sort.Ints(order)
+
+	out := make([]SizeSummary, 0, len(order))
+	for _, tok := range order {
+		group := byTokens[tok]
+		pp := make([]float64, 0, len(group))
+		tg := make([]float64, 0, len(group))
+		var sumTTFT float64
+		for _, r := range group {
+			pp = append(pp, r.PromptTokPerSec)
+			tg = append(tg, r.GenTokPerSec)
+			sumTTFT += r.TTFTMs
+		}
+		ppMean, ppStd := meanStd(pp)
+		tgMean, tgStd := meanStd(tg)
+		out = append(out, SizeSummary{
+			PromptTokens: tok,
+			GenTokens:    group[0].GenTokens,
+			Count:        len(group),
+			PPMean:       ppMean,
+			PPStd:        ppStd,
+			TGMean:       tgMean,
+			TGStd:        tgStd,
+			AvgTTFTMs:    sumTTFT / float64(len(group)),
+		})
+	}
+	return out
+}
+
+// meanStd returns the mean and population standard deviation.
+func meanStd(v []float64) (float64, float64) {
+	if len(v) == 0 {
+		return 0, 0
+	}
+	var sum float64
+	for _, x := range v {
+		sum += x
+	}
+	mean := sum / float64(len(v))
+	var sq float64
+	for _, x := range v {
+		d := x - mean
+		sq += d * d
+	}
+	return mean, math.Sqrt(sq / float64(len(v)))
 }
 
 // ComparisonData holds data for comparing multiple benchmark runs.

--- a/internal/benchmark/timings_test.go
+++ b/internal/benchmark/timings_test.go
@@ -102,3 +102,62 @@ func TestTimingSummaryIgnoresEmptySamples(t *testing.T) {
 		t.Errorf("Count = %d, want both samples counted", got.Count)
 	}
 }
+
+// Per-size reporting is the only form comparable to llama-bench, which
+// publishes one figure per fixed prompt length (pp512, pp2048) and never
+// averages across sizes — prompt throughput rises steeply with length,
+// so a mixed average matches nothing published anywhere.
+func TestComputeSummaryReportsPerSize(t *testing.T) {
+	results := []BenchmarkResult{
+		{PromptTokens: 512, GenTokens: 128, PromptTokPerSec: 1000, GenTokPerSec: 30},
+		{PromptTokens: 512, GenTokens: 128, PromptTokPerSec: 1100, GenTokPerSec: 32},
+		{PromptTokens: 2048, GenTokens: 128, PromptTokPerSec: 2000, GenTokPerSec: 28},
+		{PromptTokens: 2048, GenTokens: 128, PromptTokPerSec: 2200, GenTokPerSec: 30},
+	}
+	got := ComputeSummary(results)
+
+	if len(got.PerSize) != 2 {
+		t.Fatalf("got %d size groups, want 2: %+v", len(got.PerSize), got.PerSize)
+	}
+	// Sorted ascending by prompt length.
+	if got.PerSize[0].PromptTokens != 512 || got.PerSize[1].PromptTokens != 2048 {
+		t.Errorf("sizes = %d, %d; want 512 then 2048",
+			got.PerSize[0].PromptTokens, got.PerSize[1].PromptTokens)
+	}
+	if got.PerSize[0].PPMean != 1050 || got.PerSize[1].PPMean != 2100 {
+		t.Errorf("means = %.0f, %.0f; want 1050 and 2100",
+			got.PerSize[0].PPMean, got.PerSize[1].PPMean)
+	}
+	// Standard deviation is what tells a real difference from noise.
+	if got.PerSize[0].PPStd != 50 {
+		t.Errorf("stddev = %.1f, want 50", got.PerSize[0].PPStd)
+	}
+	if got.PerSize[0].Label() != "pp512" {
+		t.Errorf("label = %q, want pp512", got.PerSize[0].Label())
+	}
+}
+
+// The mixed average is retained for stored data but must not be mistaken
+// for a per-size figure.
+func TestComputeSummaryKeepsMixedAverage(t *testing.T) {
+	results := []BenchmarkResult{
+		{PromptTokens: 512, PromptTokPerSec: 1000, GenTokPerSec: 30},
+		{PromptTokens: 8192, PromptTokPerSec: 3000, GenTokPerSec: 30},
+	}
+	got := ComputeSummary(results)
+	if got.AvgPromptTokPerSec != 2000 {
+		t.Errorf("mixed average = %.0f, want 2000", got.AvgPromptTokPerSec)
+	}
+	if got.PerSize[0].PPMean == got.AvgPromptTokPerSec {
+		t.Error("per-size figures must not equal the mixed average")
+	}
+}
+
+func TestComputeSummarySingleSizeHasZeroStdOnOneRep(t *testing.T) {
+	got := ComputeSummary([]BenchmarkResult{
+		{PromptTokens: 512, PromptTokPerSec: 1000, GenTokPerSec: 30},
+	})
+	if len(got.PerSize) != 1 || got.PerSize[0].PPStd != 0 {
+		t.Errorf("one repetition should report zero spread, got %+v", got.PerSize)
+	}
+}

--- a/internal/benchmark/timings_test.go
+++ b/internal/benchmark/timings_test.go
@@ -1,0 +1,104 @@
+package benchmark
+
+import (
+	"math"
+	"testing"
+)
+
+// sample builds a TimingSample from tokens and the seconds they took.
+func sample(model string, promptTok int, promptSecs float64, genTok int, genSecs float64) TimingSample {
+	return TimingSample{
+		ModelID:         model,
+		PromptTokens:    promptTok,
+		PromptTokPerSec: float64(promptTok) / promptSecs,
+		GenTokens:       genTok,
+		GenTokPerSec:    float64(genTok) / genSecs,
+	}
+}
+
+// The exact scenario that made a faster server look slower: a window of
+// mostly-small cache-hit continuations alongside a few large prompts.
+// Averaging per-request rates gave a 72-token prefill the same weight as
+// a 2107-token one, so the headline figure tracked the traffic mix
+// rather than the hardware.
+func TestTimingSummaryIsTokenWeighted(t *testing.T) {
+	s := &Store{timings: map[string][]TimingSample{}}
+	// 11 small requests at ~190 t/s, 1 large at ~1220 t/s.
+	for i := 0; i < 11; i++ {
+		s.timings["m"] = append(s.timings["m"], sample("m", 150, 150.0/190, 20, 20.0/30))
+	}
+	s.timings["m"] = append(s.timings["m"], sample("m", 2107, 2107.0/1220, 100, 100.0/30))
+
+	got := s.TimingSummary()
+	if len(got) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(got))
+	}
+
+	// Unweighted mean of rates would be ~276. Token-weighted is
+	// (11*150 + 2107) / (11*150/190 + 2107/1220) = ~480.
+	unweighted := (11*190.0 + 1220.0) / 12
+	if math.Abs(got[0].AvgPromptTokPerSec-unweighted) < 20 {
+		t.Errorf("PP rate %.0f looks like the unweighted mean (%.0f); it must be token-weighted",
+			got[0].AvgPromptTokPerSec, unweighted)
+	}
+
+	wantTok := 11*150.0 + 2107
+	wantSecs := 11*(150.0/190) + 2107.0/1220
+	want := wantTok / wantSecs
+	if math.Abs(got[0].AvgPromptTokPerSec-want) > 1 {
+		t.Errorf("PP rate = %.1f, want %.1f (total tokens / total time)", got[0].AvgPromptTokPerSec, want)
+	}
+}
+
+// Per-size rows are what make two periods comparable when the mix moved.
+func TestTimingSummaryBucketsByPromptSize(t *testing.T) {
+	s := &Store{timings: map[string][]TimingSample{"m": {
+		sample("m", 100, 1, 10, 1),   // <512
+		sample("m", 1000, 1, 10, 1),  // 512–2k
+		sample("m", 4000, 1, 10, 1),  // 2k–8k
+		sample("m", 20000, 1, 10, 1), // 8k+
+	}}}
+
+	got := s.TimingSummary()[0]
+	if len(got.Buckets) != 4 {
+		t.Fatalf("got %d buckets, want one per populated range: %+v", len(got.Buckets), got.Buckets)
+	}
+	for _, b := range got.Buckets {
+		if b.Count != 1 {
+			t.Errorf("bucket %s has %d samples, want 1", b.Label, b.Count)
+		}
+	}
+	// Each bucket's rate is its own, not the overall figure.
+	if got.Buckets[0].AvgPromptTokPerSec != 100 || got.Buckets[3].AvgPromptTokPerSec != 20000 {
+		t.Errorf("bucket rates wrong: %.0f and %.0f", got.Buckets[0].AvgPromptTokPerSec, got.Buckets[3].AvgPromptTokPerSec)
+	}
+}
+
+// The prompt-length range stops a headline number being read as a
+// hardware measurement when it only covers tiny requests.
+func TestTimingSummaryReportsPromptRange(t *testing.T) {
+	s := &Store{timings: map[string][]TimingSample{"m": {
+		sample("m", 72, 0.7, 10, 1),
+		sample("m", 2210, 4.9, 10, 1),
+	}}}
+	got := s.TimingSummary()[0]
+	if got.MinPromptTokens != 72 || got.MaxPromptTokens != 2210 {
+		t.Errorf("range = %d–%d, want 72–2210", got.MinPromptTokens, got.MaxPromptTokens)
+	}
+}
+
+// A sample with no prompt tokens (pure continuation) must not divide by
+// zero or drag the rate to zero.
+func TestTimingSummaryIgnoresEmptySamples(t *testing.T) {
+	s := &Store{timings: map[string][]TimingSample{"m": {
+		sample("m", 1000, 1, 10, 1),
+		{ModelID: "m", PromptTokens: 0, PromptTokPerSec: 0, GenTokens: 10, GenTokPerSec: 30},
+	}}}
+	got := s.TimingSummary()[0]
+	if got.AvgPromptTokPerSec != 1000 {
+		t.Errorf("PP rate = %.1f, want 1000 — the empty sample should not contribute", got.AvgPromptTokPerSec)
+	}
+	if got.Count != 2 {
+		t.Errorf("Count = %d, want both samples counted", got.Count)
+	}
+}

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -113,8 +113,9 @@
                 <th>Model</th>
                 <th>Quant</th>
                 <th title="Which point of a parameter sweep this run measured">Sweep</th>
-                <th title="Prompt Processing tokens/sec">PP t/s</th>
-                <th title="Token Generation tokens/sec">TG t/s</th>
+                <th title="Prompt length this row measures, llama-bench style (pp&lt;tokens&gt;). Rows are per size because prompt throughput rises with prompt length — averaging across sizes is comparable to nothing.">Test</th>
+                <th title="Prompt Processing tokens/sec, mean ± stddev across repetitions">PP t/s</th>
+                <th title="Token Generation tokens/sec, mean ± stddev">TG t/s</th>
                 <th title="Time To First Token, milliseconds">TTFT (ms)</th>
                 <th>Size</th>
                 <th>GPUs</th>
@@ -128,29 +129,36 @@
         </thead>
         <tbody>
         {{range .Runs}}
+        {{$run := .}}
         {{$b := .EffectiveBuild}}
-        <tr data-run-id="{{.ID}}"
-            data-sort-name="{{.ModelName}}"
-            {{if .Summary}}data-sort-gen="{{printf "%.4f" .Summary.AvgGenTokPerSec}}"
-            data-sort-prompt="{{printf "%.4f" .Summary.AvgPromptTokPerSec}}"
-            data-sort-ttft="{{printf "%.4f" .Summary.AvgTTFTMs}}"{{end}}>
-            <td title="{{.ModelID}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{if .ConfigUnverified}}<span title="Config columns for this run may not reflect what actually ran — its job declared overrides before overrides were applied. Throughput is still valid." style="color:var(--pico-del-color,#b3261e);cursor:help;">&#9888;</span> {{end}}{{.ModelName}}</td>
-            <td><kbd>{{.Quant}}</kbd></td>
-            <td>{{if .SweepValues}}{{range $k, $v := .SweepValues}}<kbd title="{{$k}}">{{$v}}</kbd> {{end}}{{else}}—{{end}}</td>
-            <td>{{if .Summary}}{{printf "%.0f" .Summary.AvgPromptTokPerSec}}{{else}}—{{end}}</td>
-            <td>{{if .Summary}}<strong>{{printf "%.1f" .Summary.AvgGenTokPerSec}}</strong>{{else}}—{{end}}</td>
-            <td>{{if .Summary}}{{printf "%.0f" .Summary.AvgTTFTMs}}{{else}}—{{end}}</td>
-            <td>{{printf "%.1f" .SizeGB}} GB</td>
-            <td>{{if .Config.GPUAssign}}{{.Config.GPUAssign}}{{else}}all{{end}}</td>
-            <td>{{.Config.ContextSize}}</td>
-            <td>{{if or .Config.BatchSize .Config.UBatchSize}}{{if .Config.BatchSize}}{{.Config.BatchSize}}{{else}}—{{end}}/{{if .Config.UBatchSize}}{{.Config.UBatchSize}}{{else}}—{{end}}{{else}}—{{end}}</td>
-            <td>{{or .Config.KVCacheQuant "f16"}}</td>
-            <td>{{if .Config.FlashAttention}}yes{{else}}no{{end}}</td>
+        {{/* One row per prompt size, matching llama-bench. A run with no
+             per-size data (legacy, or failed before producing results)
+             falls back to a single row using its mixed average. */}}
+        {{range $sz := .SizeRows}}
+        <tr data-run-id="{{$run.ID}}"
+            data-sort-name="{{$run.ModelName}}"
+            data-sort-gen="{{printf "%.4f" $sz.TGMean}}"
+            data-sort-prompt="{{printf "%.4f" $sz.PPMean}}"
+            data-sort-ttft="{{printf "%.4f" $sz.AvgTTFTMs}}">
+            <td title="{{$run.ModelID}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{if $run.ConfigUnverified}}<span title="Config columns for this run may not reflect what actually ran — its job declared overrides before overrides were applied. Throughput is still valid." style="color:var(--pico-del-color,#b3261e);cursor:help;">&#9888;</span> {{end}}{{$run.ModelName}}</td>
+            <td><kbd>{{$run.Quant}}</kbd></td>
+            <td>{{if $run.SweepValues}}{{range $k, $v := $run.SweepValues}}<kbd title="{{$k}}">{{$v}}</kbd> {{end}}{{else}}—{{end}}</td>
+            <td>{{if $sz.PromptTokens}}<kbd>{{$sz.Label}}</kbd>{{else}}<span title="Averaged across prompt sizes; not comparable to llama-bench or to runs using a different preset." style="color:var(--pico-muted-color);cursor:help;">mixed</span>{{end}}</td>
+            <td>{{printf "%.0f" $sz.PPMean}}{{if gt $sz.Count 1}} <small>± {{printf "%.0f" $sz.PPStd}}</small>{{end}}</td>
+            <td><strong>{{printf "%.1f" $sz.TGMean}}</strong>{{if gt $sz.Count 1}} <small>± {{printf "%.1f" $sz.TGStd}}</small>{{end}}</td>
+            <td>{{printf "%.0f" $sz.AvgTTFTMs}}</td>
+            <td>{{printf "%.1f" $run.SizeGB}} GB</td>
+            <td>{{if $run.Config.GPUAssign}}{{$run.Config.GPUAssign}}{{else}}all{{end}}</td>
+            <td>{{$run.Config.ContextSize}}</td>
+            <td>{{if or $run.Config.BatchSize $run.Config.UBatchSize}}{{if $run.Config.BatchSize}}{{$run.Config.BatchSize}}{{else}}—{{end}}/{{if $run.Config.UBatchSize}}{{$run.Config.UBatchSize}}{{else}}—{{end}}{{else}}—{{end}}</td>
+            <td>{{or $run.Config.KVCacheQuant "f16"}}</td>
+            <td>{{if $run.Config.FlashAttention}}yes{{else}}no{{end}}</td>
             <td title="{{$b.Tag}}{{if $b.GitSHA}} · {{$b.GitSHA}}{{end}}">
                 {{if $b.Profile}}{{$b.Profile}}{{end}}{{if $b.GitRef}} · {{$b.GitRef}}{{end}}{{if and (not $b.Profile) (not $b.GitRef)}}—{{end}}
             </td>
-            {{if $.HasLlamaBench}}<td>{{if .LlamaBench}}{{printf "%.1f" .LlamaBench.GenTokPerSec}}{{else}}—{{end}}</td>{{end}}
+            {{if $.HasLlamaBench}}<td>{{if $run.LlamaBench}}{{printf "%.1f" $run.LlamaBench.GenTokPerSec}}{{else}}—{{end}}</td>{{end}}
         </tr>
+        {{end}}
         {{end}}
         </tbody>
     </table>

--- a/web/templates/partials/benchmark_detail.html
+++ b/web/templates/partials/benchmark_detail.html
@@ -55,8 +55,34 @@
     </div>
     {{end}}{{end}}
 
+    {{if .Summary}}{{if .Summary.PerSize}}
+    <small><strong>Results by prompt size</strong> — one row per prompt length, mean ± standard deviation across repetitions. This is the shape <code>llama-bench</code> reports (pp512, pp2048), and the only form comparable to externally published numbers: prompt throughput rises steeply with prompt length, so an average across sizes matches nothing.</small>
+    <table role="grid" style="font-size:0.85rem;">
+        <thead>
+            <tr>
+                <th title="llama-bench style label: pp&lt;prompt tokens&gt;">Test</th>
+                <th title="Prompt processing, mean ± stddev">PP t/s</th>
+                <th title="Token generation, mean ± stddev">TG t/s</th>
+                <th title="Time to first token">TTFT</th>
+                <th title="Repetitions at this size">Reps</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Summary.PerSize}}
+        <tr>
+            <td><kbd>{{.Label}}</kbd></td>
+            <td><strong>{{printf "%.0f" .PPMean}}</strong>{{if gt .Count 1}} ± {{printf "%.0f" .PPStd}}{{end}}</td>
+            <td><strong>{{printf "%.1f" .TGMean}}</strong>{{if gt .Count 1}} ± {{printf "%.1f" .TGStd}}{{end}}</td>
+            <td>{{printf "%.0f" .AvgTTFTMs}} ms</td>
+            <td>{{.Count}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    {{end}}{{end}}
+
     {{if .Results}}
-    <small><strong>API Benchmark</strong> — real chat completion requests through the server</small>
+    <small><strong>Individual requests</strong> — every data point behind the table above</small>
     <table role="grid" style="font-size:0.85rem;">
         <thead>
             <tr>

--- a/web/templates/partials/timings_summary.html
+++ b/web/templates/partials/timings_summary.html
@@ -2,23 +2,41 @@
 {{if not .Summary}}
 <p><small>No timing data yet. Performance stats will appear here as you use the API.</small></p>
 {{else}}
+<p style="margin:0 0 0.5rem;"><small style="color:var(--pico-muted-color);">
+    Rates are token-weighted (total tokens ÷ total time), so a short request
+    can't outweigh a long one. Prompt processing gets faster as prompts get
+    longer — fixed per-request overhead dominates a small prefill — so compare
+    like-for-like using the per-size rows rather than the overall figure, which
+    moves with your traffic mix.
+</small></p>
 <table role="grid" style="font-size:0.85rem;">
     <thead>
         <tr>
             <th>Model</th>
-            <th title="Average generation tokens/sec">Avg TG t/s</th>
-            <th title="Average prompt processing tokens/sec">Avg PP t/s</th>
+            <th title="Prompt length range these requests covered">Prompt size</th>
+            <th title="Token-weighted generation tokens/sec">TG t/s</th>
+            <th title="Token-weighted prompt processing tokens/sec">PP t/s</th>
             <th title="Number of requests observed">Requests</th>
         </tr>
     </thead>
     <tbody>
     {{range .Summary}}
     <tr>
-        <td>{{.ModelID}}</td>
+        <td><strong>{{.ModelID}}</strong></td>
+        <td><small>{{if .MaxPromptTokens}}{{.MinPromptTokens}}–{{.MaxPromptTokens}} tok{{else}}—{{end}}</small></td>
         <td><strong>{{printf "%.1f" .AvgGenTokPerSec}}</strong></td>
-        <td>{{printf "%.0f" .AvgPromptTokPerSec}}</td>
+        <td><strong>{{printf "%.0f" .AvgPromptTokPerSec}}</strong></td>
         <td>{{.Count}}</td>
     </tr>
+    {{range .Buckets}}
+    <tr style="color:var(--pico-muted-color);">
+        <td></td>
+        <td><small>{{.Label}}</small></td>
+        <td><small>{{printf "%.1f" .AvgGenTokPerSec}}</small></td>
+        <td><small>{{printf "%.0f" .AvgPromptTokPerSec}}</small></td>
+        <td><small>{{.Count}}</small></td>
+    </tr>
+    {{end}}
     {{end}}
     </tbody>
 </table>


### PR DESCRIPTION
The live performance panel reported 351 t/s prompt processing on a server that measured 2400+ t/s on 6k prompts in the same period — and appeared to have regressed against an earlier reading of 799.

Nothing had regressed. The metric was measuring the wrong thing.

## Cause

`TimingSummary` averaged per-request *rates*:

```go
sumPrompt += t.PromptTokPerSec   // each request's rate
AvgPromptTokPerSec: sumPrompt / n // divided by request count
```

A 72-token prefill counted exactly as much as a 6000-token one. Prompt-processing throughput rises steeply with prompt length, because fixed per-request overhead dominates a small prefill — so the figure tracked how many short requests happened to be in the window, not how fast the server was.

From a real production log of 14 requests, 11 of them sub-200-token cache-hit continuations:

| prompt | PP t/s |
|---|---|
| 72 | 104 |
| 150 | 193 |
| 946 | 650 |
| 2107 | 1220 |

Mean of rates: **351**. That is the number the panel showed.

## Fix

**Token-weighted rates** — total tokens ÷ total time, which is the physically meaningful figure and matches how the benchmark reports. The same 14 requests now read **445**.

**Bucketed by prompt length** (`<512 / 512–2k / 2k–8k / 8k+`), because even a correct aggregate moves with the traffic mix. The same log breaks down as 191 t/s below 512 tokens, 675 at 512–2k, 647 at 2k–8k — comparable across periods in a way one number never was.

**Prompt range shown**, so a headline figure can't be read as a hardware measurement when it only covers tiny requests.

No data migration: `TimingSample` already recorded per-request token counts, so existing history re-aggregates correctly.


## Also: benchmark summaries had the same conflation

`ComputeSummary` averaged `PromptTokPerSec` across every result in a run, including different prompt sizes — so a 4-size preset's headline was the mean of 12 rates spanning 6k to 50k tokens.

Verified how `llama-bench` actually reports, by running it:

```
| test   |              t/s |
| pp512  | 3761.31 ± 375.94 |
| pp2048 |   3922.64 ± 3.72 |
| tg64   |     90.23 ± 0.22 |
```

One row per **fixed** prompt size, labelled with it, **mean ± standard deviation** across repetitions, never averaged across sizes. The weighting question doesn't arise there because sizes are never mixed — which is the answer to "what should we do to be comparable."

Summaries now carry `PerSize`: one entry per prompt length with mean and stddev for PP and TG, and a `pp<N>` label. The detail view renders them in llama-bench's shape; the compare view expands each run into one row per size. The old mixed average is kept for stored data and labelled "mixed" so it can't be mistaken for a comparable figure. Existing runs are backfilled on load — pure re-aggregation, nothing lost or invented.

**The stddev immediately earned itself.** On a real batch sweep, TG at `-b 16384` reads `7.7 ± 0.0` over three repetitions at 50k tokens against ~30 everywhere else. Zero spread is the opposite of noise — generation collapsed four-fold partway through that cell and stayed collapsed until the router restarted. A bare mean made it look like a blip worth ignoring, and it had been dismissed as exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mvj7K685AxCULMQaRmAsFR

