### PR TITLE
fix(build): force git checkout so a dirty clone can't block builds

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -606,7 +606,12 @@ func (b *Builder) checkoutRef(ctx context.Context, srcDir string, ref string, lo
 
 	slog.Info("checking out ref", "ref", ref)
 	sendLog(logCh, fmt.Sprintf("==> Checking out %s...", ref))
-	if err := b.runCmd(ctx, srcDir, logCh, "", nil, "git", "checkout", ref); err != nil {
+	// The clone is a build cache managed entirely by us — nothing in it is
+	// ever worth preserving. Force the checkout so leftover local changes
+	// (e.g. a checkout interrupted by a restart, which leaves the tree
+	// half-updated) can't block future builds with "Please commit your
+	// changes or stash them".
+	if err := b.runCmd(ctx, srcDir, logCh, "", nil, "git", "checkout", "--force", ref); err != nil {
 		return "", "", err
 	}
 


### PR DESCRIPTION
## Summary

Fixes #100 — thanks to the git-phase logging from #98, the failure is now visible: `git checkout` aborts with "Please commit your changes or stash them before you switch branches" because the llama.cpp working tree has local modifications. The most likely cause is a checkout interrupted mid-flight (service restart or crash), which leaves the tree half-updated; git then treats the partially-written files as local changes and refuses every subsequent ref switch, so no build can start until the clone is deleted by hand.

Since the clone is a build cache managed entirely by llamactl — nothing in it is ever user-authored or worth preserving — the checkout now runs with `--force`, discarding any leftover local changes (tracked modifications and conflicting untracked files alike) before switching refs.

## Testing

- `go test ./...` passes.
- Reproduced the issue end-to-end: rigged the managed clone with a dirty tracked file so a plain `git checkout` fails with the exact "Please commit your changes or stash them" error from the issue, then triggered a build through the API — the forced checkout switched refs cleanly, the working tree came out pristine, and the build proceeded past the git phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)