### PR TITLE
fix(monitor): match rocm-smi rows to KFD positions by PCI bus address

### DIFF
--- a/internal/monitor/rocm.go
+++ b/internal/monitor/rocm.go
@@ -42,7 +42,7 @@ func (r *rocmBackend) collectROCmSMI() ([]GPUInfo, error) {
 		return nil, fmt.Errorf("rocm-smi: not found")
 	}
 	out, err := exec.Command(smi,
-		"--showuse", "--showmemuse", "--showtemp", "--showpower",
+		"--showbus", "--showuse", "--showmemuse", "--showtemp", "--showpower",
 		"--csv").Output()
 	if err != nil {
 		return nil, fmt.Errorf("rocm-smi: %w", err)
@@ -60,9 +60,26 @@ func (r *rocmBackend) collectROCmSMI() ([]GPUInfo, error) {
 		colIdx[strings.TrimSpace(h)] = i
 	}
 
+	// rocm-smi's "device" column ("card0", "card1", ...) is NOT a
+	// usable identity: depending on version and machine it is either
+	// the DRM card number (driver probe order, shifted by BMC/iGPU
+	// display devices) or rocm-smi's own row number (sorted by PCI bus
+	// address — the reverse of KFD order on some boards). Interpreting
+	// it produced swapped metrics on one machine and duplicate GPU
+	// indices on another. The PCI bus address is the only unambiguous
+	// key both sides share, so rows are matched to KFD positions by
+	// it; without the column the whole collection is rejected and the
+	// sysfs fallback (consistent by construction) takes over.
+	busCol, ok := colIdx["PCI Bus"]
+	if !ok {
+		return nil, fmt.Errorf("rocm-smi: no PCI Bus column")
+	}
+
 	// KFD-ordered device dirs: position N belongs to the GPU
 	// llama-server addresses as ROCm<N>.
 	dirs := listAMDGPUDirs()
+	byBDF := kfdIndexByBDF(dirs)
+	seen := make(map[int]bool)
 
 	var gpus []GPUInfo
 	for _, line := range lines[1:] {
@@ -72,35 +89,19 @@ func (r *rocmBackend) collectROCmSMI() ([]GPUInfo, error) {
 		}
 
 		gpu := GPUInfo{}
-		if i, ok := colIdx["device"]; ok && i < len(fields) {
-			// rocm-smi reports the device as "card0", "card1", etc.
-			// (or sometimes "GPU 0", "GPU 1"). Plain Atoi silently
-			// fails and leaves Index=0 for every GPU, which made
-			// every GPU show up as GPU0 in the sidebar.
-			s := strings.TrimSpace(fields[i])
-			if num, isCard := strings.CutPrefix(s, "card"); isCard {
-				// "cardN" is the DRM card number, which follows driver
-				// probe order — not the KFD order every other index in
-				// this package (and llama-server's ROCm<N> devices)
-				// uses. Using it directly attributed one card's
-				// utilization to another card's VRAM/name whenever the
-				// two orders disagreed. Map the card to its KFD
-				// position instead; fall back to the raw number only
-				// when the card can't be found.
-				n, _ := strconv.Atoi(num)
-				gpu.Index = n
-				cardDir := fmt.Sprintf("/sys/class/drm/card%d/device", n)
-				if idx := indexOfDevice(dirs, cardDir); idx >= 0 {
-					gpu.Index = idx
-				}
-			} else {
-				// "GPU N" is rocm-smi's logical index, already in KFD
-				// order.
-				s = strings.TrimPrefix(s, "GPU ")
-				s = strings.TrimPrefix(s, "GPU")
-				gpu.Index, _ = strconv.Atoi(s)
-			}
+		if busCol >= len(fields) {
+			return nil, fmt.Errorf("rocm-smi: row without PCI Bus field")
 		}
+		bdf := strings.ToLower(strings.TrimSpace(fields[busCol]))
+		idx, ok := byBDF[bdf]
+		if !ok || seen[idx] {
+			// A device KFD doesn't know, or two rows claiming one
+			// GPU: the mapping is unreliable — let sysfs take over
+			// rather than render wrong numbers.
+			return nil, fmt.Errorf("rocm-smi: device %s not uniquely in KFD topology", bdf)
+		}
+		seen[idx] = true
+		gpu.Index = idx
 		if i, ok := colIdx["GPU use (%)"]; ok && i < len(fields) {
 			gpu.UtilPercent, _ = strconv.Atoi(strings.TrimSpace(fields[i]))
 		}
@@ -128,13 +129,19 @@ func (r *rocmBackend) collectROCmSMI() ([]GPUInfo, error) {
 
 		gpus = append(gpus, gpu)
 	}
+	// Rows arrive in rocm-smi's PCI-address order; present them in
+	// GPU-index order so the sidebar reads ROCm0, ROCm1, ...
+	sort.Slice(gpus, func(i, j int) bool { return gpus[i].Index < gpus[j].Index })
 	return gpus, nil
 }
 
 // listAMDGPUDirs returns the sysfs device directories of AMD GPUs in
-// KFD topology order — the order rocminfo, rocm-smi, and llama-server's
-// HIP runtime all enumerate in. Shared by collectSysfs and readVRAMSysfs
-// so the enumeration lives in one place.
+// KFD topology order — the order rocminfo and llama-server's HIP
+// runtime enumerate in. (rocm-smi does NOT share it: its rows are
+// sorted by PCI bus address, which is why collectROCmSMI matches rows
+// by that address instead of by position or label.) Shared by
+// collectSysfs and collectROCmSMI so the enumeration lives in one
+// place.
 //
 // DRM card numbers follow driver probe order instead, which on desktop
 // APU boxes puts the iGPU at card0 while KFD lists the discrete GPU
@@ -249,22 +256,21 @@ func (r *rocmBackend) collectSysfs() ([]GPUInfo, error) {
 	return gpus, nil
 }
 
-// indexOfDevice returns the position of deviceDir in dirs, or -1 when
-// absent. Paths are compared after resolving symlinks: a GPU's
-// /sys/class/drm/cardN/device and /sys/class/drm/renderDM/device both
-// link to the same PCI device directory, which is what makes a DRM card
-// findable in the KFD-ordered render-node list.
-func indexOfDevice(dirs []string, deviceDir string) int {
-	target, err := filepath.EvalSymlinks(deviceDir)
-	if err != nil {
-		return -1
-	}
+// kfdIndexByBDF maps each device's PCI bus address (lowercase, e.g.
+// "0000:c7:00.0") to its position in the KFD-ordered dir list. The
+// address is the final component of the resolved sysfs device path,
+// and it is the same string rocm-smi's "PCI Bus" column reports —
+// the one identity shared by both enumerations.
+func kfdIndexByBDF(dirs []string) map[string]int {
+	m := make(map[string]int, len(dirs))
 	for i, d := range dirs {
-		if resolved, err := filepath.EvalSymlinks(d); err == nil && resolved == target {
-			return i
+		resolved, err := filepath.EvalSymlinks(d)
+		if err != nil {
+			continue
 		}
+		m[strings.ToLower(filepath.Base(resolved))] = i
 	}
-	return -1
+	return m
 }
 
 // readVRAMFromDir reads /sys/class/drm/card*/device/mem_info_vram_* from an

--- a/internal/monitor/rocm_test.go
+++ b/internal/monitor/rocm_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -115,42 +116,44 @@ Agent 1
 	}
 }
 
-// TestIndexOfDevice guards the rocm-smi index mapping: DRM card numbers
-// follow driver probe order while the monitor's device list follows KFD
-// order, and rocm-smi's "cardN" labels must be resolved to KFD positions
-// or one card's utilization gets paired with another card's VRAM and
-// name. A card and a render node of the same GPU are symlinks to one
-// PCI device directory; indexOfDevice matches them by resolved path.
-func TestIndexOfDevice(t *testing.T) {
+// TestKFDIndexByBDF guards the rocm-smi row mapping: rocm-smi orders
+// its rows by PCI bus address while KFD topology (the order behind
+// llama-server's ROCm<N> device names) can run the other way entirely
+// — on a real quad-GPU board KFD listed c7, 83, 43, 03 while rocm-smi
+// listed 03, 43, 83, c7. The PCI address is the only identity both
+// share, so rows must resolve to KFD positions through it; matching by
+// row position or by rocm-smi's "cardN" label paired one card's
+// utilization with another card's VRAM (and produced duplicate GPU
+// indices when a BMC display device shifted the DRM card numbering).
+func TestKFDIndexByBDF(t *testing.T) {
 	tmp := t.TempDir()
-	// Two PCI device directories.
-	pciA := filepath.Join(tmp, "pci0000:03:00.0")
-	pciB := filepath.Join(tmp, "pci0000:83:00.0")
-	for _, d := range []string{pciA, pciB} {
-		if err := os.Mkdir(d, 0o755); err != nil {
+	// PCI device directories named by bus address, as sysfs does.
+	bdfs := []string{"0000:c7:00.0", "0000:83:00.0", "0000:43:00.0", "0000:03:00.0"}
+	var kfdDirs []string
+	for i, bdf := range bdfs {
+		target := filepath.Join(tmp, bdf)
+		if err := os.Mkdir(target, 0o755); err != nil {
 			t.Fatal(err)
 		}
-	}
-	// KFD order lists B first; DRM probe order made A card0 and B card1.
-	link := func(name, target string) string {
-		p := filepath.Join(tmp, name)
-		if err := os.Symlink(target, p); err != nil {
+		link := filepath.Join(tmp, "renderD"+strconv.Itoa(128+i))
+		if err := os.Symlink(target, link); err != nil {
 			t.Fatal(err)
 		}
-		return p
+		kfdDirs = append(kfdDirs, link)
 	}
-	kfdDirs := []string{link("renderD128", pciB), link("renderD129", pciA)}
-	card0 := link("card0-device", pciA)
-	card1 := link("card1-device", pciB)
 
-	if got := indexOfDevice(kfdDirs, card0); got != 1 {
-		t.Errorf("indexOfDevice(card0) = %d; want 1", got)
+	m := kfdIndexByBDF(kfdDirs)
+	if len(m) != 4 {
+		t.Fatalf("kfdIndexByBDF returned %d entries; want 4", len(m))
 	}
-	if got := indexOfDevice(kfdDirs, card1); got != 0 {
-		t.Errorf("indexOfDevice(card1) = %d; want 0", got)
+	// rocm-smi reports addresses uppercase; the map is keyed lowercase.
+	for want, bdf := range bdfs {
+		if got, ok := m[bdf]; !ok || got != want {
+			t.Errorf("m[%q] = %d, %v; want %d, true", bdf, got, ok, want)
+		}
 	}
-	if got := indexOfDevice(kfdDirs, filepath.Join(tmp, "missing")); got != -1 {
-		t.Errorf("indexOfDevice(missing) = %d; want -1", got)
+	if _, ok := m["0000:c9:00.0"]; ok {
+		t.Error("BMC-style device not in KFD list must be absent from the map")
 	}
 }
 


### PR DESCRIPTION
Follow-up to #119, which was merged (and released as 2.18.1) with only the first attempt — the DRM-card-number mapping. Diagnostics from the quad-GPU server show that attempt is wrong there and produces duplicate GPU0 sidebar entries; this PR contains the actual fix, written against the real topology.

## What the diagnostics showed

rocm-smi's `cardN` device labels are ambiguous. On the quad-GPU server, rocm-smi numbers its rows by PCI bus address (03 → 43 → 83 → c7), which is the *reverse* of KFD/HIP order (c7 → 83 → 43 → 03 — what llama-server's `ROCm<N>` names mean), and DRM card numbering is shifted by the BMC's VGA device at `card0`. Interpreting the label as a DRM card number made "card0" resolve to the BMC, fail the KFD lookup, and fall back to a colliding raw index — two GPU0 rows.

## Fix

Stop interpreting the label. Ask rocm-smi for the PCI bus address (`--showbus`) and match each row to its KFD position through the resolved sysfs device path — the one identity both enumerations share, unambiguous on any topology. If the column is missing, a row maps to no KFD device, or two rows claim one GPU, the rocm-smi collection is rejected and the pure-sysfs fallback (consistent by construction) takes over instead of rendering wrong numbers. Rows are sorted by GPU index so the sidebar lists ROCm0..N in order.

## Testing

- `TestKFDIndexByBDF` models the real quad-GPU topology (reversed orders, BMC device absent from KFD) with a fake sysfs symlink tree.
- `go build ./... && go vet ./internal/monitor/ && go test ./internal/...` pass.
- Live check on the quad-GPU server pending: four distinct GPU rows, compute + VRAM together on rows 0/1 for a model on `ROCm0,ROCm1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZPyq4QeaeZKgkSeyHQ6nw