### PR TITLE
feat(benchmarks): speculative decoding off value and per-mode settings in jobs

### DIFF
--- a/internal/api/bench_config_test.go
+++ b/internal/api/bench_config_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -317,5 +318,36 @@ func TestNoTakeoverMeansNoTeardownRestart(t *testing.T) {
 
 	if e.routerOwnedByJob() {
 		t.Error("recording the build without restarting must not claim the router — cleanup would then restart it for nothing")
+	}
+}
+
+// Speculative decoding must be fully controllable per job: a mode plus
+// its parameters reach the launch flags, and the explicit off value
+// ("none" in the form, empty in the snapshot) silences a model whose
+// saved config has speculation enabled — the on-vs-off comparison in a
+// single job.
+func TestSpecParamsReachLaunchFlags(t *testing.T) {
+	base := models.ModelConfig{Enabled: true, GPULayers: 999, ContextSize: 8192, Threads: 8}
+
+	on := applySnapshotToConfig(base, benchmark.ConfigSnapshot{
+		GPULayers: 999, ContextSize: 8192, Threads: 8,
+		SpecType: "draft-mtp", DraftMax: 6, DraftPMin: "0.75",
+	})
+	flags := on.EffectiveFlagsFor(false, "")
+	for _, want := range []string{"--spec-type draft-mtp", "--spec-draft-n-max 6", "--spec-draft-p-min 0.75"} {
+		if !strings.Contains(flags, want) {
+			t.Errorf("flags missing %q: %s", want, flags)
+		}
+	}
+
+	savedMTP := base
+	savedMTP.SpecType = "draft-mtp"
+	savedMTP.DraftMax = 6
+	off := applySnapshotToConfig(savedMTP, benchmark.ConfigSnapshot{
+		GPULayers: 999, ContextSize: 8192, Threads: 8,
+		// SpecType empty: the explicit off override.
+	})
+	if flags := off.EffectiveFlagsFor(false, ""); strings.Contains(flags, "--spec-type") {
+		t.Errorf("explicit off should emit no speculative flags: %s", flags)
 	}
 }

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -97,15 +97,11 @@ func resolveSweeps(req *jobCreateRequest) error {
 		if err != nil {
 			return err
 		}
-		// Merge rather than replace: the form carries through override
-		// fields it has no control for (draft_model_path), and replacing
-		// wholesale would delete them from a job whose name was the only
-		// thing the user meant to change.
-		//
-		// Only unsweepable fields carry through. A field the params map
-		// can express is params' to decide, including deciding to leave
-		// it unset — carrying those over made a supplied override
-		// impossible to clear.
+		// Merge rather than replace, so any override field the form has
+		// no control for would survive an edit. Every field currently
+		// has a form control, making this a no-op, but the rule stays:
+		// a field the params map can express is params' to decide,
+		// including deciding to leave it unset.
 		req.Overrides = benchmark.MergeOverrides(
 			benchmark.KeepUnsweepable(req.Overrides), derived)
 		req.Sweeps = axes

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -302,6 +302,11 @@ func applySnapshotToConfig(base models.ModelConfig, snap benchmark.ConfigSnapsho
 	out.KVCacheQuant = snap.KVCacheQuant
 	out.SpecType = snap.SpecType
 	out.DraftModelPath = snap.DraftModelPath
+	out.DraftMax = snap.DraftMax
+	out.DraftMin = snap.DraftMin
+	out.DraftPMin = snap.DraftPMin
+	out.NgramSizeN = snap.NgramSizeN
+	out.NgramSizeM = snap.NgramSizeM
 	out.FlashAttention = snap.FlashAttention
 	out.DirectIO = snap.DirectIO
 	return out
@@ -365,6 +370,11 @@ func (e *jobEnv) ResolveModel(modelID string) (benchmark.ModelInfo, error) {
 			UBatchSize:     cfg.UBatchSize,
 			SpecType:       cfg.SpecType,
 			DraftModelPath: cfg.DraftModelPath,
+			DraftMax:       cfg.DraftMax,
+			DraftMin:       cfg.DraftMin,
+			DraftPMin:      cfg.DraftPMin,
+			NgramSizeN:     cfg.NgramSizeN,
+			NgramSizeM:     cfg.NgramSizeM,
 		},
 	}, nil
 }
@@ -417,6 +427,11 @@ func configDiff(base, merged models.ModelConfig) []string {
 	add("split-mode", base.SplitMode, merged.SplitMode)
 	add("main-gpu", base.MainGPU, merged.MainGPU)
 	add("spec-type", base.SpecType, merged.SpecType)
+	add("draft-max", base.DraftMax, merged.DraftMax)
+	add("draft-min", base.DraftMin, merged.DraftMin)
+	add("draft-p-min", base.DraftPMin, merged.DraftPMin)
+	add("ngram-size-n", base.NgramSizeN, merged.NgramSizeN)
+	add("ngram-size-m", base.NgramSizeM, merged.NgramSizeM)
 	if len(out) == 0 {
 		return []string{"none"}
 	}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -21,40 +21,27 @@ import (
 // it on every save would clobber user-tuned values within an existing mode
 // (the form parser already loaded them from the request into cfg).
 func applySpecDefaults(cfg *models.ModelConfig) {
-	switch cfg.SpecType {
-	case "":
-		cfg.DraftMax = 0
-		cfg.DraftMin = 0
-		cfg.DraftPMin = ""
-		cfg.NgramSizeN = 0
-		cfg.NgramSizeM = 0
-	case "draft":
-		cfg.DraftMax = 16
-		cfg.DraftMin = 0
-		cfg.DraftPMin = "0.75"
-		cfg.NgramSizeN = 0
-		cfg.NgramSizeM = 0
-	case "draft-mtp":
-		// unsloth's MTP cookbook uses --spec-draft-n-max 6 for Qwen3.6.
-		// Leave min/p-min at llama.cpp defaults — MTP heads have their
-		// own acceptance logic and the broader knobs rarely help.
-		cfg.DraftMax = 6
-		cfg.DraftMin = 0
-		cfg.DraftPMin = ""
-		cfg.NgramSizeN = 0
-		cfg.NgramSizeM = 0
-	case "ngram-simple", "ngram-cache", "ngram-map-k", "ngram-map-k4v":
-		cfg.DraftMax = 16
-		cfg.DraftMin = 0
-		cfg.DraftPMin = ""
-		cfg.NgramSizeN = 12
-		cfg.NgramSizeM = 48
-	case "ngram-mod":
-		cfg.DraftMax = 64
-		cfg.DraftMin = 48
-		cfg.DraftPMin = ""
-		cfg.NgramSizeN = 24
-		cfg.NgramSizeM = 48
+	// Zero everything, then apply the mode's recommended defaults from
+	// the shared table — the same one the benchmark job form renders, so
+	// the two surfaces cannot disagree.
+	cfg.DraftMax = 0
+	cfg.DraftMin = 0
+	cfg.DraftPMin = ""
+	cfg.NgramSizeN = 0
+	cfg.NgramSizeM = 0
+	for _, p := range models.SpecModeParams(cfg.SpecType) {
+		switch p.Key {
+		case "draft_max":
+			cfg.DraftMax, _ = strconv.Atoi(p.Default)
+		case "draft_min":
+			cfg.DraftMin, _ = strconv.Atoi(p.Default)
+		case "draft_p_min":
+			cfg.DraftPMin = p.Default
+		case "ngram_size_n":
+			cfg.NgramSizeN, _ = strconv.Atoi(p.Default)
+		case "ngram_size_m":
+			cfg.NgramSizeM, _ = strconv.Atoi(p.Default)
+		}
 	}
 }
 

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -105,6 +105,11 @@ type ConfigSnapshot struct {
 	UBatchSize     int    `json:"ubatch_size,omitempty"`
 	SpecType       string `json:"spec_type,omitempty"`
 	DraftModelPath string `json:"draft_model_path,omitempty"`
+	DraftMax       int    `json:"draft_max,omitempty"`
+	DraftMin       int    `json:"draft_min,omitempty"`
+	DraftPMin      string `json:"draft_p_min,omitempty"`
+	NgramSizeN     int    `json:"ngram_size_n,omitempty"`
+	NgramSizeM     int    `json:"ngram_size_m,omitempty"`
 }
 
 // GPUSnapshot captures GPU hardware at benchmark time.

--- a/internal/benchmark/job.go
+++ b/internal/benchmark/job.go
@@ -83,6 +83,11 @@ type ConfigOverrides struct {
 	TensorSplit    *string  `json:"tensor_split,omitempty"`
 	SpecType       *string  `json:"spec_type,omitempty"`
 	DraftModelPath *string  `json:"draft_model_path,omitempty"`
+	DraftMax       *int     `json:"draft_max,omitempty"`
+	DraftMin       *int     `json:"draft_min,omitempty"`
+	DraftPMin      *string  `json:"draft_p_min,omitempty"`
+	NgramSizeN     *int     `json:"ngram_size_n,omitempty"`
+	NgramSizeM     *int     `json:"ngram_size_m,omitempty"`
 	Temperature    *float64 `json:"temperature,omitempty"`
 	TopP           *float64 `json:"top_p,omitempty"`
 	TopK           *int     `json:"top_k,omitempty"`

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -474,6 +474,21 @@ func applyOverrides(base ConfigSnapshot, overrides *ConfigOverrides) ConfigSnaps
 	if overrides.DraftModelPath != nil {
 		out.DraftModelPath = *overrides.DraftModelPath
 	}
+	if overrides.DraftMax != nil {
+		out.DraftMax = *overrides.DraftMax
+	}
+	if overrides.DraftMin != nil {
+		out.DraftMin = *overrides.DraftMin
+	}
+	if overrides.DraftPMin != nil {
+		out.DraftPMin = *overrides.DraftPMin
+	}
+	if overrides.NgramSizeN != nil {
+		out.NgramSizeN = *overrides.NgramSizeN
+	}
+	if overrides.NgramSizeM != nil {
+		out.NgramSizeM = *overrides.NgramSizeM
+	}
 	return out
 }
 

--- a/internal/benchmark/split_params_test.go
+++ b/internal/benchmark/split_params_test.go
@@ -170,18 +170,12 @@ func TestSweepFieldOrdering(t *testing.T) {
 	}
 }
 
-// draft_model_path is sweepable as a free-text parameter: without a
-// form control for it, the draft speculative mode could only run
-// against whatever path the model's saved config happened to hold, so
-// selecting the mode in a job was not enough to use it. Free-text
-// rendering keeps filesystem paths out of the choice dropdowns.
-func TestDraftModelPathIsFreeTextSweepable(t *testing.T) {
-	f, ok := LookupSweepField("draft_model_path")
-	if !ok {
-		t.Fatal("draft_model_path should be offered as a parameter")
-	}
-	if !f.FreeText {
-		t.Error("a filesystem path must render as free text, not choices")
+// A draft model path is a thing to select, not a value to tune, and it
+// is the one override with no form control: the draft mode runs against
+// the path in the model's saved config.
+func TestDraftModelPathIsNotSweepable(t *testing.T) {
+	if _, ok := LookupSweepField("draft_model_path"); ok {
+		t.Error("draft_model_path should not be offered as a tunable parameter")
 	}
 }
 
@@ -310,25 +304,37 @@ func TestOverrideKeyTreatsEmptyAsNil(t *testing.T) {
 
 // Params own every parameter they can express, including by omission —
 // otherwise an override supplied alongside them can never be cleared.
-// Every ConfigOverrides field now has a form control (draft_model_path
-// gained a free-text one), so nothing carries through; the mechanism
-// stays for any future field the form cannot express.
+// The speculative parameters are expressible through spec_type's
+// encoded values, so they must not carry through; draft_model_path has
+// no form control and must.
 func TestKeepUnsweepableDropsExpressibleFields(t *testing.T) {
 	ngl := 40
+	dm := 8
 	path := "/models/draft.gguf"
-	got := KeepUnsweepable(&ConfigOverrides{GPULayers: &ngl, DraftModelPath: &path})
-	if got != nil {
-		t.Errorf("every field is expressible via params now; nothing should carry through, got %+v", got)
+	got := KeepUnsweepable(&ConfigOverrides{GPULayers: &ngl, DraftMax: &dm, DraftModelPath: &path})
+
+	if got == nil {
+		t.Fatal("the unsweepable field should have been kept")
+	}
+	if got.GPULayers != nil {
+		t.Error("gpu_layers is expressible via params and must not carry through")
+	}
+	if got.DraftMax != nil {
+		t.Error("draft_max is expressible via spec_type values and must not carry through")
+	}
+	if got.DraftModelPath == nil || *got.DraftModelPath != path {
+		t.Error("draft_model_path has no form control and must carry through")
 	}
 
-	// The reflection walk must cover every field: any override field
-	// whose JSON tag is missing from the registry would silently carry
-	// through edits, so require full coverage explicitly.
+	// Coverage guard: every ConfigOverrides field must be accounted for —
+	// a registry entry, the spec-parameter set, or the one deliberate
+	// carry-through — so a new field cannot silently do the wrong thing.
+	accounted := map[string]bool{"draft_model_path": true}
 	tp := reflect.TypeOf(ConfigOverrides{})
 	for i := 0; i < tp.NumField(); i++ {
 		tag := strings.Split(tp.Field(i).Tag.Get("json"), ",")[0]
-		if !IsSweepable(tag) {
-			t.Errorf("ConfigOverrides field %s (%s) has no sweep registry entry", tp.Field(i).Name, tag)
+		if !IsSweepable(tag) && !specParamTags[tag] && !accounted[tag] {
+			t.Errorf("ConfigOverrides field %s (%s) is not accounted for in the sweep registry", tp.Field(i).Name, tag)
 		}
 	}
 }
@@ -507,19 +513,60 @@ func TestSpecTypeNoneMapsToExplicitOff(t *testing.T) {
 	}
 }
 
-// The speculative decoding parameters are sweepable and reach the
-// snapshot, so a job can tune a mode, not just select it.
+// A mode's parameters travel inside the spec_type value and reach the
+// snapshot, so a job can tune a mode, not just select it. Parameters
+// the value doesn't mention inherit the model's saved setting.
 func TestSpecParamsFlowToSnapshot(t *testing.T) {
 	o, _, err := SplitParams(map[string][]string{
-		"spec_type":   {"draft-mtp"},
-		"draft_max":   {"6"},
-		"draft_p_min": {"0.75"},
+		"spec_type": {"draft-mtp:draft_max=6,draft_p_min=0.75"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	snap := applyOverrides(ConfigSnapshot{DraftMax: 16}, o)
+	snap := applyOverrides(ConfigSnapshot{DraftMax: 16, DraftMin: 3}, o)
 	if snap.SpecType != "draft-mtp" || snap.DraftMax != 6 || snap.DraftPMin != "0.75" {
 		t.Fatalf("spec params did not reach the snapshot: %+v", snap)
+	}
+	if snap.DraftMin != 3 {
+		t.Errorf("unmentioned parameter should keep the saved value, got %d", snap.DraftMin)
+	}
+}
+
+// parseSpecValue is the single parser for all three value shapes, and
+// canonicalization makes parameter order and spacing irrelevant so
+// dedup can't be fooled.
+func TestSpecValueParsingAndCanonical(t *testing.T) {
+	for _, bad := range []string{
+		"warp-drive",                // unknown mode
+		"draft-mtp:ngram_size_n=12", // key not valid for the mode
+		"draft-mtp:draft_max=lots",  // non-integer
+		"draft:draft_p_min=high",    // non-number
+		"draft-mtp:draft_max",       // not key=value
+	} {
+		if _, err := parseSpecValue(bad); err == nil {
+			t.Errorf("%q should be rejected", bad)
+		}
+	}
+
+	f, _ := LookupSweepField("spec_type")
+	a := f.canonical(" draft-mtp: draft_p_min=0.75 , draft_max=6 ")
+	b := f.canonical("draft-mtp:draft_max=6,draft_p_min=0.75")
+	if a != b {
+		t.Errorf("canonical forms differ: %q vs %q", a, b)
+	}
+	if got := f.canonical("none"); got != "none" {
+		t.Errorf("canonical none = %q", got)
+	}
+
+	// Two spellings of the same value dedup to one, so it fixes rather
+	// than sweeps.
+	_, axes, err := SplitParams(map[string][]string{
+		"spec_type": {"draft-mtp:draft_max=6,draft_p_min=0.75", "draft-mtp: draft_p_min=0.75 ,draft_max=6"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(axes) != 0 {
+		t.Errorf("equivalent values should dedup to a fixed override, got axes %+v", axes)
 	}
 }

--- a/internal/benchmark/split_params_test.go
+++ b/internal/benchmark/split_params_test.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -169,11 +170,18 @@ func TestSweepFieldOrdering(t *testing.T) {
 	}
 }
 
-// A draft model path is a thing to select, not a knob to tune, and it
-// was the only parameter whose values were filesystem paths.
-func TestDraftModelPathIsNotSweepable(t *testing.T) {
-	if _, ok := LookupSweepField("draft_model_path"); ok {
-		t.Error("draft_model_path should not be offered as a tunable parameter")
+// draft_model_path is sweepable as a free-text parameter: without a
+// form control for it, the draft speculative mode could only run
+// against whatever path the model's saved config happened to hold, so
+// selecting the mode in a job was not enough to use it. Free-text
+// rendering keeps filesystem paths out of the choice dropdowns.
+func TestDraftModelPathIsFreeTextSweepable(t *testing.T) {
+	f, ok := LookupSweepField("draft_model_path")
+	if !ok {
+		t.Fatal("draft_model_path should be offered as a parameter")
+	}
+	if !f.FreeText {
+		t.Error("a filesystem path must render as free text, not choices")
 	}
 }
 
@@ -302,19 +310,26 @@ func TestOverrideKeyTreatsEmptyAsNil(t *testing.T) {
 
 // Params own every parameter they can express, including by omission —
 // otherwise an override supplied alongside them can never be cleared.
+// Every ConfigOverrides field now has a form control (draft_model_path
+// gained a free-text one), so nothing carries through; the mechanism
+// stays for any future field the form cannot express.
 func TestKeepUnsweepableDropsExpressibleFields(t *testing.T) {
 	ngl := 40
 	path := "/models/draft.gguf"
 	got := KeepUnsweepable(&ConfigOverrides{GPULayers: &ngl, DraftModelPath: &path})
+	if got != nil {
+		t.Errorf("every field is expressible via params now; nothing should carry through, got %+v", got)
+	}
 
-	if got == nil {
-		t.Fatal("the unsweepable field should have been kept")
-	}
-	if got.GPULayers != nil {
-		t.Error("gpu_layers is expressible via params and must not carry through")
-	}
-	if got.DraftModelPath == nil || *got.DraftModelPath != path {
-		t.Error("draft_model_path has no form control and must carry through")
+	// The reflection walk must cover every field: any override field
+	// whose JSON tag is missing from the registry would silently carry
+	// through edits, so require full coverage explicitly.
+	tp := reflect.TypeOf(ConfigOverrides{})
+	for i := 0; i < tp.NumField(); i++ {
+		tag := strings.Split(tp.Field(i).Tag.Get("json"), ",")[0]
+		if !IsSweepable(tag) {
+			t.Errorf("ConfigOverrides field %s (%s) has no sweep registry entry", tp.Field(i).Name, tag)
+		}
 	}
 }
 
@@ -453,5 +468,58 @@ func TestPromptsOfDifferentSizesDoNotSharePrefix(t *testing.T) {
 	}
 	if div > 64 {
 		t.Errorf("prompts share their first %d chars; the overlap should be a few tokens at most", div)
+	}
+}
+
+// "none" is the explicit speculative-decoding-off value: it must survive
+// SplitParams (a literal empty string would be dropped as unset) and map
+// to an explicit empty SpecType override.
+func TestSpecTypeNoneMapsToExplicitOff(t *testing.T) {
+	// Single value: fixed override.
+	o, axes, err := SplitParams(map[string][]string{"spec_type": {"none"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(axes) != 0 {
+		t.Fatalf("single value should fix, not sweep: %+v", axes)
+	}
+	if o == nil || o.SpecType == nil || *o.SpecType != "" {
+		t.Fatalf("none should become an explicit empty SpecType override, got %+v", o)
+	}
+
+	// Two values: a sweep comparing off against a mode in one job.
+	_, axes, err = SplitParams(map[string][]string{"spec_type": {"none", "draft-mtp"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(axes) != 1 || len(axes[0].Values) != 2 {
+		t.Fatalf("none+mode should sweep with both values kept: %+v", axes)
+	}
+
+	// And the axis value applies per cell the same way.
+	var cell ConfigOverrides
+	f, _ := LookupSweepField("spec_type")
+	if err := f.set(&cell, "none"); err != nil {
+		t.Fatal(err)
+	}
+	if cell.SpecType == nil || *cell.SpecType != "" {
+		t.Fatalf("axis value none should apply as explicit off, got %+v", cell.SpecType)
+	}
+}
+
+// The speculative decoding parameters are sweepable and reach the
+// snapshot, so a job can tune a mode, not just select it.
+func TestSpecParamsFlowToSnapshot(t *testing.T) {
+	o, _, err := SplitParams(map[string][]string{
+		"spec_type":   {"draft-mtp"},
+		"draft_max":   {"6"},
+		"draft_p_min": {"0.75"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap := applyOverrides(ConfigSnapshot{DraftMax: 16}, o)
+	if snap.SpecType != "draft-mtp" || snap.DraftMax != 6 || snap.DraftPMin != "0.75" {
+		t.Fatalf("spec params did not reach the snapshot: %+v", snap)
 	}
 }

--- a/internal/benchmark/split_params_test.go
+++ b/internal/benchmark/split_params_test.go
@@ -140,12 +140,19 @@ func TestEnumerableParamsHaveChoices(t *testing.T) {
 
 // Ordering is a UX contract, not incidental: reload-affecting parameters
 // first (those are the ones that move throughput), sampling next, and
-// free-text controls last so they don't interleave with the dropdowns
-// and read as a rendering fault.
+// ungrouped free-text controls last so they don't interleave with the
+// dropdowns and read as a rendering fault. Grouped fields are the
+// exception to both rules: they take their parent's tier and sort
+// directly beneath it, so someone selecting a speculative decoding mode
+// finds its parameters right below the selector.
 func TestSweepFieldOrdering(t *testing.T) {
 	fields := SweepFields()
 
 	rank := func(f SweepField) int {
+		if f.Group != "" {
+			p, _ := LookupSweepField(f.Group)
+			f = p
+		}
 		switch {
 		case f.FreeText:
 			return 2
@@ -155,18 +162,46 @@ func TestSweepFieldOrdering(t *testing.T) {
 			return 0
 		}
 	}
+	key := func(f SweepField) string {
+		if f.Group != "" {
+			p, _ := LookupSweepField(f.Group)
+			return p.Label + "\x00" + f.Label
+		}
+		return f.Label
+	}
 	for i := 1; i < len(fields); i++ {
 		prev, cur := fields[i-1], fields[i]
 		if rank(prev) > rank(cur) {
 			t.Errorf("%s (tier %d) sorts before %s (tier %d)",
 				prev.Name, rank(prev), cur.Name, rank(cur))
 		}
-		if rank(prev) == rank(cur) && prev.Label > cur.Label {
+		if rank(prev) == rank(cur) && key(prev) > key(cur) {
 			t.Errorf("within a tier, %q should follow %q", prev.Label, cur.Label)
 		}
 	}
 	if len(fields) == 0 || !fields[len(fields)-1].FreeText {
 		t.Error("the last parameter should be a free-text one")
+	}
+
+	// The group contract itself: every spec parameter sits in a
+	// contiguous run immediately after the Speculative Decoding row.
+	idx := map[string]int{}
+	for i, f := range fields {
+		idx[f.Name] = i
+	}
+	specIdx, ok := idx["spec_type"]
+	if !ok {
+		t.Fatal("spec_type missing")
+	}
+	members := []string{"draft_max", "draft_min", "draft_p_min", "draft_model_path", "ngram_size_m", "ngram_size_n"}
+	for _, m := range members {
+		i, ok := idx[m]
+		if !ok {
+			t.Fatalf("%s missing", m)
+		}
+		if i <= specIdx || i > specIdx+len(members) {
+			t.Errorf("%s (index %d) is not grouped under spec_type (index %d)", m, i, specIdx)
+		}
 	}
 }
 

--- a/internal/benchmark/split_params_test.go
+++ b/internal/benchmark/split_params_test.go
@@ -140,19 +140,12 @@ func TestEnumerableParamsHaveChoices(t *testing.T) {
 
 // Ordering is a UX contract, not incidental: reload-affecting parameters
 // first (those are the ones that move throughput), sampling next, and
-// ungrouped free-text controls last so they don't interleave with the
-// dropdowns and read as a rendering fault. Grouped fields are the
-// exception to both rules: they take their parent's tier and sort
-// directly beneath it, so someone selecting a speculative decoding mode
-// finds its parameters right below the selector.
+// free-text controls last so they don't interleave with the dropdowns
+// and read as a rendering fault.
 func TestSweepFieldOrdering(t *testing.T) {
 	fields := SweepFields()
 
 	rank := func(f SweepField) int {
-		if f.Group != "" {
-			p, _ := LookupSweepField(f.Group)
-			f = p
-		}
 		switch {
 		case f.FreeText:
 			return 2
@@ -162,46 +155,18 @@ func TestSweepFieldOrdering(t *testing.T) {
 			return 0
 		}
 	}
-	key := func(f SweepField) string {
-		if f.Group != "" {
-			p, _ := LookupSweepField(f.Group)
-			return p.Label + "\x00" + f.Label
-		}
-		return f.Label
-	}
 	for i := 1; i < len(fields); i++ {
 		prev, cur := fields[i-1], fields[i]
 		if rank(prev) > rank(cur) {
 			t.Errorf("%s (tier %d) sorts before %s (tier %d)",
 				prev.Name, rank(prev), cur.Name, rank(cur))
 		}
-		if rank(prev) == rank(cur) && key(prev) > key(cur) {
+		if rank(prev) == rank(cur) && prev.Label > cur.Label {
 			t.Errorf("within a tier, %q should follow %q", prev.Label, cur.Label)
 		}
 	}
 	if len(fields) == 0 || !fields[len(fields)-1].FreeText {
 		t.Error("the last parameter should be a free-text one")
-	}
-
-	// The group contract itself: every spec parameter sits in a
-	// contiguous run immediately after the Speculative Decoding row.
-	idx := map[string]int{}
-	for i, f := range fields {
-		idx[f.Name] = i
-	}
-	specIdx, ok := idx["spec_type"]
-	if !ok {
-		t.Fatal("spec_type missing")
-	}
-	members := []string{"draft_max", "draft_min", "draft_p_min", "draft_model_path", "ngram_size_m", "ngram_size_n"}
-	for _, m := range members {
-		i, ok := idx[m]
-		if !ok {
-			t.Fatalf("%s missing", m)
-		}
-		if i <= specIdx || i > specIdx+len(members) {
-			t.Errorf("%s (index %d) is not grouped under spec_type (index %d)", m, i, specIdx)
-		}
 	}
 }
 

--- a/internal/benchmark/sweep.go
+++ b/internal/benchmark/sweep.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 // SweepAxis is one parameter varied across a job's matrix. Field names
@@ -34,6 +36,13 @@ const (
 type SweepChoice struct {
 	Value string
 	Label string
+	// Params are the tunable settings this choice carries, rendered as
+	// an expandable section under its checkbox. Only the speculative
+	// decoding modes have them; editing one changes the submitted value
+	// to the encoded form "mode:key=value,...". Mode is the bare mode
+	// name the encoded Value starts with.
+	Params []models.SpecModeParam
+	Mode   string
 }
 
 // SweepField describes one sweepable parameter. The set function is the
@@ -72,6 +81,9 @@ type SweepField struct {
 	DynamicChoices string
 
 	set func(o *ConfigOverrides, raw string) error
+	// canon overrides the kind-based canonical form for fields whose
+	// values have structure of their own (the encoded spec_type values).
+	canon func(raw string) string
 }
 
 func parseInt(raw string) (int, error) {
@@ -140,6 +152,139 @@ func boolField(name, label, help string, apply func(*ConfigOverrides, *bool)) Sw
 	}
 }
 
+// specValue is a parsed spec_type sweep value: a mode plus any
+// parameter settings from the mode's expandable section.
+type specValue struct {
+	mode   string
+	params map[string]string // key -> raw value, keys from models.SpecModeParams
+}
+
+// parseSpecValue parses the three accepted shapes: "none", a bare mode
+// name, or "mode:key=value,key=value". Keys must belong to the mode
+// (per models.SpecModeParams) and integer parameters must parse.
+func parseSpecValue(raw string) (specValue, error) {
+	v := strings.TrimSpace(raw)
+	out := specValue{params: map[string]string{}}
+	if v == "none" {
+		return out, nil // mode "" = speculative decoding off
+	}
+	mode, rest, hasParams := strings.Cut(v, ":")
+	mode = strings.TrimSpace(mode)
+	allowed := models.SpecModeParams(mode)
+	if len(allowed) == 0 {
+		return out, fmt.Errorf("%q is not a speculative decoding mode", mode)
+	}
+	out.mode = mode
+	if !hasParams {
+		return out, nil
+	}
+	allowedKeys := map[string]bool{}
+	for _, p := range allowed {
+		allowedKeys[p.Key] = true
+	}
+	for _, pair := range strings.Split(rest, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		k, val, ok := strings.Cut(pair, "=")
+		k, val = strings.TrimSpace(k), strings.TrimSpace(val)
+		if !ok || k == "" {
+			return out, fmt.Errorf("%q is not a key=value setting", pair)
+		}
+		if !allowedKeys[k] {
+			return out, fmt.Errorf("%q is not a setting of the %s mode", k, mode)
+		}
+		if k == "draft_p_min" {
+			if _, err := strconv.ParseFloat(val, 64); err != nil {
+				return out, fmt.Errorf("draft_p_min %q is not a number", val)
+			}
+		} else {
+			if _, err := strconv.Atoi(val); err != nil {
+				return out, fmt.Errorf("%s %q is not an integer", k, val)
+			}
+		}
+		out.params[k] = val
+	}
+	return out, nil
+}
+
+// applySpecValue is spec_type's set function: it writes the mode and any
+// parameter settings onto the overrides. Parameters the value doesn't
+// mention are left nil, so the model's saved values apply — the same
+// inherit rule as every other parameter.
+func applySpecValue(o *ConfigOverrides, raw string) error {
+	sv, err := parseSpecValue(raw)
+	if err != nil {
+		return err
+	}
+	mode := sv.mode
+	o.SpecType = &mode
+	for k, val := range sv.params {
+		switch k {
+		case "draft_max":
+			n, _ := strconv.Atoi(val)
+			o.DraftMax = &n
+		case "draft_min":
+			n, _ := strconv.Atoi(val)
+			o.DraftMin = &n
+		case "draft_p_min":
+			v := val
+			o.DraftPMin = &v
+		case "ngram_size_n":
+			n, _ := strconv.Atoi(val)
+			o.NgramSizeN = &n
+		case "ngram_size_m":
+			n, _ := strconv.Atoi(val)
+			o.NgramSizeM = &n
+		}
+	}
+	return nil
+}
+
+// encodeSpecValue renders a mode with its parameters' current values in
+// the encoded form the parser accepts, skipping empty values (empty =
+// inherit the model's saved setting). Bare mode when nothing is set.
+func encodeSpecValue(mode string, params []models.SpecModeParam) string {
+	var pairs []string
+	for _, p := range params {
+		if p.Default != "" {
+			pairs = append(pairs, p.Key+"="+p.Default)
+		}
+	}
+	if len(pairs) == 0 {
+		return mode
+	}
+	return mode + ":" + strings.Join(pairs, ",")
+}
+
+// canonicalSpecValue renders a spec value in its parsed, sorted form so
+// dedup catches values that differ only in spacing or parameter order.
+// Unparseable values return trimmed raw; the parser rejects them later
+// with a real error message.
+func canonicalSpecValue(raw string) string {
+	sv, err := parseSpecValue(raw)
+	if err != nil {
+		return strings.TrimSpace(raw)
+	}
+	if sv.mode == "" {
+		return "none"
+	}
+	if len(sv.params) == 0 {
+		return sv.mode
+	}
+	keys := make([]string, 0, len(sv.params))
+	for k := range sv.params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([]string, len(keys))
+	for i, k := range keys {
+		pairs[i] = k + "=" + sv.params[k]
+	}
+	return sv.mode + ":" + strings.Join(pairs, ",")
+}
+
 func floatField(name, label, help, example string, apply func(*ConfigOverrides, *float64)) SweepField {
 	return SweepField{
 		Name: name, Label: label, Kind: SweepKindFloat, Help: help,
@@ -160,6 +305,9 @@ func floatField(name, label, help, example string, apply func(*ConfigOverrides, 
 // "1.0" vs "1", "8" vs "08". Raw text is returned for free-form kinds.
 func (f SweepField) canonical(raw string) string {
 	v := strings.TrimSpace(raw)
+	if f.canon != nil {
+		return f.canon(v)
+	}
 	switch f.Kind {
 	case SweepKindInt:
 		n, err := strconv.Atoi(v)
@@ -207,29 +355,20 @@ var sweepFields = map[string]SweepField{
 		func(o *ConfigOverrides, v *string) { o.GPUAssign = v }),
 	"tensor_split": strField("tensor_split", "Tensor Split", "Proportional split across GPUs, e.g. 1,1.", "1,1|3,1",
 		func(o *ConfigOverrides, v *string) { o.TensorSplit = v }),
-	// "none" is a stand-in for the empty value: a blank axis value would
-	// be dropped as "unset", so the registry maps none -> "" here, which
-	// reaches the config as an explicit "speculative decoding off". This
-	// is what lets one job compare a mode against no speculation at all.
-	"spec_type": strField("spec_type", "Speculative Decoding", "Speculative decoding mode. Select none to turn speculative decoding off for that cell.", "none,draft-mtp",
-		func(o *ConfigOverrides, v *string) {
-			if *v == "none" {
-				*v = ""
-			}
-			o.SpecType = v
-		}),
-	"draft_max": intField("draft_max", "Draft Tokens Max", "Maximum tokens drafted per step (--spec-draft-n-max). Applies when a speculative decoding mode is active; 0 leaves llama.cpp's default.", "4,6,8,16",
-		func(o *ConfigOverrides, v *int) { o.DraftMax = v }),
-	"draft_min": intField("draft_min", "Draft Tokens Min", "Minimum tokens drafted per step (--spec-draft-n-min). Applies when a speculative decoding mode is active; 0 leaves llama.cpp's default.", "0,2",
-		func(o *ConfigOverrides, v *int) { o.DraftMin = v }),
-	"draft_p_min": strField("draft_p_min", "Draft Probability Min", "Minimum draft acceptance probability, 0-1 (--spec-draft-p-min). Applies when a speculative decoding mode is active; blank leaves llama.cpp's default.", "0.5,0.75,0.9",
-		func(o *ConfigOverrides, v *string) { o.DraftPMin = v }),
-	"ngram_size_n": intField("ngram_size_n", "N-gram Size N", "N-gram lookup size (--spec-ngram-size-n). Applies to the n-gram speculative modes; 0 leaves llama.cpp's default.", "12,24",
-		func(o *ConfigOverrides, v *int) { o.NgramSizeN = v }),
-	"ngram_size_m": intField("ngram_size_m", "N-gram Size M", "N-gram candidate count (--spec-ngram-size-m). Applies to the n-gram speculative modes; 0 leaves llama.cpp's default.", "48,64",
-		func(o *ConfigOverrides, v *int) { o.NgramSizeM = v }),
-	"draft_model_path": strField("draft_model_path", "Draft Model Path", "Path to the draft model GGUF (--model-draft). Applies to the draft and MTP-with-separate-head modes; blank uses the model's saved setting.", "/data/models/org--repo/draft.gguf",
-		func(o *ConfigOverrides, v *string) { o.DraftModelPath = v }),
+	// A value is either a bare mode name, "none" (an explicit
+	// "speculative decoding off" — a blank value would be dropped as
+	// "use the model's saved setting"), or a mode with parameter
+	// settings in the encoded form "mode:draft_max=8,draft_p_min=0.9".
+	// The form builds the encoded values from the expandable parameter
+	// sections under each mode's checkbox; parseSpecValue is the single
+	// parser for all three shapes.
+	"spec_type": {
+		Name: "spec_type", Label: "Speculative Decoding", Kind: SweepKindStr,
+		Help:    "Speculative decoding mode. Select none to turn speculative decoding off for that cell; expand a mode to adjust its settings.",
+		Example: "none,draft-mtp", RestartsRouter: true, Separator: ";",
+		set:   applySpecValue,
+		canon: canonicalSpecValue,
+	},
 
 	// Sampling params ride along with each request, so sweeping them
 	// costs no router restarts.
@@ -438,11 +577,6 @@ func init() {
 	))
 	set("temperature", true, choices("0", "0 (greedy)", "0.7", "0.7", "1.0", "1.0"))
 	set("top_p", true, choices("0.9", "0.9", "0.95", "0.95", "1.0", "1.0 (off)"))
-	set("draft_max", true, choices("4", "4", "6", "6 (MTP guidance)", "8", "8", "16", "16"))
-	set("draft_min", true, choices("0", "0 (default)", "2", "2"))
-	set("draft_p_min", true, choices("0.5", "0.5", "0.75", "0.75", "0.9", "0.9"))
-	set("ngram_size_n", true, choices("12", "12", "24", "24"))
-	set("ngram_size_m", true, choices("48", "48", "64", "64"))
 	set("top_k", true, choices("20", "20", "40", "40", "0", "0 (disabled)"))
 	set("min_p", true, choices("0", "0", "0.05", "0.05", "0.1", "0.1"))
 	set("repeat_penalty", true, choices("1.0", "1.0 (off)", "1.05", "1.05", "1.1", "1.1"))
@@ -459,10 +593,23 @@ func init() {
 	ts2.FreeText = true
 	sweepFields["tensor_split"] = ts2
 
-	// A filesystem path is free-form too.
-	dmp := sweepFields["draft_model_path"]
-	dmp.FreeText = true
-	sweepFields["draft_model_path"] = dmp
+	// Each speculative mode choice carries its tunable parameters (the
+	// same set with the same recommended defaults as the model config
+	// form), rendered as an expandable section under its checkbox. The
+	// choice's submitted value is pre-encoded with those defaults —
+	// selecting a mode in a job then behaves exactly like selecting it
+	// on the model config form, and what the inputs show is what
+	// submits. Editing an input re-encodes the value in the browser.
+	st := sweepFields["spec_type"]
+	for i := range st.Choices {
+		mode := st.Choices[i].Value
+		st.Choices[i].Params = models.SpecModeParams(mode)
+		if len(st.Choices[i].Params) > 0 {
+			st.Choices[i].Mode = mode
+			st.Choices[i].Value = encodeSpecValue(mode, st.Choices[i].Params)
+		}
+	}
+	sweepFields["spec_type"] = st
 }
 
 // SplitParams turns the unified "parameter → selected values" shape the
@@ -549,6 +696,13 @@ func MergeOverrides(base, derived *ConfigOverrides) *ConfigOverrides {
 	return &out
 }
 
+// specParamTags are ConfigOverrides fields expressible through
+// spec_type's encoded values rather than registry entries of their own.
+var specParamTags = map[string]bool{
+	"draft_max": true, "draft_min": true, "draft_p_min": true,
+	"ngram_size_n": true, "ngram_size_m": true,
+}
+
 // IsSweepable reports whether a parameter has a form control, i.e.
 // whether params can express it.
 func IsSweepable(field string) bool {
@@ -565,7 +719,10 @@ func KeepUnsweepable(o *ConfigOverrides) *ConfigOverrides {
 		return nil
 	}
 	// JSON tags are the registry keys, so a field is sweepable exactly
-	// when its tag names a registry entry.
+	// when its tag names a registry entry — with one addition: the
+	// speculative parameters have no registry entries of their own but
+	// ARE expressible through spec_type's encoded values, so params own
+	// them too and they must not carry through an edit.
 	var out ConfigOverrides
 	v := reflect.ValueOf(*o)
 	t := v.Type()
@@ -576,7 +733,7 @@ func KeepUnsweepable(o *ConfigOverrides) *ConfigOverrides {
 			continue
 		}
 		tag := strings.Split(t.Field(i).Tag.Get("json"), ",")[0]
-		if IsSweepable(tag) {
+		if IsSweepable(tag) || specParamTags[tag] {
 			continue
 		}
 		dst.Field(i).Set(v.Field(i))

--- a/internal/benchmark/sweep.go
+++ b/internal/benchmark/sweep.go
@@ -70,11 +70,6 @@ type SweepField struct {
 	// DynamicChoices names a choice set the API layer fills in at render
 	// time because it depends on the host (e.g. how many GPUs exist).
 	DynamicChoices string
-	// Group names another field this one belongs under. Grouped fields
-	// render indented directly beneath their parent in the job form —
-	// the speculative decoding parameters sit under the mode selector,
-	// where someone choosing a mode will find them.
-	Group string
 
 	set func(o *ConfigOverrides, raw string) error
 }
@@ -265,22 +260,8 @@ func init() {
 	sweepFields["tensor_split"] = ts
 }
 
-// tier2 is the ungrouped tier rule: router-restarting parameters first,
-// then request-time sampling parameters, then free-text ones.
-func tier2(f SweepField) int {
-	switch {
-	case f.FreeText:
-		return 2
-	case !f.RestartsRouter:
-		return 1
-	default:
-		return 0
-	}
-}
-
-// SweepFields returns the registry sorted for the job form: three tiers,
-// alphabetical within each, with grouped fields directly beneath their
-// parent.
+// SweepFields returns the registry sorted by label, for rendering the
+// job form.
 func SweepFields() []SweepField {
 	out := make([]SweepField, 0, len(sweepFields))
 	for _, f := range sweepFields {
@@ -292,28 +273,21 @@ func SweepFields() []SweepField {
 	// Free-text parameters sort last because they render as a different
 	// control, and interleaving them looks like a rendering fault rather
 	// than a distinction.
-	// Grouped fields take their parent's tier and sort directly after
-	// it (parent label, then own label), so a group stays together
-	// wherever the parent lands — including a free-text member like
-	// draft_model_path, which would otherwise sink to the bottom away
-	// from its group.
 	tier := func(f SweepField) int {
-		if f.Group != "" {
-			return tier2(sweepFields[f.Group])
+		switch {
+		case f.FreeText:
+			return 2
+		case !f.RestartsRouter:
+			return 1
+		default:
+			return 0
 		}
-		return tier2(f)
-	}
-	key := func(f SweepField) string {
-		if f.Group != "" {
-			return sweepFields[f.Group].Label + "\x00" + f.Label
-		}
-		return f.Label
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if ti, tj := tier(out[i]), tier(out[j]); ti != tj {
 			return ti < tj
 		}
-		return key(out[i]) < key(out[j])
+		return out[i].Label < out[j].Label
 	})
 	return out
 }
@@ -489,13 +463,6 @@ func init() {
 	dmp := sweepFields["draft_model_path"]
 	dmp.FreeText = true
 	sweepFields["draft_model_path"] = dmp
-
-	// The speculative decoding parameters group under the mode selector.
-	for _, name := range []string{"draft_max", "draft_min", "draft_p_min", "ngram_size_n", "ngram_size_m", "draft_model_path"} {
-		f := sweepFields[name]
-		f.Group = "spec_type"
-		sweepFields[name] = f
-	}
 }
 
 // SplitParams turns the unified "parameter → selected values" shape the

--- a/internal/benchmark/sweep.go
+++ b/internal/benchmark/sweep.go
@@ -70,6 +70,11 @@ type SweepField struct {
 	// DynamicChoices names a choice set the API layer fills in at render
 	// time because it depends on the host (e.g. how many GPUs exist).
 	DynamicChoices string
+	// Group names another field this one belongs under. Grouped fields
+	// render indented directly beneath their parent in the job form —
+	// the speculative decoding parameters sit under the mode selector,
+	// where someone choosing a mode will find them.
+	Group string
 
 	set func(o *ConfigOverrides, raw string) error
 }
@@ -260,8 +265,22 @@ func init() {
 	sweepFields["tensor_split"] = ts
 }
 
-// SweepFields returns the registry sorted by label, for rendering the
-// job form.
+// tier2 is the ungrouped tier rule: router-restarting parameters first,
+// then request-time sampling parameters, then free-text ones.
+func tier2(f SweepField) int {
+	switch {
+	case f.FreeText:
+		return 2
+	case !f.RestartsRouter:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// SweepFields returns the registry sorted for the job form: three tiers,
+// alphabetical within each, with grouped fields directly beneath their
+// parent.
 func SweepFields() []SweepField {
 	out := make([]SweepField, 0, len(sweepFields))
 	for _, f := range sweepFields {
@@ -273,21 +292,28 @@ func SweepFields() []SweepField {
 	// Free-text parameters sort last because they render as a different
 	// control, and interleaving them looks like a rendering fault rather
 	// than a distinction.
+	// Grouped fields take their parent's tier and sort directly after
+	// it (parent label, then own label), so a group stays together
+	// wherever the parent lands — including a free-text member like
+	// draft_model_path, which would otherwise sink to the bottom away
+	// from its group.
 	tier := func(f SweepField) int {
-		switch {
-		case f.FreeText:
-			return 2
-		case !f.RestartsRouter:
-			return 1
-		default:
-			return 0
+		if f.Group != "" {
+			return tier2(sweepFields[f.Group])
 		}
+		return tier2(f)
+	}
+	key := func(f SweepField) string {
+		if f.Group != "" {
+			return sweepFields[f.Group].Label + "\x00" + f.Label
+		}
+		return f.Label
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if ti, tj := tier(out[i]), tier(out[j]); ti != tj {
 			return ti < tj
 		}
-		return out[i].Label < out[j].Label
+		return key(out[i]) < key(out[j])
 	})
 	return out
 }
@@ -463,6 +489,13 @@ func init() {
 	dmp := sweepFields["draft_model_path"]
 	dmp.FreeText = true
 	sweepFields["draft_model_path"] = dmp
+
+	// The speculative decoding parameters group under the mode selector.
+	for _, name := range []string{"draft_max", "draft_min", "draft_p_min", "ngram_size_n", "ngram_size_m", "draft_model_path"} {
+		f := sweepFields[name]
+		f.Group = "spec_type"
+		sweepFields[name] = f
+	}
 }
 
 // SplitParams turns the unified "parameter → selected values" shape the

--- a/internal/benchmark/sweep.go
+++ b/internal/benchmark/sweep.go
@@ -207,8 +207,29 @@ var sweepFields = map[string]SweepField{
 		func(o *ConfigOverrides, v *string) { o.GPUAssign = v }),
 	"tensor_split": strField("tensor_split", "Tensor Split", "Proportional split across GPUs, e.g. 1,1.", "1,1|3,1",
 		func(o *ConfigOverrides, v *string) { o.TensorSplit = v }),
-	"spec_type": strField("spec_type", "Speculative Decoding", "Speculative decoding mode.", "none,draft-mtp",
-		func(o *ConfigOverrides, v *string) { o.SpecType = v }),
+	// "none" is a stand-in for the empty value: a blank axis value would
+	// be dropped as "unset", so the registry maps none -> "" here, which
+	// reaches the config as an explicit "speculative decoding off". This
+	// is what lets one job compare a mode against no speculation at all.
+	"spec_type": strField("spec_type", "Speculative Decoding", "Speculative decoding mode. Select none to turn speculative decoding off for that cell.", "none,draft-mtp",
+		func(o *ConfigOverrides, v *string) {
+			if *v == "none" {
+				*v = ""
+			}
+			o.SpecType = v
+		}),
+	"draft_max": intField("draft_max", "Draft Tokens Max", "Maximum tokens drafted per step (--spec-draft-n-max). Applies when a speculative decoding mode is active; 0 leaves llama.cpp's default.", "4,6,8,16",
+		func(o *ConfigOverrides, v *int) { o.DraftMax = v }),
+	"draft_min": intField("draft_min", "Draft Tokens Min", "Minimum tokens drafted per step (--spec-draft-n-min). Applies when a speculative decoding mode is active; 0 leaves llama.cpp's default.", "0,2",
+		func(o *ConfigOverrides, v *int) { o.DraftMin = v }),
+	"draft_p_min": strField("draft_p_min", "Draft Probability Min", "Minimum draft acceptance probability, 0-1 (--spec-draft-p-min). Applies when a speculative decoding mode is active; blank leaves llama.cpp's default.", "0.5,0.75,0.9",
+		func(o *ConfigOverrides, v *string) { o.DraftPMin = v }),
+	"ngram_size_n": intField("ngram_size_n", "N-gram Size N", "N-gram lookup size (--spec-ngram-size-n). Applies to the n-gram speculative modes; 0 leaves llama.cpp's default.", "12,24",
+		func(o *ConfigOverrides, v *int) { o.NgramSizeN = v }),
+	"ngram_size_m": intField("ngram_size_m", "N-gram Size M", "N-gram candidate count (--spec-ngram-size-m). Applies to the n-gram speculative modes; 0 leaves llama.cpp's default.", "48,64",
+		func(o *ConfigOverrides, v *int) { o.NgramSizeM = v }),
+	"draft_model_path": strField("draft_model_path", "Draft Model Path", "Path to the draft model GGUF (--model-draft). Applies to the draft and MTP-with-separate-head modes; blank uses the model's saved setting.", "/data/models/org--repo/draft.gguf",
+		func(o *ConfigOverrides, v *string) { o.DraftModelPath = v }),
 
 	// Sampling params ride along with each request, so sweeping them
 	// costs no router restarts.
@@ -406,16 +427,22 @@ func init() {
 	set("kv_cache_quant", true, choices(
 		"f16", "f16 (no quant)", "q8_0", "q8_0", "q4_0", "q4_0",
 	))
-	// No empty choice: a blank value already means "use the model's saved
-	// setting", so an "off" entry would be dropped as if unset.
+	// "none" (not an empty value, which would be dropped as unset) is the
+	// explicit off entry; the field's set function maps it to "".
 	set("spec_type", false, choices(
+		"none", "Off (no speculative decoding)",
 		"draft", "Draft Model", "draft-mtp", "MTP (self-speculation)",
 		"ngram-simple", "N-gram Simple", "ngram-cache", "N-gram Cache",
 		"ngram-map-k", "N-gram Map-K", "ngram-map-k4v", "N-gram Map-K4V",
 		"ngram-mod", "N-gram Mod",
 	))
 	set("temperature", true, choices("0", "0 (greedy)", "0.7", "0.7", "1.0", "1.0"))
-	set("top_p", true, choices("0.9", "0.9", "0.95", "0.95", "1.0", "1.0"))
+	set("top_p", true, choices("0.9", "0.9", "0.95", "0.95", "1.0", "1.0 (off)"))
+	set("draft_max", true, choices("4", "4", "6", "6 (MTP guidance)", "8", "8", "16", "16"))
+	set("draft_min", true, choices("0", "0 (default)", "2", "2"))
+	set("draft_p_min", true, choices("0.5", "0.5", "0.75", "0.75", "0.9", "0.9"))
+	set("ngram_size_n", true, choices("12", "12", "24", "24"))
+	set("ngram_size_m", true, choices("48", "48", "64", "64"))
 	set("top_k", true, choices("20", "20", "40", "40", "0", "0 (disabled)"))
 	set("min_p", true, choices("0", "0", "0.05", "0.05", "0.1", "0.1"))
 	set("repeat_penalty", true, choices("1.0", "1.0 (off)", "1.05", "1.05", "1.1", "1.1"))
@@ -431,6 +458,11 @@ func init() {
 	ts2 := sweepFields["tensor_split"]
 	ts2.FreeText = true
 	sweepFields["tensor_split"] = ts2
+
+	// A filesystem path is free-form too.
+	dmp := sweepFields["draft_model_path"]
+	dmp.FreeText = true
+	sweepFields["draft_model_path"] = dmp
 }
 
 // SplitParams turns the unified "parameter → selected values" shape the

--- a/internal/models/specparams.go
+++ b/internal/models/specparams.go
@@ -1,0 +1,38 @@
+package models
+
+// SpecModeParam is one tunable parameter of a speculative decoding mode,
+// with the recommended default the model config form applies when the
+// mode is selected. The benchmark job form shows the same parameters
+// with the same defaults under each mode, so the two surfaces cannot
+// disagree about what a mode's settings are.
+type SpecModeParam struct {
+	Key     string // form key: draft_max, draft_min, draft_p_min, ngram_size_n, ngram_size_m
+	Label   string
+	Default string // recommended default as entered in a form field; "" = leave llama.cpp's default
+}
+
+// SpecModeParams returns the tunable parameters for a speculative
+// decoding mode, in display order. An unknown or empty mode has none.
+func SpecModeParams(mode string) []SpecModeParam {
+	draftMax := func(d string) SpecModeParam { return SpecModeParam{"draft_max", "Draft tokens max", d} }
+	draftMin := func(d string) SpecModeParam { return SpecModeParam{"draft_min", "Draft tokens min", d} }
+	pMin := func(d string) SpecModeParam { return SpecModeParam{"draft_p_min", "Draft probability min", d} }
+	ngramN := func(d string) SpecModeParam { return SpecModeParam{"ngram_size_n", "N-gram size N", d} }
+	ngramM := func(d string) SpecModeParam { return SpecModeParam{"ngram_size_m", "N-gram size M", d} }
+
+	switch mode {
+	case "draft":
+		return []SpecModeParam{draftMax("16"), draftMin("0"), pMin("0.75")}
+	case "draft-mtp":
+		// unsloth's MTP guidance uses --spec-draft-n-max 6; p-min is left
+		// at llama.cpp's default — MTP heads have their own acceptance
+		// logic.
+		return []SpecModeParam{draftMax("6"), draftMin("0"), pMin("")}
+	case "ngram-simple", "ngram-cache", "ngram-map-k", "ngram-map-k4v":
+		return []SpecModeParam{draftMax("16"), ngramN("12"), ngramM("48")}
+	case "ngram-mod":
+		return []SpecModeParam{draftMax("64"), draftMin("48"), ngramN("24"), ngramM("48")}
+	default:
+		return nil
+	}
+}

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -396,6 +396,34 @@ function onParamInheritToggle(cb) {
     syncParamRow(row);
 }
 
+// updateSpecValue re-encodes a speculative mode's checkbox value from
+// its settings inputs: "mode:key=value,..." with empty inputs omitted
+// (empty = use the model's saved value), bare "mode" when all are
+// empty. Editing a setting selects the mode, since editing expresses
+// intent to use it.
+function updateSpecValue(input) {
+    var box = input.closest('.spec-params');
+    var row = input.closest('.param-row');
+    if (!box || !row) return;
+    var mode = box.getAttribute('data-mode');
+    var pairs = [];
+    box.querySelectorAll('.spec-param-input').forEach(function (inp) {
+        var v = (inp.value || '').trim();
+        if (v !== '') pairs.push(inp.getAttribute('data-key') + '=' + v);
+    });
+    var cb = Array.from(row.querySelectorAll('.param-value'))
+        .find(function (c) { return c.getAttribute('data-mode') === mode; });
+    if (!cb) return;
+    cb.value = pairs.length ? mode + ':' + pairs.join(',') : mode;
+    if (!cb.checked) {
+        cb.checked = true;
+        onParamValueToggle(cb);
+    } else {
+        syncParamRow(row);
+    }
+    updateMatrixCount();
+}
+
 function onParamValueToggle(cb) {
     var row = cb.closest('.param-row');
     var inherit = row.querySelector('.param-inherit');
@@ -428,6 +456,32 @@ function addParamCustom(el) {
 // booleans) previously dropped any stored value the list didn't cover,
 // silently deleting the setting when the job was edited.
 function addParamValue(row, raw) {
+    // Speculative decoding values restore onto their mode's checkbox and
+    // settings inputs rather than becoming custom entries: the mode is
+    // the text before ":", the settings are key=value pairs after it.
+    var specMode = raw.split(':')[0].trim();
+    var specCb = Array.from(row.querySelectorAll('.param-value'))
+        .find(function (c) { return c.getAttribute('data-mode') === specMode; });
+    if (specCb) {
+        var box = row.querySelector('.spec-params[data-mode="' + specMode + '"]');
+        if (box) {
+            var settings = {};
+            (raw.split(':')[1] || '').split(',').forEach(function (pair) {
+                var kv = pair.split('=');
+                if (kv.length === 2) settings[kv[0].trim()] = kv[1].trim();
+            });
+            box.querySelectorAll('.spec-param-input').forEach(function (inp) {
+                var k = inp.getAttribute('data-key');
+                inp.value = (k in settings) ? settings[k] : '';
+            });
+        }
+        specCb.value = raw;
+        specCb.checked = true;
+        var inh = row.querySelector('.param-inherit');
+        if (inh) inh.checked = false;
+        syncParamRow(row);
+        return;
+    }
     // Reuse an existing checkbox when the value is already offered, so
     // this can't create a duplicate the server would reject.
     var existing = Array.from(row.querySelectorAll('.param-value'))

--- a/web/templates/partials/job_form.html
+++ b/web/templates/partials/job_form.html
@@ -36,6 +36,13 @@
 .param-custom input { margin: 0; font-size: 0.85rem; }
 .param-custom button { margin: 0; width: auto; padding: 0.15rem 0.6rem; font-size: 0.8rem; }
 
+/* Per-mode settings under a speculative decoding choice. */
+.spec-params { margin: 0 0 0.3rem 1.5rem; }
+.spec-params > summary { font-size: 0.8rem; color: var(--pico-muted-color); cursor: pointer; }
+.spec-params .spec-param { display: flex; align-items: center; gap: 0.5rem; margin: 0.15rem 0; }
+.spec-params .spec-param small { min-width: 10rem; color: var(--pico-muted-color); }
+.spec-params .spec-param-input { margin: 0; width: 7rem; font-size: 0.85rem; padding: 0.1rem 0.4rem; height: auto; }
+
 </style>
 
 <form id="new-job-form" data-max-cells="{{.MaxCells}}" onsubmit="event.preventDefault();submitNewJob();">
@@ -120,9 +127,23 @@
                     {{range .Choices}}
                     <label>
                         <input type="checkbox" class="param-value" data-param-value="{{$p.Name}}"
-                               value="{{.Value}}" onchange="onParamValueToggle(this)">
+                               value="{{.Value}}"{{if .Params}} data-mode="{{.Mode}}"{{end}} onchange="onParamValueToggle(this)">
                         {{.Label}}
                     </label>
+                    {{if .Params}}
+                    <details class="spec-params" data-mode="{{.Mode}}">
+                        <summary><small>settings</small></summary>
+                        {{range .Params}}
+                        <label class="spec-param" title="Clear the field to use the model's saved value.">
+                            <small>{{.Label}}</small>
+                            <input type="text" inputmode="decimal" class="spec-param-input"
+                                   data-key="{{.Key}}" value="{{.Default}}"
+                                   placeholder="model's saved value"
+                                   oninput="updateSpecValue(this)">
+                        </label>
+                        {{end}}
+                    </details>
+                    {{end}}
                     {{end}}
                     {{if .AllowCustom}}
                     <div class="param-custom">

--- a/web/templates/partials/job_form.html
+++ b/web/templates/partials/job_form.html
@@ -91,8 +91,7 @@
         </p>
 
         {{range $p := .Params}}
-        <div class="param-row{{if .Group}} param-row-grouped{{end}}" data-param="{{.Name}}" data-sep="{{.Separator}}" data-restarts="{{if .RestartsRouter}}1{{end}}"
-             {{if .Group}}style="margin-left:1.5rem; border-left:2px solid var(--pico-muted-border-color); padding-left:0.75rem;"{{end}}>
+        <div class="param-row" data-param="{{.Name}}" data-sep="{{.Separator}}" data-restarts="{{if .RestartsRouter}}1{{end}}">
             {{if .FreeText}}
             <div class="param-freetext">
                 <div class="param-freetext-head">

--- a/web/templates/partials/job_form.html
+++ b/web/templates/partials/job_form.html
@@ -91,7 +91,8 @@
         </p>
 
         {{range $p := .Params}}
-        <div class="param-row" data-param="{{.Name}}" data-sep="{{.Separator}}" data-restarts="{{if .RestartsRouter}}1{{end}}">
+        <div class="param-row{{if .Group}} param-row-grouped{{end}}" data-param="{{.Name}}" data-sep="{{.Separator}}" data-restarts="{{if .RestartsRouter}}1{{end}}"
+             {{if .Group}}style="margin-left:1.5rem; border-left:2px solid var(--pico-muted-border-color); padding-left:0.75rem;"{{end}}>
             {{if .FreeText}}
             <div class="param-freetext">
                 <div class="param-freetext-head">


### PR DESCRIPTION
## Problem

Two gaps made speculative decoding untestable in a single benchmark job:

1. **No off value.** A blank sweep value means "use the model's saved setting", so the Speculative Decoding parameter deliberately offered no off entry — comparing MTP on vs off required two jobs.
2. **No mode settings.** Selecting a mode gave no control over its parameters (draft token counts, acceptance probability, n-gram sizes); cells ran with whatever the model's saved config happened to hold.

## What changed

**Off as a first-class choice.** The dropdown gains "Off (no speculative decoding)", sent as `none` and mapped to an explicit empty `SpecType` override — one job can now sweep a mode against no speculation, even on a model whose saved config has MTP enabled.

**Per-mode settings under each checkbox.** Every mode carries a collapsed settings section prefilled with the same recommended defaults the model config form applies. Both surfaces read one new shared table (`models.SpecModeParams`) — `applySpecDefaults` was refactored onto it — so they cannot disagree.

- What you see is what submits: an untouched mode runs with the card defaults, exactly like selecting it on the model card. A cleared field means "use the model's saved value". Editing a setting auto-selects its mode.
- Each value is self-contained (`draft-mtp:draft_max=6,draft_min=0`): built server-side from the defaults, re-encoded in the browser on edit, parsed and validated in one place (`parseSpecValue` — unknown modes, keys not valid for a mode, and non-numeric values are rejected with specific messages). Canonicalization makes spacing and parameter order irrelevant to dedup, and editing a saved job restores stored values back onto the checkboxes and inputs.
- The recorded per-cell config (`ConfigSnapshot`) now carries the spec parameters, so results are labeled with what actually ran.

**Audit of the other parameters** found no further instances of either gap class: every boolean has explicit true/false choices, defaults are selectable as explicit values (`top_p`'s 1.0 is now labeled "(off)"), and `draft_model_path` remains the one deliberate carry-through override (the draft mode uses the model's saved path). A coverage assertion in the `KeepUnsweepable` test now accounts for every override field — registry entry, expressible-via-spec_type, or deliberate carry-through — so a future field can't silently become unreachable.

History note: an intermediate design (six standalone parameters grouped under the selector) is committed and reverted within this branch; the final design replaced it after UX review.

## Verified

`go build && go test ./internal/...` green. New tests cover the off mapping (override and axis paths), value parsing/rejection, canonical dedup, parameter flow to the snapshot and launch flags (including off silencing a saved-MTP config), and the coverage guard. Form rendering verified live with a headless-browser screenshot of the expanded sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZPyq4QeaeZKgkSeyHQ6nw