### PR TITLE
docs(plan): capability benchmarks implementation plan

### DIFF
--- a/plan/capability-benchmarks/overview.md
+++ b/plan/capability-benchmarks/overview.md
@@ -1,0 +1,166 @@
+# Capability Benchmarks — Project Overview
+
+## Problem
+
+The benchmark tab measures only speed. Nothing in the toolchest can answer
+the questions its own features raise: how much quality does Q4_K_M give up
+against UD-Q8_K_XL, does a quantized KV cache hurt reasoning, does a build
+or flag change alter model output quality at all. Users step outside the
+tool (or guess) for exactly the comparisons the tool's matrix machinery is
+built to run.
+
+llama.cpp already ships the measurement tool: `llama-perplexity`, compiled
+by every build the toolchest makes (ninja builds all targets; the install
+step just doesn't copy it). It implements perplexity, KL-divergence against
+a reference model's logits, HellaSwag, Winogrande, and an MMLU-style
+multiple-choice mode — with HellaSwag preprocessing deliberately matched to
+EleutherAI's lm-evaluation-harness so scores are comparable to published
+numbers.
+
+## Goals
+
+- Four evaluation modes in v1, as **capability presets** in the existing
+  job matrix next to the performance presets: perplexity (wikitext-2),
+  KL-divergence (vs a reference quant), HellaSwag, and Winogrande. One job
+  can mix performance and capability presets — sweep KV cache quant and get
+  tokens/sec and HellaSwag accuracy per cell from the same job.
+- Two presets per mode: a **quick** variant sized for sweeps (HellaSwag
+  400 tasks, Winogrande 400 tasks, perplexity over a bounded chunk count —
+  the sizes llama.cpp's own documentation quotes for comparisons) and a
+  **full** variant for publishable numbers, each with a duration hint in
+  its label matching the existing preset naming style.
+- KL-divergence reference logits: a KL cell names its reference model,
+  defaulting to the largest installed quant of the same HF repo. A missing
+  logits file is generated as its own visible job step, then cached in the
+  data dir keyed by (reference model identity, dataset, chunk count,
+  context size) for reuse across jobs. The multi-GB files get a disk-space guard before generation and a
+  delete control in the UI.
+- Datasets (a few MB total) download on first use from pinned URLs with
+  SHA-256 verification, cached in the data dir — the HF tokenizer-cache
+  pattern. Every dataset is redistributable (wikitext-2: CC BY-SA;
+  HellaSwag: MIT; Winogrande: Apache-2.0) and its license is named in the
+  help page.
+- `llama-perplexity` joins `llama-server` in the build install step. Builds
+  made before this change lack the binary; a capability cell on such a
+  build fails with a message naming the fix (rebuild), never a silent skip.
+- Scores land on `BenchmarkRun` as optional fields (perplexity ± error,
+  KL-divergence statistics, task accuracy with confidence bounds, tasks
+  run), render in
+  the results/compare tables alongside the timing columns, and ride the
+  existing export.
+- Config fidelity: capability cells map the applicable subset of the
+  model's `ModelConfig` (and job overrides) onto `llama-perplexity` flags —
+  GPU layers, GPU placement/device, flash attention, KV cache quant,
+  batch/ubatch, threads — so a swept parameter measurably reaches the
+  evaluation. The recorded config snapshot tells the truth about what ran.
+
+## Non-goals
+
+- No MMLU-style multiple-choice mode in v1 — its dataset uses llama.cpp's
+  own binary format with no clean public source; it can follow once the
+  dataset story is settled.
+- No generative (through-the-router) benchmarks — GSM8K/IFEval are a later
+  tier with different machinery.
+- No external harness integration (lm-evaluation-harness, simple-evals)
+  beyond help-page documentation; no judge models; no execution of
+  model-generated code.
+- No custom or user-supplied datasets in v1; the pinned three
+  (wikitext-2, HellaSwag, Winogrande — wikitext-2 serves both
+  perplexity and KL-divergence) are the offering.
+- Sampling parameters (temperature, top-p, …) are not applied to
+  capability cells — the evaluations are deterministic log-likelihood
+  scoring where sampling has no role. A job may still sweep them for its
+  performance presets; capability cells record the load-time config only.
+
+## Users & primary flow
+
+Self-hosters comparing quants, builds, and settings on their own hardware.
+
+Creating a job: Benchmarks → New Job → pick models (e.g. every installed
+quant of one repo), a build, and presets — checking, say,
+"hellaswag-quick" and "perplexity-quick" alongside "internal-standard".
+For KL presets, a reference-model selector appears, prefilled with the
+largest installed quant of each selected model's repo. The matrix count
+and duration hints update as usual.
+
+Running: capability cells load the model directly with `llama-perplexity`,
+so the job runner stops the inference server for their duration (the
+existing router-ownership machinery) and restores it afterward, exactly as
+it already does around config changes. A KL cell missing its cached
+reference logits generates them first as a distinct progress step.
+
+Reading results: each cell row shows its scores — perplexity with its
+error bound, HellaSwag/Winogrande accuracy with confidence interval and
+task count, KL-divergence mean and top-token agreement — next to the
+timing columns of performance cells from the same job. Compare and export
+include the new columns.
+
+## Constraints
+
+- Go backend; the evaluation binary is invoked as a subprocess and its
+  combined stdout+stderr is parsed (llama-perplexity prints final scores
+  in stable, greppable lines, split across the two streams by its
+  logger); no Python anywhere.
+- All evaluations run at a fixed context size of 512 tokens — required
+  by `llama-perplexity`, score-determining (it is the perplexity chunk
+  size), and the value llama.cpp's published wikitext figures use, so
+  scores stay comparable.
+- Capability cells cannot run through the router: `llama-perplexity` loads
+  the model itself. The inference server is therefore offline while a
+  capability cell runs — the job queue already owns the router during jobs
+  (`routerBusyWithJob` guards), and cleanup already restores it.
+- VRAM exclusivity extends to the KL logits generation step, which loads
+  the (large) reference model.
+- The flag mapping is a subset: parameters meaningless to the evaluation
+  (parallel slots, context-shift, sampling, speculative decoding) are
+  excluded by listing, not silently dropped — the mapping function is the
+  single source shared by execution and the recorded snapshot.
+- Old builds lack `llama-perplexity`; detection is by file existence at
+  cell start with an actionable error.
+- Dataset downloads use plain `net/http` — these are small static files
+  with pinned URLs, not HF-API objects, so the HF client's auth/resume
+  machinery isn't needed; SHA-256 pins live next to the URLs in one
+  table.
+- Logits cache location: under the data dir with the other caches;
+  size shown and deletable from the UI (the disk-space guard reuses
+  `AvailableForDownload`'s pattern).
+- Score fields are additive on `BenchmarkRun` (older records simply lack
+  them — same pattern as every schema addition in this codebase).
+
+## Success criteria
+
+- A single job over four quants of one repo with "perplexity-quick" +
+  "hellaswag-quick" produces a table where quality degradation across
+  quants is visible per cell, exported with the same columns.
+- A KL-divergence job on a Q4 quant with a Q8 reference: first run
+  generates and caches the logits file (visible as its own step), second
+  run reuses the cache and completes in a fraction of the time.
+- A job mixing "internal-standard" with capability presets yields both
+  t/s and accuracy per cell; the inference server is back up when the job
+  ends, including on failure and cancel paths.
+- Sweeping kv_cache_quant f16 vs q4_0 with "hellaswag-quick" shows the
+  accuracy difference (or its absence) — the swept flag provably reaches
+  `llama-perplexity`, verified by the recorded snapshot and a test
+  asserting the flag mapping.
+- A capability cell on a pre-existing build without `llama-perplexity`
+  fails with a message that names rebuilding as the fix.
+- Datasets download once, verify against pinned hashes, and are reused;
+  a corrupted download is rejected with a clear error.
+- `go build ./... && go test ./internal/...` passes; help page documents
+  the modes, datasets, licenses, and the server-offline behavior.
+
+## Decisions
+
+- **Mode scope** → Perplexity, KL-divergence, HellaSwag, Winogrande in v1;
+  MMLU-style multiple-choice deferred until its dataset story is cleaner.
+- **Job shape** → Capability presets in the same job matrix as performance
+  presets; one job can mix both; cells/retry/compare/export machinery
+  reused.
+- **KL reference logits** → Generated on demand as a visible job step,
+  cached keyed by (reference model, dataset, chunk count, context
+  size), user-selectable reference defaulting to the largest installed
+  quant of the same repo; disk-space guard and delete control.
+- **Datasets** → Download on first use from pinned URLs with SHA-256
+  verification, cached in the data dir.
+- **Run sizes** → Quick + full preset per mode, with duration hints in the
+  labels.

--- a/plan/capability-benchmarks/phase-01-eval-engine.md
+++ b/plan/capability-benchmarks/phase-01-eval-engine.md
@@ -1,0 +1,203 @@
+# Phase 01 — Evaluation engine and binary install
+
+**Depends on:** nothing · **Enables:** dataset plumbing (02) feeds it paths;
+the job runner (03) invokes it.
+
+## Goal
+
+The core that runs `llama-perplexity` and understands its output: a new
+`internal/evaluate` package with the mode definitions, the
+ConfigSnapshot→CLI flag mapping, subprocess execution, and stdout parsing
+into typed scores — plus the one-line builder change that installs
+`llama-perplexity` next to `llama-server`. After this phase the engine is
+fully unit-tested against canned outputs; nothing invokes it yet.
+
+## Files touched
+
+- `internal/builder/builder.go` — the install step (currently copies only
+  `llama-server`, `builder.go:511`) also copies `llama-perplexity` from
+  the same candidate locations (`bin/llama-perplexity`); missing binary is
+  NOT a build failure (old refs, exotic layouts) — capability cells detect
+  absence at run time.
+- `internal/evaluate/evaluate.go` (new) — modes, spec, flag mapping,
+  execution.
+- `internal/models/gpu_assign.go` — exported `GPUPlacementFlags` wrapper
+  around the unexported `gpuPlacementParams` (step 2); the preset
+  emitter's behavior is unchanged.
+- `internal/evaluate/parse.go` (new) — stdout parsers per mode.
+- `internal/evaluate/evaluate_test.go`, `parse_test.go` (new).
+- `internal/benchmark/benchmark.go` — `EvalScores` struct and the additive
+  `Eval *EvalScores` field on `BenchmarkRun` (defined here because
+  `internal/evaluate` must not import `internal/benchmark`; evaluate
+  returns its own result type, the runner copies it over in phase 03).
+
+## Steps
+
+1. Mode registry in `internal/evaluate`:
+   ```go
+   type Mode string
+   const (
+       ModePerplexity Mode = "perplexity"
+       ModeKLDiv      Mode = "kl-divergence"
+       ModeHellaSwag  Mode = "hellaswag"
+       ModeWinogrande Mode = "winogrande"
+   )
+   type Spec struct {
+       Binary    string // path to llama-perplexity
+       ModelPath string
+       Mode      Mode
+       DatasetPath string
+       Tasks     int    // hellaswag/winogrande task cap; 0 = full
+       Chunks    int    // perplexity/KL chunk cap; 0 = full
+       KLBasePath string // ModeKLDiv: read base; KL base GENERATION uses GenerateKLBase
+       Flags     []string // pre-mapped model/config flags (step 2)
+   }
+   ```
+2. Flag mapping — `MapConfigFlags(snap SnapshotSubset) []string`, the
+   single allow-list shared by execution and the recorded snapshot. To
+   avoid an import cycle it takes a small struct of plain fields.
+   Mapped from those fields: `--n-gpu-layers`, `--threads`,
+   `--batch-size`, `--ubatch-size`, `--flash-attn on|off`,
+   `--cache-type-k/-v` (KV quant), `--direct-io` (accepted by the tool,
+   `common/arg.cpp:2656`; mapping it keeps the excluded list a complete
+   statement — every `ConfigSnapshot` field is either mapped or listed).
+   GPU placement (`--split-mode`, `--main-gpu`, `--device`, trimmed
+   `--tensor-split`) is NOT derivable from the snapshot — it carries
+   neither `SplitMode` nor `MainGPU` (`benchmark.go:95-113`), and a
+   swept `gpu_assign` value only becomes a tensor-split through the
+   merge-and-resolve the performance path already does (the standalone
+   package-level functions `applySnapshotToConfig`,
+   `internal/api/jobs_env.go:283-313`, and `resolveGPUAssignment`,
+   `jobs_env.go:324-342` — directly callable, no extraction needed).
+   The api side therefore owns the WHOLE flag construction: phase 03
+   adds a `JobEnv` method `EvalFlags(modelID string, snap
+   ConfigSnapshot, buildID string) ([]string, error)` whose
+   implementation merges the snapshot onto the saved `ModelConfig`,
+   runs `resolveGPUAssignment`, fills `SnapshotSubset` (plain fields +
+   `PlacementFlags []string`), and calls `evaluate.MapConfigFlags` —
+   which remains the single allow-list deciding what reaches the
+   command line. The cell loop puts the returned flags into
+   `Spec.Flags`; `Spec` itself stays engine-shaped (no model ID, no
+   snapshot). `PlacementFlags` come from a new exported wrapper in
+   `internal/models`: `GPUPlacementFlags(c *ModelConfig, backend
+   string) []string` — a thin wrapper over the unexported
+   `gpuPlacementParams` (`internal/models/gpu_assign.go:286`) that
+   formats its `specParam` pairs as `--name value` strings. The preset
+   emitter and llama-server arg builder keep calling the unexported
+   function with their own formatting (INI vs CLI); one implementation,
+   the wrapper is just the exported CLI-formatted view.
+   Excluded by listing, with a comment naming each: model-config
+   context size (replaced by the fixed evaluation context, step 3),
+   parallel slots, speculative decoding, sampling, mmproj,
+   context-shift.
+   Context size: the ctx value IS the perplexity chunk size
+   (`n_chunk_max = tokens/n_ctx`, `perplexity.cpp:493`), so it
+   determines the score. The tool's own default happens to be 512
+   (`perplexity.cpp:2015`; an explicit non-positive value is rejected,
+   `perplexity.cpp:2024-2030`), but the engine never relies on an
+   upstream default: it always passes a package constant
+   `EvalContextSize = 512` — the value llama.cpp's own wikitext-2
+   perplexity figures are quoted at — never the model's configured
+   context. The constant is part of every invocation in step 3 and
+   part of the KL cache key (phase 02).
+3. Command assembly per mode (documented against
+   `tools/perplexity/perplexity.cpp` in the checkout). Every invocation
+   carries `--ctx-size 512` (`EvalContextSize`, step 2) — required by
+   the tool and score-determining:
+   - perplexity: `-c 512 -f <wikitext> [--chunks N]`
+   - hellaswag: `-c 512 --hellaswag -f <hellaswag_val> [--hellaswag-tasks N]`
+   - winogrande: `-c 512 --winogrande -f <winogrande.csv> [--winogrande-tasks N]`
+   - kl-divergence: `-c 512 --kl-divergence --kl-divergence-base <base.kld> -f <wikitext>`
+     — no `--chunks` here: the comparison's chunk count comes solely
+     from the base file (`params.n_chunks` is read only by the
+     perplexity functions, `perplexity.cpp:344,495`), so the flag would
+     be inert. The base file embeds its n_ctx, and the tool does NOT
+     reliably guard a mismatch (`perplexity.cpp:1717-1722` logs
+     without returning; a smaller embedded n_ctx passes silently and
+     wins) — the phase 02 cache key carrying ctx and chunks is the
+     ONLY thing keeping base and comparison consistent, which is why
+     both are in the key.
+   - KL base generation: `GenerateKLBase(spec)` runs
+     `-c 512 --kl-divergence-base <out.kld> -f <wikitext> [--chunks N]`
+     (no `--kl-divergence` flag → the tool writes the base file,
+     `perplexity.cpp:461-470`). Same execution model as `Run` (combined
+     buffer, parsed after exit) — NO live output parsing: the per-chunk
+     generation output is newline-less comma fragments
+     (`perplexity.cpp:633`), so live progress cannot come from the
+     stream. Progress during generation is the CALLER's job by polling
+     the growing output file's size against the phase 02 estimate
+     (phase 03 step 2); the engine only runs the process.
+4. Execution: `Run(ctx, Spec) (Result, error)` — `exec.CommandContext`
+   with the environment treated the way the codebase already launches
+   build binaries: prepend the binary's directory to `LD_LIBRARY_PATH`
+   so co-located `libllama.so`/`libggml*.so` resolve (mirroring
+   `internal/api/jobs_env.go:72-87` and `process.Manager`; without it
+   every eval fails to start). Stdout and stderr are captured into ONE
+   combined buffer that is both the parse input and the error-tail
+   source (bounded, last 64KB kept): llama.cpp's logger routes plain
+   `LOG` lines to stdout but `LOG_INF` to stderr (`common/log.cpp:89-92`),
+   and the final Perplexity and Winogrande score lines are `LOG_INF` —
+   a stdout-only parser would miss two of the four modes. Context
+   cancellation kills the process. A nonzero exit returns the tail of
+   the combined output in the error.
+5. Parsers (`parse.go`), one per mode, anchored to the source's exact
+   format strings (all parse the combined output of step 4):
+   - `Final estimate: PPL = <f> +/- <f>` (`perplexity.cpp:654`, stderr)
+     → Perplexity, PerplexityErr.
+   - `Final Winogrande score(<n> tasks): <f> +/- <f>`
+     (`perplexity.cpp:1300`, stderr) → Accuracy plus a symmetric error
+     mapped into AccuracyCILow/High (acc−err, acc+err), Tasks.
+   - HellaSwag prints one line per task
+     (`perplexity.cpp:1006`, stdout):
+     `%zu\t%3.8lf%%\t[%3.4lf%%, %3.4lf%%]` — task number, cumulative
+     accuracy percent, and an ASYMMETRIC 95% confidence interval in
+     brackets. The last such line is the score: Accuracy from column 2,
+     AccuracyCILow/High from the bracketed bounds, Tasks from column 1.
+     The parser test encodes a captured real output block.
+   - KL block (stdout): `Mean    KLD: <f> ± <f>`, `Maximum KLD: <f>`,
+     `99.9%   KLD: <f>`, and `Same top p: <f> ± <f> %`
+     (`perplexity.cpp:2005`) — parse Mean±err, Max, P99.9, SameTopPct±err
+     (exact labels pinned from source lines 1949-2005).
+   - Every parser returns a typed error naming the missing line when
+     output doesn't match, so a llama.cpp format change fails loudly.
+6. `Result` struct mirrors `benchmark.EvalScores` fields: mode, dataset
+   name, evaluation context size, requested chunk cap (perplexity/KL —
+   copied from `Spec.Chunks`, 0 = full; the final-score lines carry no
+   actual chunk count and the plan does not invent one), perplexity±,
+   accuracy with CI bounds (`accuracy`, `accuracy_ci_low`,
+   `accuracy_ci_high` — asymmetric for HellaSwag, symmetric-derived for
+   Winogrande), tasks (parsed, actual), KL stats including
+   same-top-token percentage, reference identity (filled by the
+   runner). `EvalScores` in
+   `internal/benchmark/benchmark.go` carries json tags (`eval` on the
+   run, snake_case fields), additive and omitempty like every schema
+   addition.
+
+## Build gate
+
+`go build ./... && go vet ./internal/... && go test ./internal/...`
+
+## Test plan
+
+- Parser tests with canned output blocks (captured from a real
+  `llama-perplexity` run during implementation) for all four modes, plus
+  mismatch cases asserting the named-line errors.
+- Flag mapping tests: KV quant reaches `--cache-type-k/-v`, GPU subset
+  emits the device list, excluded params provably absent.
+- Execution test with a fake binary (shell script echoing a canned block)
+  covering success, nonzero exit with tail-of-output error, and context
+  cancellation.
+- Builder: extend `profiles_test.go`-style coverage asserting the install
+  candidate list includes `llama-perplexity` (unit level; a real build is
+  manual).
+- Manual: rebuild the vulkan build on the dev box; confirm
+  `llama-perplexity` lands in the build output dir.
+
+## Commit
+
+`feat(evaluate): llama-perplexity evaluation engine and binary install`
+
+## Rollback
+
+Delete `internal/evaluate/`, revert the two-line install addition and the
+additive `EvalScores` field. No stored data or behavior touched.

--- a/plan/capability-benchmarks/phase-02-datasets.md
+++ b/plan/capability-benchmarks/phase-02-datasets.md
@@ -1,0 +1,143 @@
+# Phase 02 — Dataset download, verification, and the logits cache store
+
+**Depends on:** 01 (the engine defines the modes datasets serve) ·
+**Enables:** the runner (03) calls `EnsureDataset`/logits-cache functions;
+the UI (04) lists and deletes what this phase stores.
+
+## Goal
+
+Every file an evaluation needs, obtained and managed: the three pinned
+datasets downloaded on first use with SHA-256 verification, and the KL
+reference logits cache with its naming scheme, disk-space guard, and
+deletion. All filesystem layout decisions land here.
+
+## Files touched
+
+- `internal/evaluate/datasets.go` (new) — pinned dataset table,
+  `EnsureDataset`, cache paths.
+- `internal/models` GGUF metadata parse — additive `VocabSize` field
+  (step 4's estimate needs it and nothing in the codebase records it
+  today).
+- `cmd/llama-toolchest/main.go` — the one-line `CleanStalePartials`
+  call at startup (step 4).
+- `internal/evaluate/klcache.go` (new) — logits cache key/paths, listing,
+  delete, disk guard.
+- `internal/evaluate/datasets_test.go`, `klcache_test.go` (new).
+
+## Steps
+
+1. Layout under the data dir (constant root passed in by callers —
+   `<dataDir>/eval-data/`):
+   ```
+   eval-data/
+   ├── datasets/wikitext-2-raw-test.txt
+   ├── datasets/hellaswag_val_full.txt
+   ├── datasets/winogrande-debiased-eval.csv
+   └── logits/<SafeModelID>~<quant>~<dataset>~c<chunks>~ctx<n>.kld
+   ```
+   (`SafeModelID` lives in `internal/huggingface/names.go:9`;
+   `internal/evaluate` importing `internal/huggingface` is cycle-free —
+   huggingface imports neither benchmark nor evaluate. The field
+   separator is `~`, NOT `--`: `SafeModelID` maps `/` to `--`, so a
+   `--` separator would make reverse-parsing the filename ambiguous;
+   `~` is filesystem-safe and appears in neither `SafeModelID` output
+   nor quant names, keeping the key→filename→key round trip lossless.)
+2. Pinned dataset table — one struct per dataset: name, download URL,
+   SHA-256, license string, approximate size. Sources (implementer
+   verifies URLs and pins the hashes at implementation time by
+   downloading and hashing once):
+   - wikitext-2 raw test set (CC BY-SA 3.0) — the file llama.cpp's own
+     perplexity documentation uses.
+   - `hellaswag_val_full.txt` (MIT) — the preprocessed file the
+     `--hellaswag` mode consumes (the format `perplexity.cpp` parses; the
+     llama.cpp wiki names its canonical HF source).
+   - Winogrande debiased eval CSV (Apache-2.0) — the format
+     `load_winogrande_from_csv` parses.
+3. `EnsureDataset(ctx, root, name) (path, error)`: present + hash
+   matches → return; absent → download to a temp file (plain
+   `net/http` — these are static files, not HF-API objects; the HF
+   client's auth/resume machinery isn't needed), verify SHA-256, rename
+   into place. Hash mismatch → delete temp, return an error naming
+   expected vs got. No re-verification on every call (hash once at
+   download; a `Verify(root)` helper exists for the UI's state display).
+4. Logits cache (`klcache.go`):
+   - `KLBaseKey{ModelID, Quant, Dataset string, Chunks, Ctx int}` →
+     deterministic filename as in step 1. Chunks is in the key because
+     a base generated at 100 chunks cannot serve a full-run comparison
+     (quick and full cache separately). Ctx is in the key because the
+     base file embeds its n_ctx and the embedded value silently wins in
+     the comparison — `llama-perplexity` only logs on a mismatch, it
+     does not reject (`perplexity.cpp:1717-1722`), so this key is the
+     ONLY consistency guard. Today ctx is always
+     `evaluate.EvalContextSize` (512); keying it means a future
+     constant change invalidates cleanly instead of mis-serving.
+   - `KLBasePath(root, key)`, `ListKLBases(root) []KLBaseInfo` (key
+     parsed back from filename + size + mtime), `DeleteKLBase`,
+     `HasKLBase`.
+   - Interruption safety — same temp-then-rename discipline as the
+     datasets, because the stakes are higher, not lower: generation
+     writes a valid-looking header FIRST (magic + n_ctx,
+     `perplexity.cpp:465-470`, then n_vocab/n_chunk/tokens at
+     `:523-525`) and streams log-probs for minutes to hours, so a
+     killed or canceled generation leaves a truncated file whose
+     header claims the full chunk count; the comparison reader then
+     fails mid-loop with an unrelated-looking error, and a
+     presence-keyed cache would serve that corpse forever. Rule:
+     generation writes to `<final-name>.partial`; `HasKLBase` and
+     `ListKLBases` ignore `.partial` files; clean exit renames into
+     place; failure/cancel deletes the partial. Stale partials (a
+     crash skipped the delete) are removed by
+     `CleanStalePartials(root)` in `klcache.go`, called once at
+     process startup from `cmd/llama-toolchest/main.go` next to the
+     existing startup directory creation (`main.go:99`). Phase 02
+     test: `HasKLBase`/`ListKLBases` ignore a `.partial` file and
+     `CleanStalePartials` removes it. (That an interrupted generation
+     leaves no cache entry and a later `EnsureKLBase` regenerates is
+     phase 03's test.)
+   - Disk guard: `CheckKLBaseSpace(root, estimate)` — from the tool's
+     own math (writer at `perplexity.cpp:461-470`, `:523-525`, `:619`;
+     per-token layout confirmed on the reader side at `:1752-1760`):
+     per chunk the tool stores
+     `n_ctx − 1 − n_ctx/2` evaluated tokens, each carrying
+     `2×((n_vocab+1)/2) + 4` uint16 values, so
+     `estimate = chunks × (n_ctx − 1 − n_ctx/2) × (2×((n_vocab+1)/2) + 4) × 2 bytes`
+     with a 1.15 safety factor for headers/rounding. Cross-check the
+     formula at implementation against the perplexity README's own
+     scale figures (≈11 GiB for a full LLaMA-2 wikitext base, ≈37 GiB
+     for LLaMA-3 — vocab-size driven).
+     `n_vocab` source: the codebase records no vocab size anywhere, so
+     the GGUF metadata parse in `internal/models` gains an additive
+     `VocabSize` field read from the `tokenizer.ggml.tokens` array
+     LENGTH in the header (array lengths sit in the header; the
+     contents are not read). Models registered before the field exists
+     fall back to a documented worst-case constant of 262144 (covers
+     current large vocabularies, e.g. Qwen's ~248K) — a conservative
+     overestimate that can only refuse early, never under-reserve.
+     Callers refuse generation when
+     free space minus the 2 GiB safety margin (same constant the
+     downloader uses, `internal/huggingface/disk.go:9`) is
+     insufficient, with an error naming the estimate.
+5. License strings live in the dataset table and render in phase 04's UI
+   and help; the table is the single source.
+
+## Build gate
+
+`go build ./... && go vet ./internal/... && go test ./internal/...`
+
+## Test plan
+
+- `EnsureDataset` against `httptest.Server`: fresh download + hash verify
+  + rename; cached short-circuit (server hit count stays 0 on second
+  call); corrupted body → named hash-mismatch error, no file left behind.
+- KL cache: key→filename→key round trip (including quants with dots like
+  `Q4_K_M` and model IDs with slashes through `SafeModelID`), list/delete,
+  disk-guard refusal with a too-small free-space fake.
+- Manual: none needed beyond phase 04's end-to-end.
+
+## Commit
+
+`feat(evaluate): pinned evaluation datasets and KL logits cache`
+
+## Rollback
+
+Delete the two files; `eval-data/` on disk is inert without them.

--- a/plan/capability-benchmarks/phase-03-runner-integration.md
+++ b/plan/capability-benchmarks/phase-03-runner-integration.md
@@ -1,0 +1,367 @@
+# Phase 03 — Capability presets, job runner integration, and the job form
+
+**Depends on:** 01 (engine), 02 (datasets/logits cache) · **Enables:**
+results display and management UI (04).
+
+## Goal
+
+Capability evaluations become runnable jobs: eight new presets in the
+picker, the cell loop branching on preset kind, router exclusivity, KL
+reference resolution with on-demand base generation as a visible step, and
+scores landing on the run. After this phase a mixed job runs end to end;
+scores are only visible via the run JSON until phase 04.
+
+## Files touched
+
+- `internal/benchmark/benchmark.go` — capability presets use the
+  EXISTING dispatch key: `Preset.Source` gains the value
+  `"capability"` (no separate `Kind` field — `EffectiveSource()` at
+  `benchmark.go:248-254` is already the dispatch key and a second one
+  would drift). `Preset` gains `EvalMode`, `EvalTasks`, `EvalChunks`;
+  the eight capability presets appended in `Presets()`. Every site
+  that branches on `EffectiveSource()` handles the new value:
+  `runner.go:143`'s switch gains a `case "capability"` returning an
+  internal error ("capability presets run through the job runner" —
+  the cell loop branches before ever calling it, so reaching this is a
+  bug, not a user state); the sweep registry (`sweep.go`) gains the
+  per-field `AffectsEval` flag per step 3, while
+  `ValidateSamplingSupport` itself is unchanged — the capability
+  refusal lives in `bench_jobs.go` (step 7). `bench_about.go:45`
+  needs NO change (its
+  `!= PresetSourceBenchy → continue` already handles a new source);
+  the About-benchmarks modal's preset table is phase 04's concern.
+- `internal/benchmark/job.go` — `Job` gains `KLReference string`
+  (registry ID; "" = automatic), carried on `jobCreateRequest` in the api.
+- `internal/benchmark/job_runner.go` — `JobEnv` additions and the
+  capability-cell branch; sampling-axis cell collapsing. `ModelInfo`
+  (`job_runner.go:80-87`) gains additive fields the capability path
+  needs and today's struct lacks: `ID` (registry model ID),
+  `FilePath` (GGUF path), and `SizeBytes int64` (kept alongside the
+  display-oriented `SizeGiB`); populated where `ModelInfo` is built
+  (`internal/api/jobs_env.go:345-380`, which already has all three
+  before converting them away).
+- `internal/api/jobs_env.go` — `jobEnv` implementations of the new
+  methods.
+- `internal/api/bench_jobs.go` — request field, validation, matrix count.
+- `internal/api/bench.go` (`:467`) / `web/templates/partials/benchmark_form.html`
+  — the single-run quick-benchmark form filters capability presets out
+  (step 6).
+- `web/templates/partials/job_form.html` — capability presets in the
+  preset list; KL reference dropdown revealed when a KL preset is
+  checked.
+- `web/templates/benchmarks.html` — small JS for the reveal + matrix
+  count awareness.
+- Tests across `internal/benchmark` and `internal/api`.
+
+## Steps
+
+1. Presets (labels follow the existing duration-hint style; all counts
+   are at the fixed evaluation context of 512 — phase 01 — which is
+   what makes "all chunks" a defined quantity):
+   - `perplexity-quick` (100 chunks, ~2-5 min/model) / `perplexity-full`
+     (all chunks — wikitext-2 test at ctx 512 is ~650 chunks)
+   - `kl-divergence-quick` (100 chunks) / `kl-divergence-full`
+     (all chunks; the base file for a full run is tens of GiB for
+     large-vocab models — the phase 02 disk guard is the gate)
+   - `hellaswag-quick` (400 tasks) / `hellaswag-full` (all ~10K)
+   - `winogrande-quick` (400 tasks) / `winogrande-full`
+   Descriptions state what the score means and that the inference server
+   is offline while the cell runs.
+2. `JobEnv` additions (implemented in `jobs_env.go` with the api server's
+   existing machinery; every method documented on the interface):
+   ```go
+   // StopRouterForEval stops llama-server so an evaluation can own the
+   // GPU. It records that THIS JOB stopped a RUNNING router — when the
+   // router was already stopped (by the user, before the job) nothing
+   // is recorded, so cleanup will not start a server the user had
+   // turned off. Idempotent.
+   StopRouterForEval(ctx context.Context) error
+   // EvalBinary returns the llama-perplexity path for a build, or an
+   // error naming the fix ("rebuild") when the build predates the
+   // binary's installation.
+   EvalBinary(buildID string) (string, error)
+   // EnsureEvalData downloads/verifies the dataset for a mode.
+   EnsureEvalData(ctx context.Context, mode evaluate.Mode) (path string, err error)
+   // ResolveKLReference picks the reference for a model: the override
+   // when set, else the largest installed quant (by SizeBytes) sharing
+   // the model's HF repo. Returns an error when no distinct candidate
+   // exists (the model is the only installed quant of its repo).
+   ResolveKLReference(modelID, overrideID string) (ModelInfo, error)
+   // EvalFlags builds the complete llama-perplexity flag list for a
+   // cell: merges the snapshot onto the model's saved config
+   // (applySnapshotToConfig), validates the merged config the same
+   // way ApplyEphemeralConfig does (ValidateBatchSizes,
+   // jobs_env.go:204-210 — a -ub > -b sweep fails with the named
+   // message, not the loader's raw error), resolves GPU assignment
+   // (resolveGPUAssignment), fills evaluate.SnapshotSubset (plain
+   // fields + PlacementFlags via models.GPUPlacementFlags with the
+   // build's backend), and returns evaluate.MapConfigFlags's output.
+   // The single place config becomes CLI flags — phase 01 step 2.
+   EvalFlags(modelID string, snap ConfigSnapshot, buildID string) ([]string, error)
+   // EnsureKLBase returns the cached logits path for (reference,
+   // dataset, chunks, ctx), generating it first when absent. The
+   // progress callback receives plain-language status lines; the
+   // runner wires it to the run's ProgressDetail through the store —
+   // the same transport performance runs already use (runner.go:93-95)
+   // — which is what makes generation the overview's "visible job
+   // step". Progress SOURCE: the generation's own output is
+   // newline-less fragments (perplexity.cpp:633), so the
+   // implementation polls the growing .kld.partial file's size (the
+   // phase 02 interruption-safe temp path — generation never writes
+   // the final name directly) on a ticker and reports "generating
+   // reference logits: 2.1 of ~4.6 GiB" against the phase 02
+   // estimate — no output parsing (phase 01 step 3). On failure or
+   // cancel the partial is deleted, never cached. Generation loads the reference model with the
+   // REFERENCE's own saved ModelConfig mapped through EvalFlags (no
+   // sweep overrides) — GPU layers and placement apply, so a large
+   // reference is not silently evaluated on CPU. Enforces the phase
+   // 02 disk guard before generating.
+   EnsureKLBase(ctx context.Context, ref ModelInfo, chunks int, buildID string, progress func(string)) (string, error)
+   // RunEval executes one evaluation and returns parsed scores.
+   RunEval(ctx context.Context, spec evaluate.Spec) (evaluate.Result, error)
+   ```
+   Router restore is NOT free-riding on today's cleanup — as written,
+   `ClearEphemeralConfig` (`internal/api/jobs_env.go:232-269`) would do
+   nothing for a capability job: it early-returns when the job never
+   took router ownership, and its "user stopped the router mid-job,
+   leave it stopped" check reads `IsRunning()`, which is false after
+   `StopRouterForEval` for the wrong reason. Concretely:
+   `StopRouterForEval` sets the same ownership flag
+   `EnsureBuildActive`/`ApplyEphemeralConfig` set AND a new
+   `stoppedForEval bool` on `jobEnv`; `ClearEphemeralConfig` is amended
+   so that when `stoppedForEval` is set it restarts the router
+   (restoring the pre-job state) instead of treating not-running as a
+   user stop, then clears the flag. The user-stop semantics for
+   performance-only jobs are unchanged. The `JobEnv` doc comment on
+   `ClearEphemeralConfig` (`job_runner.go:53-55`) is updated to state
+   the eval-stop case. This is what makes the overview's "router is
+   back up afterward, including on failure and cancel" criterion true;
+   the test in step 5 asserts it.
+   `internal/benchmark` importing `internal/evaluate` is cycle-free
+   (evaluate imports models, huggingface, and stdlib — none of which
+   import benchmark).
+3. Cell expansion — the collapse rule: capability cells run only what
+   `MapConfigFlags` lets through, so when a job's sweep axes vary
+   parameters that never reach the evaluation, capability presets
+   generate ONE cell per distinct EVAL-REACHING configuration, not one
+   per swept value — duplicate expensive cells reporting different
+   labels for identical runs is exactly the mislabeled-results failure
+   this codebase guards against elsewhere.
+   The discriminator is NOT `RestartsRouter`: three load-time axes
+   restart the router yet never reach the eval — `context_size`
+   (`sweep.go:340-341`; replaced by the fixed `-c 512`), `spec_type`
+   (`sweep.go:366`; speculative decoding excluded), and any future
+   axis of that kind — so keying on `RestartsRouter` would fan
+   capability cells out into byte-identical invocations under
+   different labels. Instead `SweepField` gains an explicit
+   `AffectsEval bool` in the registry — true exactly for fields that
+   reach the eval command line, whether through the phase 01 direct
+   mapping (kv cache quant, batch/ubatch, flash attention, gpu layers,
+   threads, direct_io) or through the placement resolution
+   (`gpu_assign` AND `tensor_split`, `sweep.go:356` — both become
+   `--device`/`--tensor-split` via `PlacementFlags`). That is the
+   complete 16-field registry classified: the remaining seven —
+   temperature, top_p, min_p, repeat_penalty, top_k (sampling),
+   context_size, spec_type — are `AffectsEval == false` and collapse
+   for capability presets. The registry stays the single source; a new
+   mapped/excluded flag in phase 01 has one place to be reflected. The collapse happens
+   at matrix expansion; the form's matrix count reflects it (step 7).
+   Relationship to the existing sampling guard: `ValidateSamplingSupport`
+   (`sweep.go:748-793`) already REFUSES benchy presets combined with
+   sampling settings, for the same mislabeled-results reason. The two
+   remedies coexist deliberately: benchy cannot apply sampling at all
+   (refusal is the only honest option), while capability cells have a
+   well-defined meaning under collapse. `ValidateSamplingSupport`
+   itself is UNCHANGED — its signature sees only presets, overrides,
+   and sweeps (`sweep.go:756`), while step 7's capability refusal also
+   needs the job's model and build counts, so that refusal lives in
+   `bench_jobs.go`'s request validation (which has the whole request)
+   next to the KL checks. A job mixing benchy, capability, and a
+   sampling axis still gets the benchy refusal first, unchanged.
+4. Capability cell execution (the branch in the cell loop — entered
+   when `preset.EffectiveSource() == "capability"`, before the
+   performance path is ever consulted). `CheckBuildRunnable` and
+   `EnsureBuildActive` currently share one `prevBuildID`-guarded block
+   (`job_runner.go:320-328`); that block is SPLIT so a capability cell
+   runs `CheckBuildRunnable` (build must exist and be runnable) but
+   NEVER `EnsureBuildActive` — starting llama-server just to stop it
+   again would add a full router restart + health wait between every
+   pair of consecutive capability cells. The branch creates and saves
+   the cell's `BenchmarkRun` (status running) FIRST — deliberately
+   unlike the performance path, which creates its run last
+   (`job_runner.go:367-389`) — because sub-step c's `EnsureKLBase`
+   progress lands on the run's `ProgressDetail`, which must exist and
+   be stored before generation starts. The performance path finalizes
+   its run inside `Runner.Run` (`runner.go:84-140`), which this branch
+   bypasses — so the branch owns the run's WHOLE lifecycle explicitly,
+   on every exit: any sub-step failure (a's rebuild message, b's
+   dataset error, c's resolve/generation error, f's eval error) sets
+   `StatusFailed` + `Error` and saves; success (f) sets
+   `StatusCompleted` and saves; the 4c reference-model skip DELETES
+   the pre-created run and clears `cell.BenchmarkRunID` (restoring
+   "skipped cell has no run"). No exit may leave a stored
+   `StatusRunning` run — the run list renders those as live and retry
+   would orphan them. Then:
+   a. `EvalBinary(buildID)` — absent → cell fails with the rebuild
+      message.
+   b. `EnsureEvalData` for the mode.
+   c. KL only: `ResolveKLReference` (job's `KLReference` as override).
+      If the resolved reference IS the cell's own model (the largest
+      quant's own cell in an all-quants job — the flagship flow), the
+      cell is SKIPPED, not failed and not run: an expensive eval whose
+      answer is known is waste, and a refusal would break the primary
+      use case. Storage for the skip: the cell is marked
+      `CellStatusCompleted` with an additive `SkipReason string` on
+      `JobCell` (`job.go:101-113`) and produces no `BenchmarkRun`.
+      Deliberately NOT `CellStatusSkipped` — that status already means
+      "job canceled before this cell ran" (`job_runner.go:235-237`)
+      and such cells are re-run on retry, which is correct for them
+      and wrong for a reference cell; and NOT a reuse of `Error`
+      (retry and error-styling collisions). Completed-with-reason
+      means the existing loop short-circuit (`job_runner.go:229`),
+      retry selection, and the Done/Total progress counting
+      (`bench_jobs.go:38-46`, `:485`) all behave correctly with ZERO
+      changes — a 4-quant KL job shows 4/4 done, not 3/4 forever.
+      The note ("this is the reference model — its difference from
+      itself is zero") renders where cell status renders (phase 04).
+      Otherwise
+      `EnsureKLBase` — generation runs with the reference model loaded
+      (router already stopped, step d ordering below); the resolved
+      reference identity is recorded on the run's `EvalScores`.
+   d. `StopRouterForEval` — called before b/c's GPU work: concretely,
+      first thing after a; dataset downloads don't need it but base
+      generation and the eval do, and stopping early keeps the ordering
+      simple and the window deterministic.
+   e. Build `evaluate.Spec`: binary, model path (`ResolveModel` →
+      `ModelInfo.FilePath`, the field added in this phase),
+      mode/dataset/limits from the preset, and `Flags` from
+      `EvalFlags(modelID, cellSnapshot, buildID)` — the api-side
+      method (step 2) that performs the same merge/resolve the
+      performance path uses and runs everything through
+      `evaluate.MapConfigFlags`. The cell's `ConfigSnapshot` passed in
+      is the same snapshot recorded on the run, so the recorded config
+      and the flags that ran share one source; this is what makes a
+      swept `gpu_assign` measurably reach `llama-perplexity` — the
+      overview's config-fidelity criterion.
+   f. `RunEval`; copy `Result` into `run.Eval`; timings fields stay zero
+      (phase 04 renders them as absent).
+   Failure text includes the engine's tail-of-output.
+5. Router lifecycle: a capability cell following a performance cell
+   stops the router. The reverse direction does NOT come free: the
+   cell loop skips `EnsureBuildActive` when the build is unchanged
+   (`job_runner.go:320-328`) and skips `ApplyEphemeralConfig` when the
+   wanted overrides match `lastApplied` (`job_runner.go:354-365`), so
+   a performance cell after a capability cell would run its warmup
+   against a stopped router and fail. Fix in the cell loop: after any
+   capability cell runs (equivalently, after `StopRouterForEval`),
+   invalidate the loop's `prevBuildID` and `lastApplied` caches so the
+   NEXT PERFORMANCE cell unconditionally re-enters
+   `EnsureBuildActive`/`ApplyEphemeralConfig`, which start the router
+   back up through the existing blocking calls. The invalidation only
+   affects performance cells — capability cells never call
+   `EnsureBuildActive` (step 4's block split), so consecutive
+   capability cells run back-to-back with the router simply staying
+   stopped, no start/stop churn. Job-end cleanup
+   (`ClearEphemeralConfig` with the `stoppedForEval` amendment of step
+   2, run on success, failure, and cancel) restores the user's router
+   state — assert both the mid-job revival and the job-end restore in
+   tests.
+6. Single-run quick-benchmark form: `bench.go:467` feeds
+   `benchmark.Presets()` into `benchmark_form.html`'s dropdown. This
+   path does NOT bypass the cell loop — `handleStartBenchmark`
+   (`bench.go:240-292`) builds a 1-cell job and submits it to the same
+   JobQueue, so a capability preset selected there would actually run
+   correctly. The form still FILTERS capability presets out as a
+   product decision: it has no KL-reference selector, its "router is
+   not running — start the server first" gate (`bench.go:260-262`) is
+   meaningless for capability cells (they stop the router), and its
+   single-run framing is built around timing results. The filter is by
+   `EffectiveSource()`, next to the existing benchy handling; the
+   JSON API needs no extra guard (a capability preset POSTed directly
+   runs fine through the cell loop).
+7. Job form: capability presets render in the existing preset checkbox list
+   (same fieldset — the Source only matters to the runner and phase
+   04's columns). Checking a KL preset reveals a "KL reference model"
+   dropdown (options: installed models grouped by repo, default
+   "automatic — largest quant of each model's repo"), posted as
+   `kl_reference`. Matrix count JS applies the collapse rule to
+   capability presets. Capability refusal (in `bench_jobs.go`'s
+   request validation, per step 3 — it needs model/build counts):
+   refuse ONLY jobs where ALL FOUR hold — capability-only presets, AT
+   LEAST ONE sweep axis configured, no configured axis has
+   `AffectsEval == true`, and models × builds == 1 — i.e. the
+   configured sweep is the job's only variation and none of it reaches
+   the evaluation, so the whole job collapses to one cell per preset
+   ("the swept parameters do not affect capability evaluations —
+   nothing would vary between cells"). Precisely NOT refused:
+   sweep-free capability jobs (the overview's flagship four-quant job
+   — zero sweeps is the normal case), and multi-model or multi-build
+   jobs with inert sweeps (after collapse the cells still vary by
+   model/build — meaningful; the matrix count shows the collapse).
+   KL-specific
+   validation in `bench_jobs.go`: a KL preset whose every cell would be
+   skipped under step 4c (each selected model resolves to itself as
+   reference — e.g. a single-model job whose model is the only
+   installed quant of its repo, or an explicit reference on a
+   single-model job naming that model) → refused with a message naming
+   what to add (a second quant or a different reference). A reference
+   that is merely AMONG the job's models is fine — that is the primary
+   all-quants flow; only its own cell skips.
+
+## Build gate
+
+`go build ./... && go vet ./internal/... && go test ./internal/...`
+
+## Test plan
+
+- Runner tests with a fake `JobEnv` (the existing pattern in
+  `job_runner_test.go`): capability cell happy path lands scores on the
+  run; missing binary fails with the rebuild message; KL resolves
+  automatic reference (largest quant fake) and records it; the
+  reference model's own cell is skipped with the note, other cells run;
+  base generated once then cache hit on the second cell; cancel
+  mid-generation deletes the `.kld.partial` and leaves no cache entry,
+  and a subsequent `EnsureKLBase` regenerates (the test phase 02's
+  interruption-safety rule delegates here); router stop
+  called before eval and cleanup restores after success, failure, AND
+  cancel (the `stoppedForEval` path — this is the test the old plan
+  could not have passed); `stoppedForEval` NOT set when the router was
+  already stopped before the job (cleanup leaves it stopped); the
+  mixed-order sequence perf → capability → perf on ONE build with no
+  overrides — the middle cell stops the router and the third cell must
+  see `EnsureBuildActive`/`ApplyEphemeralConfig` re-invoked (cache
+  invalidation per step 5), not a dead router.
+- Expansion tests: sampling axis + capability preset collapses to one
+  cell while the same job's performance preset still fans out;
+  context_size axis (RestartsRouter true, `AffectsEval` false) ALSO
+  collapses for capability presets — the case a RestartsRouter-keyed
+  collapse would miss; eval-reaching axis (kv_cache_quant) fans
+  capability cells out normally.
+- Validation tests: all-cells-would-skip KL refusal; the four-condition
+  capability refusal fires for a single-model, single-build,
+  capability-only job whose only sweep is a sampling axis; it does NOT
+  fire for the sweep-free four-quant flagship job nor for a
+  multi-model job with the same inert sweep; existing benchy refusal
+  unchanged; batch/ubatch mismatch on a capability cell refused with
+  the named message (the `ValidateBatchSizes` call in `EvalFlags`).
+- Run-lifecycle tests: failed capability cell's run is `StatusFailed`
+  with the error (never left `StatusRunning`); the reference-skip
+  path deletes its pre-created run and clears `cell.BenchmarkRunID`.
+- Expansion test addition: `tensor_split` axis fans capability cells
+  out (`AffectsEval` true via placement).
+- Form render test (existing job-form render pattern): capability
+  presets listed, KL dropdown present and hidden by default.
+- Manual on the dev box (vulkan build, TWO small models so the
+  perf-after-capability ordering actually occurs mid-job): run
+  `hellaswag-quick` + `internal-quick` in one job; watch the router
+  stop and come back between cells and at job end; inspect the run
+  JSON for scores.
+
+## Commit
+
+`feat(benchmarks): capability evaluation presets and job runner integration`
+
+## Rollback
+
+Revert the branch commits; `Eval` on stored runs is additive and ignored
+by older code. No persisted format changes beyond additive fields.

--- a/plan/capability-benchmarks/phase-04-results-and-management.md
+++ b/plan/capability-benchmarks/phase-04-results-and-management.md
@@ -1,0 +1,110 @@
+# Phase 04 — Results display, export, evaluation-data card, and docs
+
+**Depends on:** 01, 02, 03 · **Enables:** nothing — final phase.
+
+## Goal
+
+Scores become visible and manageable: evaluation columns in the results
+and compare tables, export coverage, the Evaluation Data card on the
+Benchmarks tab (datasets + logits cache with delete), and help-page
+documentation.
+
+## Files touched
+
+- `web/templates/benchmarks.html` / the results-table and compare
+  partials (`web/templates/partials/benchmark_detail.html`,
+  `benchmark_compare.html`, and the run-row rendering — exact partial
+  confirmed at implementation from where timing columns render) — score
+  columns.
+- `internal/api/bench_export.go` — export columns.
+- `internal/api/bench_jobs.go` or a new `internal/api/eval_data.go` —
+  the Evaluation Data card's handlers.
+- `internal/api/server.go` — route registration for the two new
+  endpoints (all routes register there, e.g. `server.go:380`).
+- `web/templates/partials/eval_data.html` (new) — the card.
+- `web/templates/partials/bench_about.html` (and `internal/api/bench_about.go`
+  only if the capability section needs data the template doesn't
+  already get) — step 5's preset-table section and intro-copy fix.
+- `web/templates/help.html` — Benchmarks section addition.
+- Render tests following the existing partial-render pattern.
+
+## Steps
+
+1. Results columns, conditional: a job or run list containing any run
+   with `Eval != nil` gains a "Score" column group; runs render their
+   mode-appropriate value with its uncertainty and task/chunk count —
+   `PPL 6.234 ±0.04 (100 chunks)` / `PPL 6.198 ±0.03 (full)` (the
+   requested chunk cap from `EvalScores`; 0 renders as "full" — no
+   actual-count parsing exists, phase 01 step 6),
+   `HellaSwag 77.2% [75.9–78.5] (400)` (the
+   asymmetric 95% confidence interval the tool reports, phase 01),
+   `KLD 0.012 ±0.001 · same top token 97.4% (vs UD-Q8_K_XL)` (the
+   top-token agreement the overview promises, from the `Same top p`
+   statistic), `Winogrande 74.1% ±2.2 (400)` —
+   em-dash in timing columns for capability runs and in the score
+   column for performance runs. A KL cell skipped as the reference
+   model (phase 03 step 4c) has no run at all — its `SkipReason`
+   renders where cell status renders (the job's cell grid), styled as
+   informational, not as an error. Tooltips explain each metric in
+   plain language (lower perplexity is better; KL-divergence measures
+   deviation from the reference, 0 = identical).
+2. Compare view: the same conditional columns; comparing runs of
+   different modes shows each row's own metric (the mode is part of the
+   row identity, no cross-metric math).
+3. Export: the CSV/JSON export gains the eval fields (mode, dataset,
+   score, error, tasks/chunks, KL statistics, reference identity) —
+   empty for performance runs, matching how per-mode columns already
+   behave.
+4. Evaluation Data card (Benchmarks tab, beneath the jobs list):
+   - Datasets: name, license, size, state (not downloaded / verified),
+     from phase 02's table + `Verify`.
+   - KL reference logits: reference model + quant, dataset, chunks,
+     size, age; per-row Delete (htmx post → refreshed card). Total size
+     shown. Copy states these regenerate automatically when needed.
+   - Handlers: `GET /api/benchmarks/eval-data` (card partial),
+     `POST /api/benchmarks/eval-data/delete-logits` (form: the cache
+     key fields). Deleting while a job runs is refused with the same
+     busy message other job-conflicting actions use.
+5. About-benchmarks modal (`bench_about.html`): its preset table's
+   columns are performance-shaped (prompt/gen tokens, repetitions);
+   capability presets get their own short section listing mode, task or
+   chunk count, and what the score means — not em-dashes in columns
+   that don't apply. The modal's intro copy ("Two source paths produce
+   results, both via real HTTP requests through the running router")
+   is also updated — capability evaluations load the model directly
+   and do not go through the router, so the sentence becomes false as
+   written.
+6. Help page: a "Capability benchmarks" subsection under Benchmarks —
+   what each mode measures, quick-vs-full guidance, dataset names and
+   licenses (rendered from the phase 02 table's strings verbatim), the
+   server-offline behavior during capability cells, KL reference
+   selection and the logits cache's disk cost, and a plain-language note
+   that sampling parameters do not affect these scores.
+7. Render tests: run row with `Eval` set shows the score and em-dash
+   timings; performance row unchanged; eval-data card renders both
+   sections; export test asserts the new columns round-trip one
+   capability run.
+
+## Build gate
+
+`go build ./... && go vet ./internal/... && go test ./internal/...`
+
+## Test plan
+
+- The render/export tests above.
+- Manual end-to-end on the dev box (the overview's success criteria):
+  four-quants job with `perplexity-quick` + `hellaswag-quick` → scores
+  visible per cell and exported; KL job generates then reuses the base
+  (visible step, then cache hit); mixed job yields t/s and accuracy
+  side by side with the router restored afterward; kv_cache_quant sweep
+  with `hellaswag-quick` shows per-value cells; logits delete from the
+  card works and a re-run regenerates.
+
+## Commit
+
+`feat(benchmarks): capability score display, export, and evaluation data management`
+
+## Rollback
+
+Template/handler layer only; phases 01-03 remain fully functional (scores
+in run JSON and export-by-API). No stored state beyond what 02 manages.


### PR DESCRIPTION
Planning documents for the capability-benchmarks feature — adding llama.cpp's own `llama-perplexity` evaluation modes (perplexity, KL-divergence, HellaSwag, Winogrande) as capability presets in the existing benchmark job matrix, so one job can measure tokens/sec and quality side by side across quants, builds, and settings.

## Contents

- `overview.md` — problem, goals, non-goals, constraints, success criteria, and the decisions made during planning interviews
- `phase-01-eval-engine.md` — `internal/evaluate` package: modes, config→flag mapping, subprocess execution, output parsers; `llama-perplexity` joins the build install step
- `phase-02-datasets.md` — pinned datasets with SHA-256 verification; the KL reference logits cache with interruption safety and a disk guard
- `phase-03-runner-integration.md` — eight capability presets, the capability cell branch in the job runner (router stop/restore lifecycle), KL reference resolution, sweep collapse rules, job form changes
- `phase-04-results-and-management.md` — score columns, export, the Evaluation Data management card, documentation

## Verification

The plan went through nine rounds of adversarial verification, each by a fresh reviewer reading the plan against the actual codebase and the llama.cpp source. Rounds 1–8 found and fixed 48 defects (14/9/9/7/3/3/2/1), converging from design breaks (router-restore assumptions, mandatory `--ctx-size`, stderr-vs-stdout score lines) through wiring gaps to a single missing test bullet; round 9 confirmed clean. Every file:line citation in the plan has been verified against source.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZPyq4QeaeZKgkSeyHQ6nw