### PR TITLE
fix(downloads): stop stale cached pages rendering 'null' into the Models page

### DIFF
--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -215,7 +215,19 @@ func (s *Server) handleHFDownloadProgress(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleHFActiveDownloads(w http.ResponseWriter, r *http.Request) {
-	respondJSON(w, s.downloader.ListActive())
+	// Compat shim: a Models page cached from before the merged Downloads card
+	// polls this endpoint with htmx and would otherwise swap raw JSON —
+	// literally the text "null" for an empty list — into the page. Serve such
+	// pages the merged card; its old sibling panel gets empty HTML below.
+	if isHTMX(r) {
+		s.handleDownloadsPanel(w, r)
+		return
+	}
+	active := s.downloader.ListActive()
+	if active == nil {
+		active = []huggingface.DownloadStatus{}
+	}
+	respondJSON(w, active)
 }
 
 // downloadRow is one entry in the merged Downloads panel: either an active
@@ -298,7 +310,17 @@ func domID(s string) string {
 // models, each offering Resume (reuses the normal download path, which picks up
 // from the existing partial) and Discard. Mirrors handleHFActiveDownloads.
 func (s *Server) handleIncompleteDownloads(w http.ResponseWriter, r *http.Request) {
-	respondJSON(w, s.registry.OrphanParts())
+	// Compat shim, same as handleHFActiveDownloads: stale pages get empty
+	// HTML here (their other panel already shows the merged card).
+	if isHTMX(r) {
+		respondHTML(w)
+		return
+	}
+	parts := s.registry.OrphanParts()
+	if parts == nil {
+		parts = []models.OrphanPart{}
+	}
+	respondJSON(w, parts)
 }
 
 // handleIncompleteDiscard deletes the on-disk files (completed shards and

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -688,6 +688,10 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 		http.Error(w, "page not found", http.StatusNotFound)
 		return
 	}
+	// Pages carry the polling endpoints and swap targets for this build's
+	// partials; a heuristically-cached page from an older build can poll new
+	// endpoints with mismatched expectations. Make browsers revalidate.
+	w.Header().Set("Cache-Control", "no-cache")
 	respondHTML(w)
 	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil {
 		slog.Error("template render error", "name", name, "error", err)


### PR DESCRIPTION
## Summary

Follow-up to #105. A Models page heuristically cached by the browser from before the merged Downloads card still polls the old `/api/hf/downloads` and `/api/hf/incomplete` endpoints with htmx — and swapped their new JSON-only responses, literally the text `null` for an empty list, into the page (screenshot in the field showed two `null` lines where the panels used to sit).

## Fix

- htmx requests to `/api/hf/downloads` now serve the merged Downloads card, and `/api/hf/incomplete` serves empty HTML — a stale cached page renders correctly and stays fully functional.
- The JSON forms of both endpoints return `[]` instead of `null`.
- Rendered pages now send `Cache-Control: no-cache`, so browsers revalidate after upgrades and this class of stale-page-vs-new-endpoint bug can't recur.

Verified live against a running server: old-endpoint htmx responses are clean, JSON is `[]`, and `GET /models` carries the header. Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyAucmn941ztzmuk9YC3g8