### PR TITLE
fix(obs): show a single averaged row per model in live performance

### DIFF
--- a/web/templates/partials/timings_summary.html
+++ b/web/templates/partials/timings_summary.html
@@ -5,9 +5,8 @@
 <p style="margin:0 0 0.5rem;"><small style="color:var(--pico-muted-color);">
     Rates are token-weighted (total tokens ÷ total time), so a short request
     can't outweigh a long one. Prompt processing gets faster as prompts get
-    longer — fixed per-request overhead dominates a small prefill — so compare
-    like-for-like using the per-size rows rather than the overall figure, which
-    moves with your traffic mix.
+    longer, so the figure moves with your traffic mix — the prompt-size range
+    shows what it covered. For like-for-like comparisons, run a benchmark.
 </small></p>
 <table role="grid" style="font-size:0.85rem;">
     <thead>
@@ -28,15 +27,6 @@
         <td><strong>{{printf "%.0f" .AvgPromptTokPerSec}}</strong></td>
         <td>{{.Count}}</td>
     </tr>
-    {{range .Buckets}}
-    <tr style="color:var(--pico-muted-color);">
-        <td></td>
-        <td><small>{{.Label}}</small></td>
-        <td><small>{{printf "%.1f" .AvgGenTokPerSec}}</small></td>
-        <td><small>{{printf "%.0f" .AvgPromptTokPerSec}}</small></td>
-        <td><small>{{.Count}}</small></td>
-    </tr>
-    {{end}}
     {{end}}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- The live performance table on the server tab now shows one row per model: token-weighted TG/PP averages, the prompt-size range those requests covered, and the request count.
- Removes the muted per-prompt-size bucket rows added in #93 from this view only — benchmark detail and compare keep their per-size reporting, where fixed sizes make the breakdown meaningful.
- Caption updated to note the average moves with traffic mix and to point at benchmarks for like-for-like comparison. The backend `TimingSummary()` still computes buckets for the JSON API.

## Test plan
- `go build ./...` and `go test ./internal/api ./internal/benchmark` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFh2jysrvbhPDc5QG4s9wR