### PR TITLE
feat(downloads): unified Downloads card with pause/resume/discard

### DIFF
--- a/internal/api/downloads_panel_render_test.go
+++ b/internal/api/downloads_panel_render_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/web"
+)
+
+func renderDownloadsPanel(t *testing.T, rows []downloadRow) string {
+	t.Helper()
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, "downloads_panel", struct{ Rows []downloadRow }{rows}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return buf.String()
+}
+
+func TestDownloadsPanelActiveRow(t *testing.T) {
+	out := renderDownloadsPanel(t, []downloadRow{{
+		ID: "org--M-GGUF--m.gguf", ModelID: "org/M-GGUF", Filename: "m.gguf",
+		Active: true, Pct: 42, DownGB: 4.2, TotalGB: 10.0, SpeedMB: 55.5,
+	}})
+	if !strings.Contains(out, ">Pause</button>") {
+		t.Errorf("active row must offer Pause; output=\n%s", out)
+	}
+	if strings.Contains(out, ">Resume</button>") || strings.Contains(out, ">Discard</button>") {
+		t.Errorf("active row must not offer Resume/Discard; output=\n%s", out)
+	}
+	if !strings.Contains(out, `hx-delete="/api/hf/download/org--M-GGUF--m.gguf"`) {
+		t.Errorf("Pause must target the cancel route; output=\n%s", out)
+	}
+	if !strings.Contains(out, "dl-row-active") || !strings.Contains(out, "<progress") {
+		t.Errorf("active row must render progress and the active marker class; output=\n%s", out)
+	}
+}
+
+func TestDownloadsPanelPausedRow(t *testing.T) {
+	out := renderDownloadsPanel(t, []downloadRow{{
+		ID: "org--M-GGUF--m.gguf", ModelID: "org/M-GGUF", Filename: "m.gguf",
+		OnDiskGB: 3.5, PartCount: 2,
+	}})
+	if !strings.Contains(out, ">Resume</button>") || !strings.Contains(out, ">Discard</button>") {
+		t.Errorf("paused row must offer Resume and Discard; output=\n%s", out)
+	}
+	if strings.Contains(out, ">Pause</button>") {
+		t.Errorf("paused row must not offer Pause; output=\n%s", out)
+	}
+	if strings.Contains(out, "dl-row-active") {
+		t.Errorf("paused row must not carry the active marker class")
+	}
+	if !strings.Contains(out, "3.5 GB on disk, 2 partial file(s)") {
+		t.Errorf("paused row must show on-disk size; output=\n%s", out)
+	}
+	if !strings.Contains(out, "hx-confirm") {
+		t.Errorf("Discard must keep its confirmation; output=\n%s", out)
+	}
+}
+
+func TestDownloadsPanelEmpty(t *testing.T) {
+	if out := strings.TrimSpace(renderDownloadsPanel(t, nil)); out != "" {
+		t.Errorf("empty row set must render nothing (card hidden), got:\n%s", out)
+	}
+}

--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -198,7 +199,7 @@ func (s *Server) handleHFDownloadProgress(w http.ResponseWriter, r *http.Request
 			case "failed":
 				html = fmt.Sprintf(`<p>Download failed: %s</p>`, status.Error)
 			case "cancelled":
-				html = `<p>Download cancelled.</p>`
+				html = `<p>Download paused — resume it from the Models page.</p>`
 			default:
 				html = string(data)
 			}
@@ -214,24 +215,68 @@ func (s *Server) handleHFDownloadProgress(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleHFActiveDownloads(w http.ResponseWriter, r *http.Request) {
-	active := s.downloader.ListActive()
+	respondJSON(w, s.downloader.ListActive())
+}
 
-	if isHTMX(r) {
-		respondHTML(w)
-		if len(active) == 0 {
-			return // empty response — nothing to show
+// downloadRow is one entry in the merged Downloads panel: either an active
+// download (live progress + Pause) or paused/incomplete on-disk partials
+// (Resume + Discard). A row leaves the panel only when the download completes
+// (the model registers, so the partial scan stops reporting it) or the user
+// discards the files.
+type downloadRow struct {
+	ID       string // download ID, also used as a stable DOM handle
+	ModelID  string
+	Filename string
+	Active   bool
+
+	// Active rows
+	Pct     float64
+	DownGB  float64
+	TotalGB float64
+	SpeedMB float64
+
+	// Paused/incomplete rows
+	OnDiskGB  float64
+	PartCount int
+}
+
+// handleDownloadsPanel renders the single Downloads card on the Models page:
+// all in-flight downloads plus all resumable partials on disk, deduped by
+// download ID (an in-flight download's own .part files must not surface as a
+// second "incomplete" row — the pre-merge UI had that bug, offering Resume on
+// a download that was actively running).
+func (s *Server) handleDownloadsPanel(w http.ResponseWriter, r *http.Request) {
+	var rows []downloadRow
+	activeIDs := make(map[string]bool)
+	for _, dl := range s.downloader.ListActive() {
+		activeIDs[dl.ID] = true
+		row := downloadRow{
+			ID: dl.ID, ModelID: dl.ModelID, Filename: dl.Filename, Active: true,
+			DownGB:  models.BytesToGB(dl.BytesDownloaded),
+			TotalGB: models.BytesToGB(dl.TotalBytes),
+			SpeedMB: float64(dl.SpeedBPS) / (1024 * 1024),
 		}
-		for _, dl := range active {
-			fmt.Fprintf(w, `<div style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">
-				<strong>%s</strong> — <small>%s</small>
-				%s
-			</div>`, dl.ModelID, dl.Filename,
-				downloadProgressHTML(dl, ` style="margin: 0.25rem 0;"`))
+		if dl.TotalBytes > 0 {
+			row.Pct = float64(dl.BytesDownloaded) / float64(dl.TotalBytes) * 100
 		}
-		return
+		rows = append(rows, row)
 	}
+	for _, p := range s.registry.OrphanParts() {
+		id := huggingface.SafeModelID(p.ModelID) + "--" + huggingface.SafeFileID(p.Filename)
+		if activeIDs[id] {
+			continue
+		}
+		rows = append(rows, downloadRow{
+			ID: id, ModelID: p.ModelID, Filename: p.Filename,
+			OnDiskGB: models.BytesToGB(p.BytesOnDisk), PartCount: p.PartCount,
+		})
+	}
+	// Stable order — ListActive iterates a map, and the client skips the swap
+	// when the rendered HTML is byte-identical to what it already shows.
+	sort.Slice(rows, func(i, j int) bool { return rows[i].ID < rows[j].ID })
 
-	respondJSON(w, active)
+	respondHTML(w)
+	s.renderPartial(w, "downloads_panel", struct{ Rows []downloadRow }{rows})
 }
 
 // domID sanitizes a string for use as an HTML id attribute or CSS selector
@@ -253,49 +298,7 @@ func domID(s string) string {
 // models, each offering Resume (reuses the normal download path, which picks up
 // from the existing partial) and Discard. Mirrors handleHFActiveDownloads.
 func (s *Server) handleIncompleteDownloads(w http.ResponseWriter, r *http.Request) {
-	parts := s.registry.OrphanParts()
-
-	if isHTMX(r) {
-		respondHTML(w)
-		if len(parts) == 0 {
-			return // empty response — nothing to show
-		}
-		fmt.Fprint(w, `<article style="padding: 0.5rem 0.75rem; margin: 0.5rem 0;">
-			<strong style="font-size: 0.9rem;">Incomplete downloads</strong>`)
-		for _, p := range parts {
-			id := domID(p.ModelID + "--" + p.Filename)
-			onDiskGB := models.BytesToGB(p.BytesOnDisk)
-			fmt.Fprintf(w, `<div style="padding: 0.25rem 0; font-size: 0.85rem; border-top: 1px solid var(--pico-muted-border-color);">
-				<div style="display:flex; justify-content:space-between; align-items:center; gap:0.5rem;">
-					<span><strong>%s</strong> — <small>%s</small> <small>(%.1f GB on disk, %d partial file(s))</small></span>
-					<span role="group" style="margin:0; flex:0 0 auto;">
-						<button type="button" class="outline"
-								style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem;"
-								hx-post="/api/hf/download"
-								hx-vals='{"model_id":"%s","filename":"%s","size":"0"}'
-								hx-target="#incdl-%s"
-								hx-swap="innerHTML">Resume</button>
-						<button type="button" class="outline secondary"
-								style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem;"
-								hx-delete="/api/hf/incomplete"
-								hx-vals='{"model_id":"%s","filename":"%s"}'
-								hx-confirm="Delete the partial files for %s? This cannot be undone."
-								hx-target="#incdl-%s"
-								hx-swap="innerHTML">Discard</button>
-					</span>
-				</div>
-				<div id="incdl-%s"></div>
-			</div>`,
-				p.ModelID, p.Filename, onDiskGB, p.PartCount,
-				p.ModelID, p.Filename, id,
-				p.ModelID, p.Filename, p.ModelID, id,
-				id)
-		}
-		fmt.Fprint(w, `</article>`)
-		return
-	}
-
-	respondJSON(w, parts)
+	respondJSON(w, s.registry.OrphanParts())
 }
 
 // handleIncompleteDiscard deletes the on-disk files (completed shards and

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -404,6 +404,7 @@ func (s *Server) buildRouter() chi.Router {
 			r.Get("/model", s.handleHFModel)
 			r.Post("/download", s.handleHFDownload)
 			r.Get("/downloads", s.handleHFActiveDownloads)
+			r.Get("/downloads-panel", s.handleDownloadsPanel)
 			r.Get("/incomplete", s.handleIncompleteDownloads)
 			r.Delete("/incomplete", s.handleIncompleteDiscard)
 			r.Get("/download/{id}/progress", s.handleHFDownloadProgress)

--- a/internal/huggingface/downloader.go
+++ b/internal/huggingface/downloader.go
@@ -2,6 +2,7 @@ package huggingface
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -93,9 +94,14 @@ func (d *Downloader) Start(ctx context.Context, modelID, filename string, expect
 	downloadID := fmt.Sprintf("%s--%s", safeName, safeFilename)
 
 	d.mu.Lock()
-	if _, exists := d.active[downloadID]; exists {
-		d.mu.Unlock()
-		return downloadID, fmt.Errorf("download already in progress")
+	if existing, exists := d.active[downloadID]; exists {
+		if s := existing.last(); s.Status == "downloading" {
+			d.mu.Unlock()
+			return downloadID, fmt.Errorf("download already in progress")
+		}
+		// Terminal entry still inside its 30s late-subscriber grace window —
+		// evict it so a paused/failed download can be resumed immediately.
+		delete(d.active, downloadID)
 	}
 
 	dlCtx, cancel := context.WithCancel(context.Background())
@@ -260,6 +266,13 @@ func (d *Downloader) run(ctx context.Context, downloadID, modelID, filename stri
 
 		downloaded, err := d.downloadFile(ctx, downloadID, modelID, fn, label, modelDir, totalDownloaded, combinedTotal, dl)
 		if err != nil {
+			// A mid-file cancellation surfaces as ctx.Err() from downloadFile —
+			// report it as "cancelled" like the between-files check above, not
+			// as a failure.
+			if errors.Is(err, context.Canceled) {
+				sendProgress(DownloadStatus{ID: downloadID, ModelID: modelID, Filename: label, Status: "cancelled"})
+				return
+			}
 			sendProgress(DownloadStatus{ID: downloadID, ModelID: modelID, Filename: label, Status: "failed", Error: err.Error()})
 			return
 		}

--- a/internal/huggingface/downloader_test.go
+++ b/internal/huggingface/downloader_test.go
@@ -1,0 +1,47 @@
+package huggingface
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/broadcast"
+)
+
+// seedActive injects a download entry with the given last status, simulating
+// the 30s late-subscriber grace window during which terminal downloads stay
+// in the active map.
+func seedActive(d *Downloader, downloadID, status string) {
+	dl := &download{
+		cancel: func() {},
+		bc:     broadcast.New[DownloadStatus](1, 16),
+	}
+	dl.broadcast(DownloadStatus{ID: downloadID, Status: status})
+	d.mu.Lock()
+	d.active[downloadID] = dl
+	d.mu.Unlock()
+}
+
+func TestStartRefusesWhileDownloading(t *testing.T) {
+	d := NewDownloader(t.TempDir(), t.TempDir(), "")
+	seedActive(d, "org--Repo-GGUF--file", "downloading")
+
+	if _, err := d.Start(context.Background(), "org/Repo-GGUF", "file.gguf", 0); err == nil {
+		t.Fatal("Start should refuse while the same download is in progress")
+	}
+}
+
+// TestStartReplacesTerminalEntry covers pause→resume inside the grace window:
+// a cancelled entry lingers in the active map for 30s so late subscribers can
+// read its final status, but that must not block an immediate resume.
+func TestStartReplacesTerminalEntry(t *testing.T) {
+	for _, status := range []string{"cancelled", "failed", "complete"} {
+		d := NewDownloader(t.TempDir(), t.TempDir(), "")
+		seedActive(d, "org--Repo-GGUF--file", status)
+
+		id, err := d.Start(context.Background(), "org/Repo-GGUF", "file.gguf", 0)
+		if err != nil {
+			t.Fatalf("Start after %q entry: %v", status, err)
+		}
+		d.Cancel(id) // stop the spawned goroutine; we only care about admission
+	}
+}

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -170,8 +170,10 @@
     <h3>VRAM Est. column</h3>
     <p>Shows <em>base</em> (weights + small overhead) and <em>peak</em> (weights + full KV cache at configured context size). The GPU allocation map uses the peak number so the bars reflect actual VRAM use when a model is loaded.</p>
 
+    <h3>Downloads card</h3>
+    <p>A single <strong>Downloads</strong> card at the top of the Models page tracks every download — one row per model, whether it's actively downloading, paused, or was interrupted. Active rows show live progress and a <strong>Pause</strong> button (stops the transfer but keeps the partial files); paused or interrupted rows show what's on disk with <strong>Resume</strong> (picks up from the bytes already downloaded) and <strong>Discard</strong> (deletes the partial files). Rows persist across restarts — an interrupted download reappears as paused on the next boot — and leave the card only when the download completes or you discard it. To fully cancel a download: Pause, then Discard.</p>
     <h3>Incomplete &amp; missing files</h3>
-    <p>If a download was interrupted, the model carries an <code>incomplete</code> badge and a <strong>Resume</strong> button that picks up from the bytes already on disk; it can't be enabled until the download finishes. A pending-download tracker also sits at the top of the Models page. If a model's GGUF has gone missing from disk entirely, it's flagged as an orphan and likewise can't be enabled — remove it or re-download.</p>
+    <p>If a registered model's download was interrupted, its card carries an <code>incomplete</code> badge and a <strong>Resume</strong> button; it can't be enabled until the download finishes. If a model's GGUF has gone missing from disk entirely, it's flagged as an orphan and likewise can't be enabled — remove it or re-download.</p>
 
     <h2 id="model-config">Model config (Configure dialog)</h2>
 

--- a/web/templates/models.html
+++ b/web/templates/models.html
@@ -16,19 +16,12 @@
      hx-swap="innerHTML">
 </div>
 
-<div id="active-downloads"
-     hx-get="/api/hf/downloads"
-     hx-trigger="load, every 3s"
+<div id="downloads-panel"
+     hx-get="/api/hf/downloads-panel"
+     hx-trigger="load, every 3s, dlPanelRefresh from:body, modelsChanged from:body"
      hx-swap="innerHTML"
      hx-on::before-swap="if(event.detail.xhr.responseText===this.innerHTML){event.detail.shouldSwap=false;}"
-     hx-on::after-swap="var has=this.innerHTML.trim().length>0;if(this.dataset.wasActive==='1'&&!has){htmx.trigger(document.body,'modelsChanged');}this.dataset.wasActive=has?'1':'0';">
-</div>
-
-<div id="incomplete-downloads"
-     hx-get="/api/hf/incomplete"
-     hx-trigger="load, every 5s, modelsChanged from:body"
-     hx-swap="innerHTML"
-     hx-on::before-swap="if(event.detail.xhr.responseText===this.innerHTML){event.detail.shouldSwap=false;}">
+     hx-on::after-swap="var act=this.querySelectorAll('.dl-row-active').length;var prev=parseInt(this.dataset.act||'0');if(prev>act){htmx.trigger(document.body,'modelsChanged');}this.dataset.act=act;">
 </div>
 
 <div id="model-list" hx-get="/api/models" hx-trigger="load, modelsChanged from:body" hx-swap="innerHTML">

--- a/web/templates/partials/download_progress.html
+++ b/web/templates/partials/download_progress.html
@@ -1,11 +1,20 @@
 {{define "download_progress"}}
 <td colspan="6">
-    <div hx-ext="sse"
-         sse-connect="/api/hf/download/{{.DownloadID}}/progress"
-         sse-swap="progress"
-         hx-swap="innerHTML">
-        <progress></progress>
-        <small>Downloading {{.Filename}}...</small>
+    <div style="display:flex; align-items:center; gap:0.75rem;">
+        <div style="flex:1;"
+             hx-ext="sse"
+             sse-connect="/api/hf/download/{{.DownloadID}}/progress"
+             sse-swap="progress"
+             hx-swap="innerHTML">
+            <progress></progress>
+            <small>Downloading {{.Filename}}...</small>
+        </div>
+        <button type="button" class="outline secondary"
+                style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem; flex:0 0 auto;"
+                title="Stop downloading but keep the partial files — resume from the Models page"
+                hx-delete="/api/hf/download/{{.DownloadID}}"
+                hx-swap="none"
+                hx-on::after-request="this.style.display='none'">Pause</button>
     </div>
 </td>
 {{end}}

--- a/web/templates/partials/downloads_panel.html
+++ b/web/templates/partials/downloads_panel.html
@@ -1,0 +1,47 @@
+{{define "downloads_panel"}}
+{{if .Rows}}
+<article style="padding: 0.5rem 0.75rem; margin: 0.5rem 0;">
+    <strong style="font-size: 0.9rem;">Downloads</strong>
+    {{range .Rows}}
+    <div class="dl-row{{if .Active}} dl-row-active{{end}}" style="padding: 0.25rem 0; font-size: 0.85rem; border-top: 1px solid var(--pico-muted-border-color);">
+        <div style="display:flex; justify-content:space-between; align-items:center; gap:0.5rem;">
+            <span>
+                <strong>{{.ModelID}}</strong> — <small>{{.Filename}}</small>
+                {{if not .Active}}<small>({{printf "%.1f" .OnDiskGB}} GB on disk, {{.PartCount}} partial file(s))</small>{{end}}
+            </span>
+            <span role="group" style="margin:0; flex:0 0 auto;">
+                {{if .Active}}
+                <button type="button" class="outline secondary"
+                        style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem;"
+                        title="Stop downloading but keep the partial files — resume any time"
+                        hx-delete="/api/hf/download/{{.ID}}"
+                        hx-swap="none"
+                        hx-on::after-request="htmx.trigger(document.body,'dlPanelRefresh')">Pause</button>
+                {{else}}
+                <button type="button" class="outline"
+                        style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem;"
+                        title="Continue this download from the bytes already on disk"
+                        hx-post="/api/hf/download"
+                        hx-vals='{"model_id":"{{.ModelID}}","filename":"{{.Filename}}","size":"0"}'
+                        hx-swap="none"
+                        hx-on::after-request="htmx.trigger(document.body,'dlPanelRefresh')">Resume</button>
+                <button type="button" class="outline secondary"
+                        style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem;"
+                        title="Delete the partial files from disk"
+                        hx-delete="/api/hf/incomplete"
+                        hx-vals='{"model_id":"{{.ModelID}}","filename":"{{.Filename}}"}'
+                        hx-confirm="Delete the partial files for {{.ModelID}}? This cannot be undone."
+                        hx-swap="none"
+                        hx-on::after-request="htmx.trigger(document.body,'dlPanelRefresh')">Discard</button>
+                {{end}}
+            </span>
+        </div>
+        {{if .Active}}
+        <progress value="{{printf "%.0f" .Pct}}" max="100" style="margin: 0.25rem 0;"></progress>
+        <small>{{printf "%.1f" .DownGB}} / {{printf "%.1f" .TotalGB}} GB ({{printf "%.1f" .SpeedMB}} MB/s) — {{printf "%.0f" .Pct}}%</small>
+        {{end}}
+    </div>
+    {{end}}
+</article>
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary

Merges the Models page's two download panels (active-downloads bar + Incomplete downloads) into a single **Downloads** card with one sub-card per download, and introduces an explicit pause/resume/discard lifecycle.

Fixes the bug where a download still in flight also appeared in the Incomplete panel with a live **Resume** button (the `.part` disk scan didn't exclude active download IDs — clicking it silently errored with "download already in progress").

## Behavior

- **Active row:** live progress bar + speed, **Pause** button (no confirm — stops the transfer, keeps the partial files).
- **Paused / interrupted row:** bytes on disk + partial-file count, **Resume** (continues from existing `.part` data) and **Discard** (deletes files, confirm kept).
- **True cancel = Pause → Discard**; the card hides when its last row resolves.
- Rows are removed only by successful completion or discard. Everything else — pause, failure, server restart — degrades to the paused state, because rows come from the `.part` disk scan, preserving the interruption-recovery behavior this section was built for.
- Simultaneous downloads each render their own sub-card; the model-list refresh on completion is preserved.
- Search HF's live progress view gains the same Pause button; the SSE stream reports a pause as "paused — resume from the Models page".

## Downloader fixes required for pause→resume

- `Start` refused any download ID present in the active map, but terminal (cancelled/failed/complete) entries linger there for 30s so late subscribers can read final status — so resuming within 30s of pausing failed. `Start` now evicts terminal entries and admits the restart.
- Cancelling mid-file surfaced `ctx.Err()` as a **failed** status ("context canceled"); only between-shard cancellation reported "cancelled". Now normalized via `errors.Is(err, context.Canceled)`.

`GET /api/hf/downloads` and `GET /api/hf/incomplete` remain as JSON endpoints; the new `GET /api/hf/downloads-panel` serves the merged HTMX card. `DELETE /api/hf/download/{id}` (already routed, previously unused by any UI) is the pause action.

## Testing

- Downloader admission tests: refuse while downloading, admit over each terminal status.
- Panel render tests: active row offers only Pause (with progress + marker class), paused row offers only Resume/Discard (with confirm), empty set renders nothing so the card hides.
- Live smoke test: booted the binary with a planted `.part` file — paused row rendered correctly; discard via the query-string form htmx 2 sends deleted the files and emptied the panel.
- Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyAucmn941ztzmuk9YC3g8