### PR TITLE
fix(units): report binary sizes as GiB/MiB in benchmark exports and UI

### DIFF
--- a/internal/api/bench_export.go
+++ b/internal/api/bench_export.go
@@ -26,7 +26,9 @@ type ExportEnvelope struct {
 	Runs    []benchmark.BenchmarkRun  `json:"runs"`
 }
 
-const exportEnvelopeVersion = 1
+// v2: runs carry size_gib / gpus[].vram_total_mib instead of the
+// misnamed size_gb / vram_total_mb (the values were always binary units).
+const exportEnvelopeVersion = 2
 
 const (
 	exportFormatCSV  = "csv"

--- a/internal/api/downloads_panel_render_test.go
+++ b/internal/api/downloads_panel_render_test.go
@@ -56,7 +56,7 @@ func TestDownloadsPanelPausedRow(t *testing.T) {
 	if strings.Contains(out, "dl-row-active") {
 		t.Errorf("paused row must not carry the active marker class")
 	}
-	if !strings.Contains(out, "3.5 GB on disk, 2 partial file(s)") {
+	if !strings.Contains(out, "3.5 GiB on disk, 2 partial file(s)") {
 		t.Errorf("paused row must show on-disk size; output=\n%s", out)
 	}
 	if !strings.Contains(out, "hx-confirm") {

--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -129,7 +129,7 @@ func (s *Server) handleHFDownload(w http.ResponseWriter, r *http.Request) {
 			needGB := float64(req.Size) / (1024 * 1024 * 1024)
 			haveGB := float64(avail) / (1024 * 1024 * 1024)
 			http.Error(w,
-				fmt.Sprintf("insufficient disk space: need %.1f GB, only %.1f GB available after reserving the 2 GB safety margin and any in-flight downloads", needGB, haveGB),
+				fmt.Sprintf("insufficient disk space: need %.1f GiB, only %.1f GiB available after reserving the 2 GiB safety margin and any in-flight downloads", needGB, haveGB),
 				http.StatusInsufficientStorage)
 			return
 		}
@@ -163,10 +163,10 @@ func downloadProgressHTML(status huggingface.DownloadStatus, progressStyle strin
 		pct = float64(status.BytesDownloaded) / float64(status.TotalBytes) * 100
 	}
 	speedMB := float64(status.SpeedBPS) / (1024 * 1024)
-	downloadedGB := models.BytesToGB(status.BytesDownloaded)
-	totalGB := models.BytesToGB(status.TotalBytes)
+	downloadedGB := models.BytesToGiB(status.BytesDownloaded)
+	totalGB := models.BytesToGiB(status.TotalBytes)
 	return fmt.Sprintf(
-		`<progress value="%.0f" max="100"%s></progress><small>%.1f / %.1f GB (%.1f MB/s) — %.0f%%</small>`,
+		`<progress value="%.0f" max="100"%s></progress><small>%.1f / %.1f GiB (%.1f MiB/s) — %.0f%%</small>`,
 		pct, progressStyle, downloadedGB, totalGB, speedMB, pct)
 }
 
@@ -264,8 +264,8 @@ func (s *Server) handleDownloadsPanel(w http.ResponseWriter, r *http.Request) {
 		activeIDs[dl.ID] = true
 		row := downloadRow{
 			ID: dl.ID, ModelID: dl.ModelID, Filename: dl.Filename, Active: true,
-			DownGB:  models.BytesToGB(dl.BytesDownloaded),
-			TotalGB: models.BytesToGB(dl.TotalBytes),
+			DownGB:  models.BytesToGiB(dl.BytesDownloaded),
+			TotalGB: models.BytesToGiB(dl.TotalBytes),
 			SpeedMB: float64(dl.SpeedBPS) / (1024 * 1024),
 		}
 		if dl.TotalBytes > 0 {
@@ -280,7 +280,7 @@ func (s *Server) handleDownloadsPanel(w http.ResponseWriter, r *http.Request) {
 		}
 		rows = append(rows, downloadRow{
 			ID: id, ModelID: p.ModelID, Filename: p.Filename,
-			OnDiskGB: models.BytesToGB(p.BytesOnDisk), PartCount: p.PartCount,
+			OnDiskGB: models.BytesToGiB(p.BytesOnDisk), PartCount: p.PartCount,
 		})
 	}
 	// Stable order — ListActive iterates a map, and the client skips the swap

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -349,7 +349,7 @@ func (e *jobEnv) ResolveModel(modelID string) (benchmark.ModelInfo, error) {
 	return benchmark.ModelInfo{
 		HFRepoID:    m.ModelID,
 		Quant:       m.Quant,
-		SizeGB:      models.BytesToGB(m.SizeBytes),
+		SizeGiB:     models.BytesToGiB(m.SizeBytes),
 		DisplayName: shortenModelName(m.ModelID),
 		RouterName:  e.s.registry.RouterName(modelID),
 		Config: benchmark.ConfigSnapshot{

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -363,7 +363,7 @@ func (s *Server) renderModelCard(w http.ResponseWriter, m *models.Model, routerK
 		state = routerKnown[m.PublicName()]
 	}
 
-	vramGB := models.BytesToGB(m.SizeBytes) + 0.2
+	vramGB := models.BytesToGiB(m.SizeBytes) + 0.2
 	enabled := true
 	hasVision := m.HasBuiltinVision
 	gpuLabel := ""

--- a/internal/api/monitor.go
+++ b/internal/api/monitor.go
@@ -80,7 +80,7 @@ func monitorBarData(m monitor.Metrics) struct {
 			Name:        gpu.Name,
 			UtilPercent: gpu.UtilPercent,
 			VRAMPercent: vramPct,
-			VRAMGB:      fmt.Sprintf("%.1f/%.1fGB", float64(gpu.VRAMUsedMB)/1024, float64(gpu.VRAMTotalMB)/1024),
+			VRAMGB:      fmt.Sprintf("%.1f/%.1fGiB", float64(gpu.VRAMUsedMB)/1024, float64(gpu.VRAMTotalMB)/1024),
 			Details:     details,
 		}
 	}
@@ -97,6 +97,6 @@ func monitorBarData(m monitor.Metrics) struct {
 		GPUs:       gpus,
 		CPUPercent: m.CPU.UsagePercent,
 		RAMPercent: ramPct,
-		RAMGB:      fmt.Sprintf("%.1f/%.1fGB", float64(m.Memory.UsedMB)/1024, float64(m.Memory.TotalMB)/1024),
+		RAMGB:      fmt.Sprintf("%.1f/%.1fGiB", float64(m.Memory.UsedMB)/1024, float64(m.Memory.TotalMB)/1024),
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -218,7 +218,7 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 // per page so each page's {{define "content"}} doesn't collide.
 func (s *Server) parseTemplates() map[string]*template.Template {
 	funcMap := template.FuncMap{
-		"divGB": models.BytesToGB,
+		"divGB": models.BytesToGiB,
 		// cssID sanitizes a string so it's safe to use as both an HTML id
 		// attribute and a CSS selector (see domID in hf.go).
 		"cssID": domID,

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -679,16 +679,16 @@ func (s *Server) handleModelVRAMEstimate(w http.ResponseWriter, r *http.Request)
 
 	total := models.VRAMEstimateForConfig(model, cfg)
 	kvGB := model.KVCacheGB(contextSize, kvCacheQuant)
-	weightsGB := models.BytesToGB(model.SizeBytes)
+	weightsGB := models.BytesToGiB(model.SizeBytes)
 	extraGB := models.AuxFilesVRAMGB(cfg)
 
 	if isHTMX(r) {
 		respondHTML(w)
 		extra := ""
 		if extraGB > 0.05 {
-			extra = fmt.Sprintf(" + aux files: %.1f GB", extraGB)
+			extra = fmt.Sprintf(" + aux files: %.1f GiB", extraGB)
 		}
-		fmt.Fprintf(w, `<strong>%.1f GB</strong> <small>(weights: %.1f GB + KV cache: %.1f GB%s + overhead)</small>`,
+		fmt.Fprintf(w, `<strong>%.1f GiB</strong> <small>(weights: %.1f GiB + KV cache: %.1f GiB%s + overhead)</small>`,
 			total, weightsGB, kvGB, extra)
 		return
 	}
@@ -1002,7 +1002,7 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		if model, err := s.registry.Get(id); err == nil {
 			vramGB := models.VRAMEstimateForConfig(model, cfg)
 			w.Header().Set("HX-Trigger", fmt.Sprintf(
-				`{"vramUpdated":{"id":%q,"vram":"%.1f GB"},"gpuMapChanged":true}`,
+				`{"vramUpdated":{"id":%q,"vram":"%.1f GiB"},"gpuMapChanged":true}`,
 				id, vramGB))
 		}
 	}

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -32,7 +32,12 @@ type BenchmarkRun struct {
 	ModelID   string  `json:"model_id"`
 	ModelName string  `json:"model_name"`
 	Quant     string  `json:"quant"`
-	SizeGB    float64 `json:"size_gb"`
+	SizeGiB   float64 `json:"size_gib"` // model file size, bytes/1024³
+
+	// LegacySizeGB reads files written before the size_gib rename (the
+	// value was always binary GiB despite the name); load() folds it
+	// into SizeGiB and clears it so it never persists again.
+	LegacySizeGB float64 `json:"size_gb,omitempty"`
 
 	// Configuration snapshot
 	Config ConfigSnapshot `json:"config"`
@@ -104,9 +109,13 @@ type ConfigSnapshot struct {
 
 // GPUSnapshot captures GPU hardware at benchmark time.
 type GPUSnapshot struct {
-	Index       int    `json:"index"`
-	Name        string `json:"name"`
-	VRAMTotalMB int    `json:"vram_total_mb"`
+	Index        int    `json:"index"`
+	Name         string `json:"name"`
+	VRAMTotalMiB int    `json:"vram_total_mib"` // as reported by nvidia-smi / sysfs, binary MiB
+
+	// LegacyVRAMTotalMB reads files written before the vram_total_mib
+	// rename; load() folds it into VRAMTotalMiB and clears it.
+	LegacyVRAMTotalMB int `json:"vram_total_mb,omitempty"`
 }
 
 // BuildSnapshot freezes the llama.cpp build that produced a benchmark
@@ -336,9 +345,9 @@ func GPUSnapshotsFromMetrics(m monitor.Metrics) []GPUSnapshot {
 	snaps := make([]GPUSnapshot, len(m.GPU))
 	for i, g := range m.GPU {
 		snaps[i] = GPUSnapshot{
-			Index:       g.Index,
-			Name:        g.Name,
-			VRAMTotalMB: g.VRAMTotalMB,
+			Index:        g.Index,
+			Name:         g.Name,
+			VRAMTotalMiB: g.VRAMTotalMB,
 		}
 	}
 	return snaps
@@ -368,8 +377,10 @@ const maxTimingSamples = 1000
 
 // schemaVersion is the on-disk envelope version this build writes. v1
 // was a bare JSON array of runs; v2 wraps them with a jobs list; v3
-// flags runs whose recorded config was never actually applied.
-const schemaVersion = 3
+// flags runs whose recorded config was never actually applied; v4
+// renames size_gb → size_gib and vram_total_mb → vram_total_mib (the
+// values were always binary units — the old names were wrong).
+const schemaVersion = 4
 
 // benchmarkFile is the v2 envelope. v1 files are detected by an
 // unmarshal failure into this shape and a successful retry as []BenchmarkRun.
@@ -969,6 +980,26 @@ func (s *Store) load() {
 		if r.Summary != nil && len(r.Summary.PerSize) == 0 && len(r.Results) > 0 {
 			r.Summary.PerSize = computePerSize(r.Results)
 			dirty = true
+		}
+	}
+
+	// v3→v4: fold the misnamed legacy unit fields into their renamed
+	// successors. Unconditional rather than version-gated — it's
+	// idempotent, and pre-v2 files carry no version at all.
+	for i := range s.runs {
+		r := &s.runs[i]
+		if r.SizeGiB == 0 && r.LegacySizeGB != 0 {
+			r.SizeGiB = r.LegacySizeGB
+			r.LegacySizeGB = 0
+			dirty = true
+		}
+		for gi := range r.GPUs {
+			g := &r.GPUs[gi]
+			if g.VRAMTotalMiB == 0 && g.LegacyVRAMTotalMB != 0 {
+				g.VRAMTotalMiB = g.LegacyVRAMTotalMB
+				g.LegacyVRAMTotalMB = 0
+				dirty = true
+			}
 		}
 	}
 

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -80,7 +80,7 @@ type JobEnv interface {
 type ModelInfo struct {
 	HFRepoID    string // model.ModelID — passed to llama-benchy --tokenizer
 	Quant       string
-	SizeGB      float64
+	SizeGiB     float64
 	DisplayName string         // short, human-readable name for the run
 	RouterName  string         // identifier the router responds to
 	Config      ConfigSnapshot // saved baseline; ConfigOverrides overlay on this
@@ -372,7 +372,7 @@ func (q *JobQueue) runCell(ctx context.Context, job *BenchmarkJob, cell *JobCell
 		ModelID:      cell.ModelID,
 		ModelName:    modelInfo.DisplayName,
 		Quant:        modelInfo.Quant,
-		SizeGB:       modelInfo.SizeGB,
+		SizeGiB:      modelInfo.SizeGiB,
 		Config:       cfg,
 		BuildID:      buildSnap.ID,
 		BuildRef:     buildSnap.GitRef,

--- a/internal/benchmark/migration_v4_test.go
+++ b/internal/benchmark/migration_v4_test.go
@@ -1,0 +1,62 @@
+package benchmark
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A v3 file's size_gb / vram_total_mb (values always were binary units)
+// must load into SizeGiB / VRAMTotalMiB and be rewritten under the new
+// names, with the legacy keys gone.
+func TestLoadMigratesLegacyUnitFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config", "benchmarks.json")
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	v3 := `{
+  "version": 3,
+  "jobs": [{"id": "adhoc", "name": "Ad-Hoc Runs"}],
+  "runs": [{
+    "id": "r1", "job_id": "adhoc", "status": "completed",
+    "model_id": "m", "model_name": "m", "quant": "Q4",
+    "size_gb": 16.5,
+    "config": {"gpu_layers": 99, "context_size": 4096, "flash_attention": true, "threads": 8},
+    "build_id": "", "build_ref": "", "build_profile": "",
+    "gpus": [{"index": 0, "name": "RX 7900", "vram_total_mb": 24560}],
+    "preset": "internal-standard", "prompt_tokens": [128], "gen_tokens": 128
+  }]
+}`
+	if err := os.WriteFile(path, []byte(v3), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(dir, nil)
+	run, err := s.Get("r1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.SizeGiB != 16.5 {
+		t.Errorf("SizeGiB = %v, want 16.5", run.SizeGiB)
+	}
+	if run.LegacySizeGB != 0 {
+		t.Errorf("LegacySizeGB = %v, want 0 after migration", run.LegacySizeGB)
+	}
+	if len(run.GPUs) != 1 || run.GPUs[0].VRAMTotalMiB != 24560 {
+		t.Errorf("GPUs = %+v, want VRAMTotalMiB 24560", run.GPUs)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"size_gb"`) || strings.Contains(string(data), `"vram_total_mb"`) {
+		t.Error("rewritten file still contains legacy field names")
+	}
+	if !strings.Contains(string(data), `"size_gib": 16.5`) {
+		t.Error("rewritten file missing size_gib")
+	}
+	if !strings.Contains(string(data), `"vram_total_mib": 24560`) {
+		t.Error("rewritten file missing vram_total_mib")
+	}
+}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -935,7 +935,7 @@ func (r *Registry) ScanModels() int {
 	for _, m := range found {
 		r.Add(m)
 		slog.Info("scanned model", "id", m.ID, "file", m.FilePath,
-			"size_gb", fmt.Sprintf("%.1f", float64(m.SizeBytes)/(1024*1024*1024)),
+			"size_gib", fmt.Sprintf("%.1f", float64(m.SizeBytes)/(1024*1024*1024)),
 			"arch", m.Arch)
 	}
 
@@ -1187,7 +1187,7 @@ func (r *Registry) FindDraftCandidates(id string) []DraftCandidate {
 			ID:       m.ID,
 			Filename: m.Filename,
 			FilePath: m.FilePath,
-			SizeGB:   BytesToGB(m.SizeBytes),
+			SizeGB:   BytesToGiB(m.SizeBytes),
 			Arch:     m.Arch,
 		})
 	}

--- a/internal/models/vram.go
+++ b/internal/models/vram.go
@@ -8,8 +8,8 @@ import (
 
 const vramOverheadGB = 0.2 // fixed overhead for compute buffers, scratch space, etc.
 
-// BytesToGB converts bytes to gigabytes.
-func BytesToGB(b int64) float64 {
+// BytesToGiB converts bytes to gibibytes (binary, 1024³).
+func BytesToGiB(b int64) float64 {
 	return float64(b) / (1024 * 1024 * 1024)
 }
 
@@ -115,7 +115,7 @@ func VRAMEstimateForConfig(m *Model, cfg *ModelConfig) float64 {
 		ctx = m.ContextLength
 	}
 	// Weight memory: file size is a good proxy for quantized weights in VRAM.
-	return BytesToGB(m.SizeBytes) + m.KVCacheGB(ctx, cfg.KVCacheQuant) + AuxFilesVRAMGB(cfg) + vramOverheadGB
+	return BytesToGiB(m.SizeBytes) + m.KVCacheGB(ctx, cfg.KVCacheQuant) + AuxFilesVRAMGB(cfg) + vramOverheadGB
 }
 
 // AuxFilesVRAMGB sums the on-disk sizes of auxiliary GGUFs that load into VRAM
@@ -142,7 +142,7 @@ func AuxFilesVRAMGB(cfg *ModelConfig) float64 {
 // downloaded yet).
 func fileSizeGB(path string) float64 {
 	if fi, err := os.Stat(path); err == nil {
-		return BytesToGB(fi.Size())
+		return BytesToGiB(fi.Size())
 	}
 	return 0
 }
@@ -177,12 +177,12 @@ func VRAMFitLabel(estimatedGB float64, perGPU float64, numGPUs int, numberProces
 	return fmt.Sprintf("%d GPU", needed)
 }
 
-// FormatVRAM formats a VRAM estimate as a human-readable string.
+// FormatVRAM formats a VRAM estimate (in GiB) as a human-readable string.
 func FormatVRAM(gb float64) string {
 	if gb < 1 {
-		return formatFloat(gb*1024, 0) + " MB"
+		return formatFloat(gb*1024, 0) + " MiB"
 	}
-	return formatFloat(gb, 1) + " GB"
+	return formatFloat(gb, 1) + " GiB"
 }
 
 func formatFloat(f float64, decimals int) string {

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -147,7 +147,7 @@
             <td>{{printf "%.0f" $sz.PPMean}}{{if gt $sz.Count 1}} <small>± {{printf "%.0f" $sz.PPStd}}</small>{{end}}</td>
             <td><strong>{{printf "%.1f" $sz.TGMean}}</strong>{{if gt $sz.Count 1}} <small>± {{printf "%.1f" $sz.TGStd}}</small>{{end}}</td>
             <td>{{printf "%.0f" $sz.AvgTTFTMs}}</td>
-            <td>{{printf "%.1f" $run.SizeGB}} GB</td>
+            <td>{{printf "%.1f" $run.SizeGiB}} GiB</td>
             <td>{{if $run.Config.GPUAssign}}{{$run.Config.GPUAssign}}{{else}}all{{end}}</td>
             <td>{{$run.Config.ContextSize}}</td>
             <td>{{if or $run.Config.BatchSize $run.Config.UBatchSize}}{{if $run.Config.BatchSize}}{{$run.Config.BatchSize}}{{else}}—{{end}}/{{if $run.Config.UBatchSize}}{{$run.Config.UBatchSize}}{{else}}—{{end}}{{else}}—{{end}}</td>

--- a/web/templates/partials/benchmark_detail.html
+++ b/web/templates/partials/benchmark_detail.html
@@ -30,7 +30,7 @@
         <div>
             <small><strong>Hardware</strong></small><br>
             <small>
-                {{range .GPUs}}GPU {{.Index}}: {{.Name}} ({{printf "%.0f" (divf .VRAMTotalMB 1024.0)}} GB)<br>{{end}}
+                {{range .GPUs}}GPU {{.Index}}: {{.Name}} ({{printf "%.0f" (divf .VRAMTotalMiB 1024.0)}} GiB)<br>{{end}}
             </small>
         </div>
     </div>

--- a/web/templates/partials/benchmark_form.html
+++ b/web/templates/partials/benchmark_form.html
@@ -13,7 +13,7 @@
                 Model
                 <select name="model_id" required>
                     {{range .Models}}
-                    <option value="{{.ID}}">{{.ModelID}} ({{.Quant}}, {{printf "%.1f" (divGB .SizeBytes)}} GB)</option>
+                    <option value="{{.ID}}">{{.ModelID}} ({{.Quant}}, {{printf "%.1f" (divGB .SizeBytes)}} GiB)</option>
                     {{end}}
                 </select>
             </label>

--- a/web/templates/partials/downloads_panel.html
+++ b/web/templates/partials/downloads_panel.html
@@ -7,7 +7,7 @@
         <div style="display:flex; justify-content:space-between; align-items:center; gap:0.5rem;">
             <span>
                 <strong>{{.ModelID}}</strong> — <small>{{.Filename}}</small>
-                {{if not .Active}}<small>({{printf "%.1f" .OnDiskGB}} GB on disk, {{.PartCount}} partial file(s))</small>{{end}}
+                {{if not .Active}}<small>({{printf "%.1f" .OnDiskGB}} GiB on disk, {{.PartCount}} partial file(s))</small>{{end}}
             </span>
             {{/* Deliberately not role="group": Pico gives groups width:100%
                  and stretches their buttons, which overflows this card. */}}
@@ -40,7 +40,7 @@
         </div>
         {{if .Active}}
         <progress value="{{printf "%.0f" .Pct}}" max="100" style="margin: 0.25rem 0;"></progress>
-        <small>{{printf "%.1f" .DownGB}} / {{printf "%.1f" .TotalGB}} GB ({{printf "%.1f" .SpeedMB}} MB/s) — {{printf "%.0f" .Pct}}%</small>
+        <small>{{printf "%.1f" .DownGB}} / {{printf "%.1f" .TotalGB}} GiB ({{printf "%.1f" .SpeedMB}} MiB/s) — {{printf "%.0f" .Pct}}%</small>
         {{end}}
     </div>
     {{end}}

--- a/web/templates/partials/gpu_map.html
+++ b/web/templates/partials/gpu_map.html
@@ -8,7 +8,7 @@
             <div style="display: flex; justify-content: space-between; font-size: 0.8rem; margin-bottom: 0.15rem;">
                 <span><strong>GPU {{.Index}}</strong> <small>{{.Name}}</small></span>
                 <span>
-                    {{printf "%.1f" .UsedGB}} / {{printf "%.1f" .TotalGB}} GB
+                    {{printf "%.1f" .UsedGB}} / {{printf "%.1f" .TotalGB}} GiB
                     {{if .Overcommit}} <mark style="padding:0 0.3rem;font-size:0.75rem;background:var(--pico-del-color);color:#fff;">OVER</mark>{{end}}
                 </span>
             </div>
@@ -26,7 +26,7 @@
             {{range .Allocations}}
             <span style="display: inline-flex; align-items: center; gap: 0.25rem;">
                 <span style="display: inline-block; width: 0.7rem; height: 0.7rem; border-radius: 2px; background: {{.Color}};"></span>
-                {{.ModelName}} <small>({{printf "%.1f" .TotalGB}} GB)</small>
+                {{.ModelName}} <small>({{printf "%.1f" .TotalGB}} GiB)</small>
             </span>
             {{end}}
         </div>

--- a/web/templates/partials/hf_files.html
+++ b/web/templates/partials/hf_files.html
@@ -4,8 +4,8 @@
     {{if lt $.AvailableBytes 0}}
         <small>Disk space unavailable — downloads not gated by free space.</small>
     {{else}}
-        <strong>{{printf "%.1f" (divGB $.AvailableBytes)}} GB</strong> available for new downloads
-        <small>(free: {{printf "%.1f" (divGB $.FreeBytes)}} GB · reserved: {{printf "%.1f" (divGB $.SafetyMargin)}} GB safety + in-flight downloads)</small>
+        <strong>{{printf "%.1f" (divGB $.AvailableBytes)}} GiB</strong> available for new downloads
+        <small>(free: {{printf "%.1f" (divGB $.FreeBytes)}} GiB · reserved: {{printf "%.1f" (divGB $.SafetyMargin)}} GiB safety + in-flight downloads)</small>
     {{end}}
 </p>
 <table role="grid">
@@ -17,8 +17,8 @@
         <tr>
             <td><small>{{$f.Filename}}{{if $f.Shards}} ({{len $f.Shards}} parts){{end}}{{if $f.IsMMProj}} <mark style="padding:0 0.3rem;">vision</mark>{{end}}</small></td>
             <td><kbd>{{$f.Quant}}</kbd></td>
-            <td>{{printf "%.1f" (divGB $f.Size)}} GB</td>
-            <td>{{printf "%.1f" $f.VRAMEstGB}} GB</td>
+            <td>{{printf "%.1f" (divGB $f.Size)}} GiB</td>
+            <td>{{printf "%.1f" $f.VRAMEstGB}} GiB</td>
             <td>
                 {{$fit := vramFit $f.VRAMEstGB}}
                 {{if eq $fit "too_large"}}
@@ -38,7 +38,7 @@
                 {{else if not $f.FitsOnDisk}}
                     <button type="button" disabled
                             style="opacity: 0.5; cursor: not-allowed;"
-                            title="Not enough free disk space — needs {{printf "%.1f" (divGB $f.Size)}} GB, only {{printf "%.1f" (divGB $.AvailableBytes)}} GB available after the 2 GB safety margin and in-flight downloads. Free space and try again.">
+                            title="Not enough free disk space — needs {{printf "%.1f" (divGB $f.Size)}} GiB, only {{printf "%.1f" (divGB $.AvailableBytes)}} GiB available after the 2 GiB safety margin and in-flight downloads. Free space and try again.">
                         Won't Fit
                     </button>
                 {{else}}

--- a/web/templates/partials/job_form.html
+++ b/web/templates/partials/job_form.html
@@ -53,7 +53,7 @@
         {{range .Models}}
         <label>
             <input type="checkbox" name="model" value="{{.ID}}" onchange="updateMatrixCount()">
-            <span>{{.ModelID}} <small style="color:var(--pico-muted-color);">({{.Quant}}, {{printf "%.1f" (divGB .SizeBytes)}} GB)</small></span>
+            <span>{{.ModelID}} <small style="color:var(--pico-muted-color);">({{.Quant}}, {{printf "%.1f" (divGB .SizeBytes)}} GiB)</small></span>
         </label>
         {{end}}
     </fieldset>

--- a/web/templates/partials/model_card.html
+++ b/web/templates/partials/model_card.html
@@ -30,8 +30,8 @@
             {{if .IsIncomplete}} <mark style="padding:0 0.3rem;font-size:0.75rem;background:var(--pico-del-color);color:var(--pico-card-background-color);">incomplete</mark>{{end}}
         </div>
         <div class="model-card-quant"><kbd>{{.Quant}}</kbd></div>
-        <div class="model-card-vram" id="vram-{{.ID}}" title="Estimated VRAM at the configured context size — llama.cpp pre-allocates the full KV cache at load time, so this is what the model actually needs to load">{{printf "%.1f" .VRAMGB}} GB</div>
-        <div class="model-card-size">{{printf "%.1f" (divGB .SizeBytes)}} GB</div>
+        <div class="model-card-vram" id="vram-{{.ID}}" title="Estimated VRAM at the configured context size — llama.cpp pre-allocates the full KV cache at load time, so this is what the model actually needs to load">{{printf "%.1f" .VRAMGB}} GiB</div>
+        <div class="model-card-size">{{printf "%.1f" (divGB .SizeBytes)}} GiB</div>
         <div class="model-card-actions">
             {{if .IsOrphan}}
             <button type="button" class="outline secondary"

--- a/web/templates/partials/model_config.html
+++ b/web/templates/partials/model_config.html
@@ -269,7 +269,7 @@
                 <option value="">None</option>
                 {{range .DraftCandidates}}
                 <option value="{{.FilePath}}" {{if eq $.Config.DraftModelPath .FilePath}}selected{{end}}>
-                    {{.Filename}} ({{printf "%.1f" .SizeGB}} GB)
+                    {{.Filename}} ({{printf "%.1f" .SizeGB}} GiB)
                 </option>
                 {{end}}
             </select>


### PR DESCRIPTION
## Summary

Model sizes and VRAM figures were computed with binary divisors (`bytes/1024³`, `bytes/1024²`) but labeled **GB/MB** throughout the benchmark exports and the UI. This renames the fields and labels to match the actual values, rather than changing the values — so numbers stay comparable with `ls -lh`, `nvidia-smi`, and previously recorded runs.

### Benchmark outputs
- JSON: `size_gb` → `size_gib`, `gpus[].vram_total_mb` → `vram_total_mib`; export envelope version bumped to 2. No re-import path exists, so previously exported files are unaffected.
- Persistence: `benchmarks.json` schema bumped to v4 with an in-place migration on load — legacy keys are still read, folded into the new fields, and rewritten. Covered by a new `migration_v4_test.go`.
- CSV: audited, no changes needed — `ttfr_ms` / `e2e_ttft_ms` are genuine milliseconds per the upstream llama-benchy schema, and no size/VRAM columns exist.

### UI
All binary-valued displays now say GiB/MiB: model cards, HF file browser (incl. the disk-space banner and 2 GiB safety-margin tooltip), downloads panel (incl. `MiB/s` transfer speed), GPU map, monitor bar VRAM/RAM readouts, VRAM estimate breakdowns, insufficient-disk-space errors, and the benchmark compare/detail/form templates.

### Code
- `models.BytesToGB` → `BytesToGiB` (the root misnomer) and the `SizeGB` struct fields feeding benchmark runs renamed to match.

Deliberately unchanged: the embedding presets table's hand-entered approximate "MB" sizes (they appear to be decimal-MB figures from Hugging Face) and the "~16 MB hash pool" help prose.

## Test plan
- [x] `go test ./...` passes
- [x] New test: v3 `benchmarks.json` with legacy keys loads correctly and is rewritten under the new names

🤖 Generated with [Claude Code](https://claude.com/claude-code)