### PR TITLE
fix(downloads): join the download goroutine on cancel and resume-eviction

### DIFF
--- a/internal/huggingface/downloader.go
+++ b/internal/huggingface/downloader.go
@@ -30,6 +30,13 @@ type DownloadStatus struct {
 type download struct {
 	cancel context.CancelFunc
 
+	// done is closed when the run goroutine has fully exited. Cancel and
+	// Start's terminal-entry eviction wait on it (bounded), so nothing
+	// races a goroutine that hasn't noticed its cancelled context yet —
+	// neither a resume opening the same .part file, nor a test's TempDir
+	// cleanup racing run's MkdirAll.
+	done chan struct{}
+
 	// Fan-out to multiple subscribers. History size 1 means the current
 	// state is retained: replayed to new subscribers (so they see where we
 	// are immediately) and queryable via last() for ListActive/PendingBytes.
@@ -102,11 +109,25 @@ func (d *Downloader) Start(ctx context.Context, modelID, filename string, expect
 		// Terminal entry still inside its 30s late-subscriber grace window —
 		// evict it so a paused/failed download can be resumed immediately.
 		delete(d.active, downloadID)
+		d.mu.Unlock()
+		// Wait (bounded) for the old goroutine to fully exit before
+		// spawning a replacement: its terminal status means it's at the
+		// end of run(), but until done closes it may still hold the
+		// .part file the new goroutine is about to open. (nil guard:
+		// entries deserialized or constructed without a goroutine.)
+		if existing.done != nil {
+			select {
+			case <-existing.done:
+			case <-time.After(5 * time.Second):
+			}
+		}
+		d.mu.Lock()
 	}
 
 	dlCtx, cancel := context.WithCancel(context.Background())
 	dl := &download{
 		cancel: cancel,
+		done:   make(chan struct{}),
 		bc:     broadcast.New[DownloadStatus](1, 16),
 	}
 	// Seed the status so PendingBytes counts this download immediately,
@@ -216,10 +237,35 @@ func (d *Downloader) Cancel(downloadID string) error {
 	}
 
 	dl.cancel()
+	// Join the goroutine (bounded): when Cancel returns, the download has
+	// actually stopped touching the filesystem — not merely been asked
+	// to. The chunk loop and the HTTP request both watch the context, so
+	// exit is prompt; the timeout only guards a wedged transfer.
+	if dl.done != nil {
+		select {
+		case <-dl.done:
+		case <-time.After(5 * time.Second):
+		}
+	}
 	return nil
 }
 
 func (d *Downloader) run(ctx context.Context, downloadID, modelID, filename string, dl *download) {
+	defer close(dl.done)
+	// Cancelled before we ever ran (pause immediately after resume, or a
+	// test's admission-only Start): report the terminal status and exit
+	// without side effects — in particular before the MkdirAll below,
+	// which otherwise races whoever is cleaning the directory up.
+	if ctx.Err() != nil {
+		dl.broadcast(DownloadStatus{ID: downloadID, ModelID: modelID, Filename: filename, Status: "cancelled"})
+		go func() {
+			time.Sleep(30 * time.Second)
+			d.mu.Lock()
+			delete(d.active, downloadID)
+			d.mu.Unlock()
+		}()
+		return
+	}
 	defer func() {
 		// Keep in active map briefly so late subscribers can see final status
 		go func() {

--- a/internal/huggingface/downloader_test.go
+++ b/internal/huggingface/downloader_test.go
@@ -13,8 +13,10 @@ import (
 func seedActive(d *Downloader, downloadID, status string) {
 	dl := &download{
 		cancel: func() {},
+		done:   make(chan struct{}),
 		bc:     broadcast.New[DownloadStatus](1, 16),
 	}
+	close(dl.done) // a seeded terminal entry represents a finished goroutine
 	dl.broadcast(DownloadStatus{ID: downloadID, Status: status})
 	d.mu.Lock()
 	d.active[downloadID] = dl
@@ -42,6 +44,23 @@ func TestStartReplacesTerminalEntry(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Start after %q entry: %v", status, err)
 		}
-		d.Cancel(id) // stop the spawned goroutine; we only care about admission
+		// Cancel joins the goroutine: when it returns, run() has fully
+		// exited (no more filesystem writes racing TempDir cleanup — the
+		// flake this test used to have) and the entry's status is
+		// terminal.
+		d.Cancel(id)
+		d.mu.Lock()
+		dl := d.active[id]
+		d.mu.Unlock()
+		if dl != nil {
+			select {
+			case <-dl.done:
+			default:
+				t.Fatalf("Cancel returned before the %q run goroutine exited", status)
+			}
+			if s := dl.last(); s.Status == "downloading" {
+				t.Fatalf("post-Cancel status still %q", s.Status)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Problem

`Downloader.Cancel` only cancelled the run goroutine's context and returned — nothing ever waited for the goroutine to actually exit. Two consequences:

1. **Flaky test** (`TestStartReplacesTerminalEntry`): the orphaned goroutine's unconditional `MkdirAll` (which runs before any context check) raced the test framework's `t.TempDir()` cleanup, failing with `TempDir RemoveAll cleanup: … directory not empty` under scheduler load. Reproduced on `main` with `-count=3`.
2. **Production wrinkle:** a pause→resume inside the 30s late-subscriber grace window could briefly run two goroutines against the same `.part` file — `Start` evicted the terminal entry and spawned a replacement while the old goroutine hadn't yet noticed its cancelled context.

## Fix

Each download carries a `done` channel closed when `run()` exits:

- **`Cancel` joins** on it (bounded 5s — the chunk loop and HTTP request both watch the context, so exit is prompt; the timeout only guards a wedged transfer). When Cancel returns, the download has actually stopped touching the filesystem, not merely been asked to.
- **`Start`'s terminal-entry eviction waits** for the old goroutine before spawning the replacement, closing the `.part` overlap window.
- **`run()` checks its context before any side effects**, reporting `cancelled` and exiting cleanly when it was dead on arrival.

The test now asserts the join (after Cancel: `done` closed, status terminal). Verified with 30 plain runs + 10 under `-race` — previously flaky within 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZPyq4QeaeZKgkSeyHQ6nw