### PR TITLE
fix(downloads): stop the Pause/Resume buttons overflowing the card

### DIFF
--- a/web/templates/partials/downloads_panel.html
+++ b/web/templates/partials/downloads_panel.html
@@ -9,7 +9,9 @@
                 <strong>{{.ModelID}}</strong> — <small>{{.Filename}}</small>
                 {{if not .Active}}<small>({{printf "%.1f" .OnDiskGB}} GB on disk, {{.PartCount}} partial file(s))</small>{{end}}
             </span>
-            <span role="group" style="margin:0; flex:0 0 auto;">
+            {{/* Deliberately not role="group": Pico gives groups width:100%
+                 and stretches their buttons, which overflows this card. */}}
+            <span style="display:inline-flex; gap:0.35rem; margin:0; flex:0 0 auto;">
                 {{if .Active}}
                 <button type="button" class="outline secondary"
                         style="margin:0; padding:0.15rem 0.6rem; font-size:0.8rem;"


### PR DESCRIPTION
## Summary

Follow-up to #105/#106. The button cluster in the Downloads card used `role="group"`, and Pico CSS gives groups `width:100%` with stretched child buttons (`flex:1 1 auto`). As a flex item with `flex-basis: auto`, that 100% width became the group's basis, so the Pause button ballooned to the card's full width and spilled past its right edge regardless of viewport size.

## Fix

Replace the `role="group"` span with a plain `inline-flex` span with a small gap. Pico only forces `width:100%` on `button[type=submit]` — these are `type="button"`, so they take their natural content width. Applies to both the active row (Pause) and paused rows (Resume/Discard).

Verified the rendered markup against a live server with a planted partial download; render tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyAucmn941ztzmuk9YC3g8