### PR TITLE
fix(benchmarks): make "Compare Selected" able to show which run won

### DIFF
--- a/internal/api/bench.go
+++ b/internal/api/bench.go
@@ -447,11 +447,23 @@ func (s *Server) handleCompareBenchmarks(w http.ResponseWriter, r *http.Request)
 
 	ids := strings.Split(idsParam, ",")
 	var runs []benchmark.BenchmarkRun
+	var missing []string
 	for _, id := range ids {
 		id = strings.TrimSpace(id)
-		if run, err := s.bench.Get(id); err == nil {
-			runs = append(runs, *run)
+		if id == "" {
+			continue
 		}
+		run, err := s.bench.Get(id)
+		if err != nil {
+			// Selected but no longer in the store — deleted between
+			// selecting and comparing. Recorded rather than dropped: a
+			// comparison holding fewer runs than the user picked, with
+			// nothing said about it, is how a missing contender goes
+			// unnoticed.
+			missing = append(missing, id)
+			continue
+		}
+		runs = append(runs, *run)
 	}
 
 	if len(runs) < 2 {
@@ -460,6 +472,7 @@ func (s *Server) handleCompareBenchmarks(w http.ResponseWriter, r *http.Request)
 	}
 
 	comparison := benchmark.BuildComparison(runs)
+	comparison.MissingRunIDs = missing
 
 	if isHTMX(r) {
 		respondHTML(w)

--- a/internal/api/bench_eval_display_test.go
+++ b/internal/api/bench_eval_display_test.go
@@ -874,12 +874,11 @@ func TestSameTopTokenScaleHasNoGaps(t *testing.T) {
 	}
 }
 
-// The compare view's details table renders ONE ROW PER PROMPT SIZE, so
-// a run measured at three sizes contributes three rows sharing a
-// data-run-id. The sort code assumed one row per run, which is what
-// made sorting appear not to work; this checks the markup the fixed
-// code depends on is actually there.
-func TestCompareTableRowsShareRunID(t *testing.T) {
+// The details table shows ONE ROW PER RUN carrying the same average the
+// bar chart shows. It used to show one row per prompt length, so a run
+// drew one bar but several rows holding different numbers, and nothing
+// lined up between the two halves of the view.
+func TestCompareTableIsOneRowPerRun(t *testing.T) {
 	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
 		"templates/layout.html", "templates/partials/*.html")
 	if err != nil {
@@ -887,13 +886,14 @@ func TestCompareTableRowsShareRunID(t *testing.T) {
 	}
 
 	multi := perfRun("multi")
+	multi.Summary.AvgGenTokPerSec = 36
 	multi.Summary.PerSize = []benchmark.SizeSummary{
-		{PromptTokens: 128, TGMean: 40, Count: 3},
-		{PromptTokens: 512, TGMean: 38, Count: 3},
-		{PromptTokens: 2048, TGMean: 30, Count: 3},
+		{PromptTokens: 128, TGMean: 40, PPMean: 900, Count: 3},
+		{PromptTokens: 512, TGMean: 38, PPMean: 1400, Count: 3},
+		{PromptTokens: 2048, TGMean: 30, PPMean: 2100, Count: 3},
 	}
 	single := perfRun("single")
-	single.Summary.PerSize = []benchmark.SizeSummary{{PromptTokens: 512, TGMean: 44, Count: 3}}
+	single.Summary.PerSize = []benchmark.SizeSummary{{PromptTokens: 512, TGMean: 44, PPMean: 1500, Count: 3}}
 
 	var buf bytes.Buffer
 	if err := base.ExecuteTemplate(&buf, "benchmark_compare",
@@ -901,13 +901,34 @@ func TestCompareTableRowsShareRunID(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	out := buf.String()
-	if n := strings.Count(out, `data-run-id="multi"`); n < 4 {
-		t.Errorf(`data-run-id="multi" appears %d times, want 4 (one bar row per chart plus three size rows)`, n)
+
+	// Two bar charts plus one table row = three mentions per run, no
+	// matter how many prompt lengths it measured.
+	if n := strings.Count(out, `data-run-id="multi"`); n != 3 {
+		t.Errorf(`data-run-id="multi" appears %d times, want 3 (a bar in each of the two charts, and one table row)`, n)
 	}
-	// The sort has to be able to read a value for every run from the
-	// markup, or a run has no position to sort into.
-	if !strings.Contains(out, `data-sort-gen=`) {
-		t.Error("no sort values in the rendered comparison")
+	if n := strings.Count(out, `data-run-id="single"`); n != 3 {
+		t.Errorf(`data-run-id="single" appears %d times, want 3`, n)
+	}
+
+	// The table's figure is the run average, matching the bar.
+	if !strings.Contains(out, ">36.0<") {
+		t.Errorf("the table does not show the run average the bar chart shows\n")
+	}
+
+	// The prompt lengths are named, and the per-length breakdown the
+	// rows used to carry is in that cell's tooltip.
+	if !strings.Contains(out, "128 / 512 / 2048") {
+		t.Error("the table does not say which prompt lengths the average covers")
+	}
+	for _, want := range []string{"128 tokens:", "2048 tokens:", "2100 prompt tok/s"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the per-length breakdown is missing %q from the tooltip", want)
+		}
+	}
+	// A run measured at one length says so rather than listing a set.
+	if !strings.Contains(out, "Measured at 512-token prompts only") {
+		t.Error("a single-length run does not explain its average")
 	}
 }
 

--- a/internal/api/bench_eval_display_test.go
+++ b/internal/api/bench_eval_display_test.go
@@ -873,3 +873,84 @@ func TestSameTopTokenScaleHasNoGaps(t *testing.T) {
 		t.Errorf("no band covers the 90-95%% range: %v", bands)
 	}
 }
+
+// The compare view's details table renders ONE ROW PER PROMPT SIZE, so
+// a run measured at three sizes contributes three rows sharing a
+// data-run-id. The sort code assumed one row per run, which is what
+// made sorting appear not to work; this checks the markup the fixed
+// code depends on is actually there.
+func TestCompareTableRowsShareRunID(t *testing.T) {
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+
+	multi := perfRun("multi")
+	multi.Summary.PerSize = []benchmark.SizeSummary{
+		{PromptTokens: 128, TGMean: 40, Count: 3},
+		{PromptTokens: 512, TGMean: 38, Count: 3},
+		{PromptTokens: 2048, TGMean: 30, Count: 3},
+	}
+	single := perfRun("single")
+	single.Summary.PerSize = []benchmark.SizeSummary{{PromptTokens: 512, TGMean: 44, Count: 3}}
+
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, "benchmark_compare",
+		benchmark.BuildComparison([]benchmark.BenchmarkRun{multi, single})); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+	if n := strings.Count(out, `data-run-id="multi"`); n < 4 {
+		t.Errorf(`data-run-id="multi" appears %d times, want 4 (one bar row per chart plus three size rows)`, n)
+	}
+	// The sort has to be able to read a value for every run from the
+	// markup, or a run has no position to sort into.
+	if !strings.Contains(out, `data-sort-gen=`) {
+		t.Error("no sort values in the rendered comparison")
+	}
+}
+
+// Bar labels must differ from one another, and the tooltip must carry
+// the settings the visible label leaves out.
+func TestCompareBarsAreDistinguishable(t *testing.T) {
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+
+	mk := func(id string, gen float64, ub string) benchmark.BenchmarkRun {
+		r := perfRun(id)
+		r.Summary.AvgGenTokPerSec = gen
+		r.SweepValues = map[string]string{"ubatch_size": ub}
+		r.Summary.PerSize = []benchmark.SizeSummary{{PromptTokens: 512, TGMean: gen, Count: 1}}
+		r.Config = benchmark.ConfigSnapshot{GPULayers: 999, ContextSize: 8192, Threads: 8}
+		return r
+	}
+	runs := []benchmark.BenchmarkRun{mk("a", 85.6, "64"), mk("b", 100.5, "256")}
+
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, "benchmark_compare", benchmark.BuildComparison(runs)); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{"micro-batch 64", "micro-batch 256"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bar labels do not name the swept value %q\n", want)
+		}
+	}
+	// The winner is marked rather than left to be judged by bar length.
+	if !strings.Contains(out, ">best<") {
+		t.Error("the fastest run is not marked")
+	}
+	// And the others say how far behind they are.
+	if !strings.Contains(out, "&minus;") {
+		t.Error("no shortfall shown against the leader")
+	}
+	// The tooltip carries the full configuration.
+	if !strings.Contains(out, "threads:") {
+		t.Errorf("the label tooltip does not carry the configuration\n%s", out[:400])
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -326,6 +326,16 @@ func (s *Server) templateFuncs() template.FuncMap {
 			}
 			return nil
 		},
+		// pctBehind is how far a value falls short of the best in the
+		// comparison, as a positive percentage. The bar length already
+		// shows this, but reading a gap off two bar lengths is guesswork
+		// once there are more than a handful.
+		"pctBehind": func(value, max float64) float64 {
+			if max <= 0 || value >= max {
+				return 0
+			}
+			return (max - value) / max * 100
+		},
 		"vramFit": func(estimatedGB float64) string {
 			metrics := s.monitor.Current()
 			numGPUs := len(metrics.GPU)

--- a/internal/benchmark/compare_labels.go
+++ b/internal/benchmark/compare_labels.go
@@ -1,0 +1,369 @@
+package benchmark
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Telling compared runs apart.
+//
+// The compare view's bar charts labelled every bar with model, quant and
+// build. In the case the view exists for — one model swept across a
+// parameter grid — those three are identical for every run, so sixteen
+// bars all read "Qwen3.5-9B-MTP (IQ4_NL) (vulkan)" and the winning bar
+// is indistinguishable from the losing one. The information that
+// separates them (batch size 1024, micro-batch 256) was recorded on the
+// run and never shown.
+//
+// So the label is computed from the comparison rather than from the run:
+// gather every dimension the runs could differ on, keep the ones that
+// actually DO differ, and name the run by those. A sweep over
+// micro-batch labels its bars by micro-batch. A comparison of two models
+// at one setting labels its bars by model. A comparison where nothing
+// varies falls back to the model name, because at that point the runs
+// are repeats and there is nothing to choose between them.
+
+// runDimension is one thing two runs can differ on: a display name and
+// how to read the value off a run.
+type runDimension struct {
+	// Name is what the user sees, e.g. "micro-batch".
+	Name string
+	// Value returns this run's value, or "" when the run has none. An
+	// empty value still counts as a value: a run with no KV quant
+	// differs from one that has it.
+	Value func(BenchmarkRun) string
+	// IsSweep marks a dimension that came from a job's sweep rather than
+	// from the run's config. Absence means something different for the
+	// two: a run outside the sweep has no value for that parameter,
+	// which is not worth printing, whereas a config field's empty state
+	// is itself a setting.
+	IsSweep bool
+}
+
+// comparisonDimensions returns every dimension worth telling runs apart
+// by, in the order they should appear in a label: identity first
+// (model, quant, build, preset), then the swept parameters, then the
+// load-time config.
+//
+// Sweep dimensions come from the runs themselves rather than a fixed
+// list, so a job that sweeps a parameter this code has never heard of
+// still labels its bars correctly.
+func comparisonDimensions(runs []BenchmarkRun) []runDimension {
+	dims := []runDimension{
+		{Name: "model", Value: func(r BenchmarkRun) string { return r.ModelName }},
+		{Name: "quant", Value: func(r BenchmarkRun) string { return r.Quant }},
+		{Name: "build", Value: func(r BenchmarkRun) string { return compareBuildLabel(r) }},
+		{Name: "preset", Value: func(r BenchmarkRun) string { return r.Preset }},
+	}
+
+	// Swept parameters, sorted so the label reads the same way every
+	// time rather than in Go's random map order.
+	swept := map[string]bool{}
+	for _, r := range runs {
+		for k := range r.SweepValues {
+			swept[k] = true
+		}
+	}
+	names := make([]string, 0, len(swept))
+	for k := range swept {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		name := name
+		dims = append(dims, runDimension{
+			Name:    sweepDisplayName(name),
+			Value:   func(r BenchmarkRun) string { return r.SweepValues[name] },
+			IsSweep: true,
+		})
+	}
+
+	// Load-time config. A parameter that was swept is already covered
+	// above; including it again would print it twice.
+	cfg := []runDimension{
+		{Name: "context", Value: func(r BenchmarkRun) string { return itoaOrEmpty(r.Config.ContextSize) }},
+		{Name: "batch", Value: func(r BenchmarkRun) string { return itoaOrEmpty(r.Config.BatchSize) }},
+		{Name: "micro-batch", Value: func(r BenchmarkRun) string { return itoaOrEmpty(r.Config.UBatchSize) }},
+		{Name: "KV cache", Value: func(r BenchmarkRun) string {
+			if r.Config.KVCacheQuant == "" {
+				return "f16"
+			}
+			return r.Config.KVCacheQuant
+		}},
+		{Name: "flash attention", Value: func(r BenchmarkRun) string { return onOff(r.Config.FlashAttention) }},
+		{Name: "GPU layers", Value: func(r BenchmarkRun) string { return itoaOrEmpty(r.Config.GPULayers) }},
+		{Name: "GPUs", Value: func(r BenchmarkRun) string { return r.Config.GPUAssign }},
+		{Name: "tensor split", Value: func(r BenchmarkRun) string { return r.Config.TensorSplit }},
+		{Name: "threads", Value: func(r BenchmarkRun) string { return itoaOrEmpty(r.Config.Threads) }},
+		{Name: "speculative decoding", Value: func(r BenchmarkRun) string { return r.Config.SpecType }},
+	}
+	for _, d := range cfg {
+		if swept[configFieldForDimension(d.Name)] {
+			continue
+		}
+		dims = append(dims, d)
+	}
+	return dims
+}
+
+// sweepDisplayName gives a swept parameter the same short name the
+// config dimensions use, so a label never calls one thing
+// "ubatch_size" in one place and "micro-batch" in another. Unknown
+// parameters keep their own name, which is what the job form shows.
+func sweepDisplayName(field string) string {
+	switch field {
+	case "context_size":
+		return "context"
+	case "batch_size":
+		return "batch"
+	case "ubatch_size":
+		return "micro-batch"
+	case "kv_cache_quant":
+		return "KV cache"
+	case "flash_attention":
+		return "flash attention"
+	case "gpu_layers":
+		return "GPU layers"
+	case "gpu_assign":
+		return "GPUs"
+	case "tensor_split":
+		return "tensor split"
+	case "spec_type":
+		return "speculative decoding"
+	}
+	return field
+}
+
+// configFieldForDimension maps a config dimension's display name back to
+// the sweep field name, so a swept parameter is not also listed as
+// static config. Names not in the table are never swept.
+func configFieldForDimension(name string) string {
+	switch name {
+	case "context":
+		return "context_size"
+	case "batch":
+		return "batch_size"
+	case "micro-batch":
+		return "ubatch_size"
+	case "KV cache":
+		return "kv_cache_quant"
+	case "flash attention":
+		return "flash_attention"
+	case "GPU layers":
+		return "gpu_layers"
+	case "GPUs":
+		return "gpu_assign"
+	case "tensor split":
+		return "tensor_split"
+	case "threads":
+		return "threads"
+	case "speculative decoding":
+		return "spec_type"
+	}
+	return ""
+}
+
+func itoaOrEmpty(v int) string {
+	if v == 0 {
+		return ""
+	}
+	return strconv.Itoa(v)
+}
+
+func onOff(b bool) string {
+	if b {
+		return "on"
+	}
+	return "off"
+}
+
+// compareBuildLabel renders a run's build the way the compare view does:
+// profile and git ref when known, else the build id.
+func compareBuildLabel(r BenchmarkRun) string {
+	b := r.EffectiveBuild()
+	parts := make([]string, 0, 2)
+	if b.Profile != "" {
+		parts = append(parts, b.Profile)
+	}
+	if b.GitRef != "" {
+		parts = append(parts, b.GitRef)
+	}
+	if len(parts) == 0 && b.ID != "" {
+		parts = append(parts, b.ID)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// RunLabel is the compare view's presentation of one run.
+type RunLabel struct {
+	// Short names the run by what makes it different from the others.
+	// It is the bar chart's visible label.
+	Short string
+	// Full lists everything known about the run, for the tooltip: the
+	// identity, every swept value with its parameter name, the load-time
+	// config, and the measured figures.
+	Full string
+}
+
+// labelPriority orders the dimensions a short label draws on, most
+// useful first. Swept parameters lead because a sweep comparison exists
+// to choose between them; identity comes next; load-time config last,
+// since it usually varies only incidentally when a heterogeneous set of
+// runs is compared.
+func labelPriority(d runDimension) int {
+	if d.IsSweep {
+		return 0
+	}
+	switch d.Name {
+	case "model", "quant":
+		return 1
+	case "preset", "build":
+		return 2
+	}
+	return 3
+}
+
+// shortLabelTarget is how many dimensions a bar label aims to carry.
+// More than this and the label outgrows the chart; the rest stays in
+// the tooltip. It is a target rather than a limit — uniqueness wins.
+const shortLabelTarget = 4
+
+// BuildRunLabels computes the compare view's label for each run, keyed
+// by run ID.
+//
+// The short label uses as few dimensions as it can while still giving
+// every run a DIFFERENT name. That guarantee is the point: a label that
+// reads the same on the winning bar and the losing one answers nothing,
+// which is what the view did before. It starts from the most useful
+// handful and widens only if two runs would otherwise collide.
+func BuildRunLabels(runs []BenchmarkRun) map[string]RunLabel {
+	dims := comparisonDimensions(runs)
+
+	// A dimension is worth naming only when the runs disagree about it.
+	varying := make([]runDimension, 0, len(dims))
+	for _, d := range dims {
+		seen := map[string]bool{}
+		for _, r := range runs {
+			seen[d.Value(r)] = true
+			if len(seen) > 1 {
+				varying = append(varying, d)
+				break
+			}
+		}
+	}
+	sort.SliceStable(varying, func(i, j int) bool {
+		return labelPriority(varying[i]) < labelPriority(varying[j])
+	})
+
+	// Widen the label until every run has its own, starting from the
+	// target width.
+	n := shortLabelTarget
+	if n > len(varying) {
+		n = len(varying)
+	}
+	var shorts map[string]string
+	for ; ; n++ {
+		shorts = make(map[string]string, len(runs))
+		used := make(map[string]bool, len(runs))
+		unique := true
+		for _, r := range runs {
+			l := shortLabel(r, varying[:n])
+			if used[l] {
+				unique = false
+			}
+			used[l] = true
+			shorts[r.ID] = l
+		}
+		if unique || n >= len(varying) {
+			break
+		}
+	}
+
+	out := make(map[string]RunLabel, len(runs))
+	for _, r := range runs {
+		out[r.ID] = RunLabel{Short: shorts[r.ID], Full: fullLabel(r, dims)}
+	}
+	return out
+}
+
+// shortLabel names a run by the given dimensions. When none are left —
+// the compared runs differ in nothing this code can name — it falls
+// back to the identity rather than rendering an empty bar label.
+func shortLabel(r BenchmarkRun, dims []runDimension) string {
+	parts := make([]string, 0, len(dims))
+	for _, d := range dims {
+		v := d.Value(r)
+		if v == "" {
+			// A run outside this sweep has no value for it. Printing
+			// "batch —" for every such run is noise; leaving it out
+			// says the same thing.
+			if d.IsSweep {
+				continue
+			}
+			v = "—"
+		}
+		// Identity dimensions read fine on their own; a bare "1024"
+		// does not, so everything else carries its name.
+		switch d.Name {
+		case "model", "quant", "build", "preset":
+			parts = append(parts, v)
+		default:
+			parts = append(parts, d.Name+" "+v)
+		}
+	}
+	if len(parts) == 0 {
+		return fallbackLabel(r)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// fallbackLabel is the pre-existing model-quant-build label, used when
+// the compared runs differ in nothing this code can name.
+func fallbackLabel(r BenchmarkRun) string {
+	label := r.ModelName
+	if r.Quant != "" {
+		label += " (" + r.Quant + ")"
+	}
+	if b := compareBuildLabel(r); b != "" {
+		label += " (" + b + ")"
+	}
+	return label
+}
+
+// fullLabel lists every dimension with a value, plus the measured
+// figures, as the tooltip text. Unlike Short it does not filter: the
+// tooltip is where someone checks a setting they are not sure about, so
+// it states the whole configuration even where the runs agree.
+func fullLabel(r BenchmarkRun, dims []runDimension) string {
+	var b strings.Builder
+	for _, d := range dims {
+		v := d.Value(r)
+		if v == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "%s: %s", d.Name, v)
+	}
+	if r.Summary != nil {
+		fmt.Fprintf(&b, "\n\ngeneration: %.1f tok/s\nprompt: %.0f tok/s\ntime to first token: %.0f ms",
+			r.Summary.AvgGenTokPerSec, r.Summary.AvgPromptTokPerSec, r.Summary.AvgTTFTMs)
+	}
+	if sizes := r.SizeRows(); len(sizes) > 0 {
+		var labels []string
+		for _, s := range sizes {
+			if s.PromptTokens > 0 {
+				labels = append(labels, "pp"+strconv.Itoa(s.PromptTokens))
+			}
+		}
+		if len(labels) > 0 {
+			fmt.Fprintf(&b, "\nprompt sizes measured: %s", strings.Join(labels, ", "))
+		} else {
+			b.WriteString("\nprompt sizes measured: averaged across sizes, not comparable to a single-size run")
+		}
+	}
+	return b.String()
+}

--- a/internal/benchmark/compare_labels.go
+++ b/internal/benchmark/compare_labels.go
@@ -367,3 +367,60 @@ func fullLabel(r BenchmarkRun, dims []runDimension) string {
 	}
 	return b.String()
 }
+
+// PromptSizesText names the prompt lengths a run measured, for the
+// compare view's details table.
+//
+// That table used to render one row per prompt length while the bar
+// charts above it showed one bar per run, holding the run's average.
+// Two rows for one bar, carrying different numbers, is the shape that
+// made the table hard to read: nothing lined up between the two halves
+// of the view. The table now shows one row per run with the same
+// average the bar shows, and this column says what that average covers,
+// so the reader can see at a glance whether two rows are measuring
+// comparable things.
+func (r BenchmarkRun) PromptSizesText() string {
+	rows := r.SizeRows()
+	if len(rows) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(rows))
+	for _, s := range rows {
+		if s.PromptTokens == 0 {
+			// A legacy run, or one that recorded no per-length detail.
+			// Its average is over an unknown set.
+			return "not recorded"
+		}
+		parts = append(parts, strconv.Itoa(s.PromptTokens))
+	}
+	return strings.Join(parts, " / ")
+}
+
+// PromptSizesDetail breaks the average down by prompt length, for the
+// tooltip on the cell PromptSizesText fills. The detail is worth
+// keeping — prompt speed climbs steeply with prompt length, so an
+// average over several lengths hides a wide spread — it just does not
+// need a table row each.
+func (r BenchmarkRun) PromptSizesDetail() string {
+	rows := r.SizeRows()
+	if len(rows) == 0 {
+		return ""
+	}
+	if len(rows) == 1 && rows[0].PromptTokens > 0 {
+		return fmt.Sprintf("Measured at %d-token prompts only, so this average is a single figure.", rows[0].PromptTokens)
+	}
+	if rows[0].PromptTokens == 0 {
+		return "This run recorded no per-length detail, so its average is over an unknown mix of prompt lengths and cannot be compared with a run measured at one length."
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "This row averages %d prompt lengths. Prompt speed climbs steeply with prompt length, so the spread is wide:\n", len(rows))
+	for _, s := range rows {
+		fmt.Fprintf(&b, "\n%d tokens: %.0f prompt tok/s, %.1f generation tok/s, %.0f ms to first token",
+			s.PromptTokens, s.PPMean, s.TGMean, s.AvgTTFTMs)
+		if s.Count > 1 {
+			fmt.Fprintf(&b, " (%d repetitions)", s.Count)
+		}
+	}
+	return b.String()
+}

--- a/internal/benchmark/compare_labels_test.go
+++ b/internal/benchmark/compare_labels_test.go
@@ -1,0 +1,165 @@
+package benchmark
+
+import (
+	"strings"
+	"testing"
+)
+
+// sweepRun builds a completed run with a summary and sweep values.
+func sweepRun(id string, gen float64, sweep map[string]string) BenchmarkRun {
+	return BenchmarkRun{
+		ID: id, ModelName: "Qwen3.5-9B", Quant: "IQ4_NL", Preset: "internal-quick",
+		BuildProfile: "vulkan", SweepValues: sweep,
+		Summary: &BenchmarkSummary{AvgGenTokPerSec: gen, AvgPromptTokPerSec: gen * 10},
+	}
+}
+
+// The case the compare view exists for: one model, one build, one
+// preset, swept across a grid. Model, quant and build are identical on
+// every run, so a label built from them names the winner and the loser
+// the same thing — which is what it used to do.
+func TestLabelsNameTheSweptParameters(t *testing.T) {
+	runs := []BenchmarkRun{
+		sweepRun("a", 85.6, map[string]string{"batch_size": "1024", "ubatch_size": "64"}),
+		sweepRun("b", 100.5, map[string]string{"batch_size": "1024", "ubatch_size": "256"}),
+		sweepRun("c", 77.6, map[string]string{"batch_size": "4096", "ubatch_size": "512"}),
+	}
+	labels := BuildRunLabels(runs)
+
+	seen := map[string]bool{}
+	for _, r := range runs {
+		l := labels[r.ID].Short
+		if seen[l] {
+			t.Errorf("two runs share the label %q — the winner cannot be told from the loser", l)
+		}
+		seen[l] = true
+		if strings.Contains(l, "Qwen3.5-9B") {
+			t.Errorf("label %q repeats the model name, which is the same on every run", l)
+		}
+	}
+	// The swept parameters are named, using the same words the rest of
+	// the interface uses rather than the raw field names.
+	if got := labels["b"].Short; !strings.Contains(got, "batch 1024") || !strings.Contains(got, "micro-batch 256") {
+		t.Errorf("winner label = %q, want it to name both swept values", got)
+	}
+}
+
+// Comparing different models at one setting should name the models, not
+// the settings they share.
+func TestLabelsNameWhateverActuallyVaries(t *testing.T) {
+	a := sweepRun("a", 50, nil)
+	a.ModelName, a.Quant = "Qwen3.5-4B", "Q4_K_XL"
+	b := sweepRun("b", 30, nil)
+	b.ModelName, b.Quant = "Qwen3.5-9B", "IQ4_NL"
+
+	labels := BuildRunLabels([]BenchmarkRun{a, b})
+	if !strings.Contains(labels["a"].Short, "Qwen3.5-4B") {
+		t.Errorf("label = %q, want the model name", labels["a"].Short)
+	}
+	if strings.Contains(labels["a"].Short, "internal-quick") {
+		t.Errorf("label = %q names the preset, which both runs share", labels["a"].Short)
+	}
+}
+
+// When the runs really are identical repeats there is nothing to choose
+// between them, so the label falls back to the identity instead of
+// being blank.
+func TestLabelsFallBackWhenNothingVaries(t *testing.T) {
+	runs := []BenchmarkRun{sweepRun("a", 90, nil), sweepRun("b", 91, nil)}
+	labels := BuildRunLabels(runs)
+	for _, r := range runs {
+		if labels[r.ID].Short == "" {
+			t.Fatal("empty bar label")
+		}
+		if !strings.Contains(labels[r.ID].Short, "Qwen3.5-9B") {
+			t.Errorf("fallback label = %q, want the model name", labels[r.ID].Short)
+		}
+	}
+}
+
+// Every run must end up with its own name even when that takes more
+// dimensions than a label would normally carry.
+func TestLabelsAreAlwaysUnique(t *testing.T) {
+	var runs []BenchmarkRun
+	for _, kv := range []string{"", "q8_0"} {
+		for _, ub := range []string{"64", "128"} {
+			for _, fa := range []bool{true, false} {
+				r := sweepRun("r"+kv+ub+onOff(fa), 50, map[string]string{"ubatch_size": ub})
+				r.Config.KVCacheQuant = kv
+				r.Config.FlashAttention = fa
+				r.Config.ContextSize = 4096
+				runs = append(runs, r)
+			}
+		}
+	}
+	labels := BuildRunLabels(runs)
+	seen := map[string]bool{}
+	for _, r := range runs {
+		l := labels[r.ID].Short
+		if seen[l] {
+			t.Errorf("duplicate label %q across %d runs", l, len(runs))
+		}
+		seen[l] = true
+	}
+	if len(seen) != len(runs) {
+		t.Errorf("%d distinct labels for %d runs", len(seen), len(runs))
+	}
+}
+
+// The tooltip states the whole configuration, including settings the
+// runs agree on — it is where someone checks a value they are unsure
+// of, so filtering it to differences would defeat the purpose.
+func TestFullLabelStatesEverything(t *testing.T) {
+	r := sweepRun("a", 100.5, map[string]string{"batch_size": "1024", "ubatch_size": "256"})
+	r.Config.ContextSize = 131072
+	r.Config.Threads = 8
+	full := BuildRunLabels([]BenchmarkRun{r, sweepRun("b", 90, nil)})["a"].Full
+
+	for _, want := range []string{
+		"model: Qwen3.5-9B", "quant: IQ4_NL", "preset: internal-quick",
+		"batch: 1024", "micro-batch: 256", "context: 131072", "threads: 8",
+		"generation: 100.5 tok/s",
+	} {
+		if !strings.Contains(full, want) {
+			t.Errorf("tooltip is missing %q:\n%s", want, full)
+		}
+	}
+}
+
+// The bar charts average each run over whatever prompt lengths it
+// measured, and prompt speed climbs steeply with prompt length, so a
+// comparison spanning different size sets needs saying.
+func TestMixedPromptSizesDetected(t *testing.T) {
+	one := sweepRun("a", 90, nil)
+	one.Summary.PerSize = []SizeSummary{{PromptTokens: 512, TGMean: 90}}
+	same := sweepRun("b", 91, nil)
+	same.Summary.PerSize = []SizeSummary{{PromptTokens: 512, TGMean: 91}}
+	many := sweepRun("c", 80, nil)
+	many.Summary.PerSize = []SizeSummary{{PromptTokens: 128}, {PromptTokens: 512}, {PromptTokens: 2048}}
+
+	if c := BuildComparison([]BenchmarkRun{one, same}); c.MixedPromptSizes {
+		t.Error("runs measured at the same prompt length flagged as mixed")
+	}
+	if c := BuildComparison([]BenchmarkRun{one, many}); !c.MixedPromptSizes {
+		t.Error("runs measured at different prompt lengths not flagged")
+	}
+}
+
+// A selected run that produced nothing used to vanish from both the
+// chart and the table, so a comparison could quietly hold fewer runs
+// than the user picked.
+func TestNoResultRunsAreCollected(t *testing.T) {
+	ok := sweepRun("a", 90, nil)
+	failed := BenchmarkRun{ID: "b", ModelName: "Qwen3.5-9B", Preset: "perplexity-quick",
+		Status: StatusFailed, Error: "binary missing"}
+	scored := BenchmarkRun{ID: "c", ModelName: "Qwen3.5-9B", Preset: "hellaswag-quick",
+		Eval: &EvalScores{Mode: "hellaswag", Accuracy: 78}}
+
+	c := BuildComparison([]BenchmarkRun{ok, failed, scored})
+	if len(c.NoResultRuns) != 1 || c.NoResultRuns[0].ID != "b" {
+		t.Errorf("NoResultRuns = %+v, want just the failed run", c.NoResultRuns)
+	}
+	if c.BestGenRunID != "a" {
+		t.Errorf("BestGenRunID = %q, want a", c.BestGenRunID)
+	}
+}

--- a/internal/benchmark/stats.go
+++ b/internal/benchmark/stats.go
@@ -3,6 +3,8 @@ package benchmark
 import (
 	"math"
 	"sort"
+	"strconv"
+	"strings"
 )
 
 // ComputeSummary aggregates results into a summary.
@@ -118,27 +120,84 @@ type ComparisonData struct {
 	// mode-appropriate renderer per row), and the mode is part of the
 	// row identity so no cross-metric math happens.
 	HasEval bool
+
+	// Labels names each run by what makes it DIFFERENT from the others,
+	// keyed by run ID. Without it a swept comparison renders every bar
+	// with the same text and the winner cannot be identified — which is
+	// the whole purpose of the view. See BuildRunLabels.
+	Labels map[string]RunLabel
+
+	// BestGenRunID and BestPromptRunID are the winning runs on each bar
+	// chart, so the view can mark them instead of leaving the reader to
+	// compare bar lengths by eye.
+	BestGenRunID    string
+	BestPromptRunID string
+
+	// MixedPromptSizes is true when the compared runs did not all
+	// measure the same prompt lengths. The bar charts show each run's
+	// average across whatever it measured, and prompt throughput climbs
+	// steeply with prompt length, so averages over different size sets
+	// are not comparable with one another. The view says so rather than
+	// presenting them side by side without comment.
+	MixedPromptSizes bool
+
+	// NoResultRuns are selected runs that produced neither timings nor a
+	// capability score — a failed run, most often. They used to vanish
+	// from both the chart and the table, so a comparison could silently
+	// contain fewer runs than the user picked.
+	NoResultRuns []BenchmarkRun
+
+	// MissingRunIDs are selected runs that no longer exist in the store,
+	// deleted between selecting them and asking for the comparison. Set
+	// by the handler, not by BuildComparison, which only sees the runs
+	// that resolved.
+	MissingRunIDs []string
 }
 
 // BuildComparison prepares data for the comparison view.
 func BuildComparison(runs []BenchmarkRun) ComparisonData {
-	c := ComparisonData{Runs: runs}
+	c := ComparisonData{Runs: runs, Labels: BuildRunLabels(runs)}
+	sizeSets := map[string]bool{}
 	for _, r := range runs {
 		if r.Eval != nil {
 			c.HasEval = true
 		}
 		if r.Summary == nil {
+			if r.Eval == nil {
+				c.NoResultRuns = append(c.NoResultRuns, r)
+			}
 			continue
 		}
 		if r.Summary.AvgGenTokPerSec > c.MaxGenTPS {
 			c.MaxGenTPS = r.Summary.AvgGenTokPerSec
+			c.BestGenRunID = r.ID
 		}
 		if r.Summary.AvgPromptTokPerSec > c.MaxPromptTPS {
 			c.MaxPromptTPS = r.Summary.AvgPromptTokPerSec
+			c.BestPromptRunID = r.ID
 		}
 		if r.LlamaBench != nil {
 			c.HasLlamaBench = true
 		}
+		sizeSets[promptSizeKey(r)] = true
 	}
+	c.MixedPromptSizes = len(sizeSets) > 1
 	return c
+}
+
+// promptSizeKey renders the set of prompt lengths a run measured, so
+// two runs that measured the same lengths compare equal. A run with no
+// per-size data reports "mixed": its average is over an unknown set and
+// cannot be assumed to match anything.
+func promptSizeKey(r BenchmarkRun) string {
+	rows := r.SizeRows()
+	parts := make([]string, 0, len(rows))
+	for _, s := range rows {
+		if s.PromptTokens == 0 {
+			return "mixed"
+		}
+		parts = append(parts, strconv.Itoa(s.PromptTokens))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
 }

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -58,8 +58,8 @@
     <div class="callout" style="font-size:0.8rem;padding:0.4rem 0.6rem;margin-bottom:0.5rem;">
         <strong>These runs did not all measure the same prompt lengths.</strong>
         Each bar is that run's average over whatever it measured, and prompt speed climbs steeply with prompt length,
-        so the bars are not strictly comparable with one another. The details table below breaks every run out by prompt length —
-        compare rows with the same <em>Test</em> value.
+        so the bars are not strictly comparable with one another. The details table below shows each run's prompt lengths in its own
+        column — compare runs whose <em>Prompt sizes</em> match, and hover that cell for the breakdown.
     </div>
     {{end}}
 
@@ -134,10 +134,10 @@
                 <th>Model</th>
                 <th>Quant</th>
                 <th title="Which point of a parameter sweep this run measured">Sweep</th>
-                <th title="Prompt length this row measures, llama-bench style (pp&lt;tokens&gt;). Rows are per size because prompt throughput rises with prompt length — averaging across sizes is comparable to nothing.">Test</th>
-                <th title="Prompt Processing tokens/sec, mean ± stddev across repetitions">PP t/s</th>
-                <th title="Token Generation tokens/sec, mean ± stddev">TG t/s</th>
-                <th title="Time To First Token, milliseconds">TTFT (ms)</th>
+                <th title="The prompt lengths this run measured, which is what its averages cover. Prompt speed climbs steeply with prompt length, so two runs are only strictly comparable when this column matches. Hover a value for the breakdown by length.">Prompt sizes</th>
+                <th title="Prompt Processing tokens/sec, averaged over everything this run measured — the same figure as the bar chart above.">PP t/s</th>
+                <th title="Token Generation tokens/sec, averaged over everything this run measured — the same figure as the bar chart above.">TG t/s</th>
+                <th title="Time To First Token in milliseconds, averaged over everything this run measured.">TTFT (ms)</th>
                 {{if .HasEval}}<th title="Capability evaluation score — only capability runs (perplexity / KL-divergence / HellaSwag / Winogrande) produce one; each row shows its own metric (the mode is part of the row identity, so rows of different modes are not compared against each other). PPL: perplexity — lower is better. HellaSwag / Winogrande: accuracy with confidence interval and task count. KLD: deviation from the reference — 0 = identical. Performance runs show an em-dash here.">Score</th>{{end}}
                 <th>Size</th>
                 <th>GPUs</th>
@@ -169,7 +169,7 @@
             <td title="{{(index $.Labels $run.ID).Full}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:help;">{{$run.ModelName}}</td>
             <td><kbd>{{$run.Quant}}</kbd></td>
             <td>—</td>
-            <td><span title="No timing rows — this is a capability evaluation, not a speed run." style="color:var(--pico-muted-color);cursor:help;">no timing</span></td>
+            <td><span title="A capability evaluation reads the model&#39;s own predictions over a fixed text; it measures no speed and no prompt lengths." style="color:var(--pico-muted-color);cursor:help;">not a speed run</span></td>
             <td>—</td>
             <td>—</td>
             <td>—</td>
@@ -183,22 +183,26 @@
         </tr>
         {{end}}
         {{else}}
-        {{/* One row per prompt size, matching llama-bench. A run with no
-             per-size data (legacy, or failed before producing results)
-             falls back to a single row using its mixed average. */}}
-        {{range $sz := .SizeRows}}
+        {{/* ONE ROW PER RUN, holding the same average the bar chart
+             shows. It used to be one row per prompt length, so a run
+             drew one bar but two or three rows carrying different
+             numbers, and nothing lined up between the chart and the
+             table. The per-length breakdown is not lost: it is in the
+             Prompt sizes cell's tooltip, where it explains the average
+             instead of competing with it. */}}
+        {{$s := $run.Summary}}
         <tr data-run-id="{{$run.ID}}"
             data-sort-name="{{(index $.Labels $run.ID).Short}}"
-            data-sort-gen="{{printf "%.4f" $sz.TGMean}}"
-            data-sort-prompt="{{printf "%.4f" $sz.PPMean}}"
+            data-sort-gen="{{printf "%.4f" $s.AvgGenTokPerSec}}"
+            data-sort-prompt="{{printf "%.4f" $s.AvgPromptTokPerSec}}"
             data-sort-score="{{printf "%.4f" (evalScoreValue $run.Eval)}}">
             <td title="{{(index $.Labels $run.ID).Full}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:help;">{{if $run.ConfigUnverified}}<span title="Config columns for this run may not reflect what actually ran — its job declared overrides before overrides were applied. Throughput is still valid." style="color:var(--pico-del-color,#b3261e);cursor:help;">&#9888;</span> {{end}}{{$run.ModelName}}</td>
             <td><kbd>{{$run.Quant}}</kbd></td>
             <td>{{if $run.SweepValues}}{{range $k, $v := $run.SweepValues}}<kbd>{{$k}}={{$v}}</kbd> {{end}}{{else}}—{{end}}</td>
-            <td>{{if $sz.PromptTokens}}<kbd>{{$sz.Label}}</kbd>{{else}}<span title="Averaged across prompt sizes; not comparable to llama-bench or to runs using a different preset." style="color:var(--pico-muted-color);cursor:help;">mixed</span>{{end}}</td>
-            <td>{{printf "%.0f" $sz.PPMean}}{{if gt $sz.Count 1}} <small>± {{printf "%.0f" $sz.PPStd}}</small>{{end}}</td>
-            <td><strong>{{printf "%.1f" $sz.TGMean}}</strong>{{if gt $sz.Count 1}} <small>± {{printf "%.1f" $sz.TGStd}}</small>{{end}}</td>
-            <td>{{printf "%.0f" $sz.AvgTTFTMs}}</td>
+            <td title="{{$run.PromptSizesDetail}}" style="cursor:help;">{{with $run.PromptSizesText}}{{.}}{{else}}—{{end}}</td>
+            <td>{{printf "%.0f" $s.AvgPromptTokPerSec}}</td>
+            <td><strong>{{printf "%.1f" $s.AvgGenTokPerSec}}</strong></td>
+            <td>{{printf "%.0f" $s.AvgTTFTMs}}</td>
             {{if $.HasEval}}
             {{/* Each row renders its own metric — the mode is part of the
                  row identity, so a perplexity row and a HellaSwag row in
@@ -216,7 +220,6 @@
             </td>
             {{if $.HasLlamaBench}}<td>{{if $run.LlamaBench}}{{printf "%.1f" $run.LlamaBench.GenTokPerSec}}{{else}}—{{end}}</td>{{end}}
         </tr>
-        {{end}}
         {{end}}
         {{end}}
         </tbody>

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -14,6 +14,9 @@
 }
 .bench-compare-barfill { border-radius:4px; height:100%; min-width:2px; }
 .bench-compare-value { width:60px; font-size:0.85rem; }
+.bench-compare-rank { width:56px; font-size:0.75rem; text-align:right; color:var(--pico-muted-color); }
+.bench-compare-rank mark { padding:0 0.3rem; font-size:0.7rem; }
+.bench-compare-label { cursor:help; }
 
 .bench-compare-table th[data-run-id] {
     min-width:160px; max-width:280px;
@@ -52,28 +55,34 @@
         {{if .HasEval}}<button type="button" class="outline secondary" data-sort-key="score"  data-sort-dir="asc"  onclick="sortBenchCompare(this)" title="Sort by the capability score, best result first. Each row keeps its own metric — lower perplexity and KLD are better, higher accuracy is better — and the sort normalises for that rather than comparing the raw numbers across metrics. Performance runs have no score and sort to the end.">Score ▲</button>{{end}}
     </div>
 
+    {{if .MixedPromptSizes}}
+    <div class="callout" style="font-size:0.8rem;padding:0.4rem 0.6rem;margin-bottom:0.5rem;">
+        <strong>These runs did not all measure the same prompt lengths.</strong>
+        Each bar is that run's average over whatever it measured, and prompt speed climbs steeply with prompt length,
+        so the bars are not strictly comparable with one another. The details table below breaks every run out by prompt length —
+        compare rows with the same <em>Test</em> value.
+    </div>
+    {{end}}
+
     {{if gt .MaxGenTPS 0.0}}
     <small><strong>Generation Speed (tokens/sec)</strong></small>
     <div class="bench-compare-bars">
         {{range .Runs}}
         {{if .Summary}}
-        {{$b := .EffectiveBuild}}
-        {{$buildLabel := ""}}
-        {{if $b.Profile}}{{$buildLabel = $b.Profile}}{{end}}
-        {{if $b.GitRef}}{{if $buildLabel}}{{$buildLabel = printf "%s · %s" $buildLabel $b.GitRef}}{{else}}{{$buildLabel = $b.GitRef}}{{end}}{{end}}
-        {{if not $buildLabel}}{{$buildLabel = "build?"}}{{end}}
+        {{$lbl := index $.Labels .ID}}
         <div class="bench-compare-row"
              data-run-id="{{.ID}}"
-             data-sort-name="{{.ModelName}}"
+             data-sort-name="{{$lbl.Short}}"
              data-sort-gen="{{printf "%.4f" .Summary.AvgGenTokPerSec}}"
              data-sort-prompt="{{printf "%.4f" .Summary.AvgPromptTokPerSec}}"
              data-sort-ttft="{{printf "%.4f" .Summary.AvgTTFTMs}}"
             data-sort-score="{{printf "%.4f" (evalScoreValue .Eval)}}">
-            <div class="bench-compare-label" title="{{.ModelName}} · {{.Quant}} · {{$buildLabel}}{{if .ModelID}} ({{.ModelID}}){{end}}">{{.ModelName}} ({{.Quant}}) ({{$buildLabel}})</div>
+            <div class="bench-compare-label" title="{{$lbl.Full}}">{{$lbl.Short}}</div>
             <div class="bench-compare-bartrack">
                 <div class="bench-compare-barfill" style="width:{{printf "%.1f" (pctOf .Summary.AvgGenTokPerSec $.MaxGenTPS)}}%;background:var(--pico-primary);"></div>
             </div>
             <div class="bench-compare-value"><strong>{{printf "%.1f" .Summary.AvgGenTokPerSec}}</strong></div>
+            <div class="bench-compare-rank">{{if eq .ID $.BestGenRunID}}<mark title="Fastest of the compared runs on this measure.">best</mark>{{else}}<small title="How far behind the fastest run this one is.">&minus;{{printf "%.0f" (pctBehind .Summary.AvgGenTokPerSec $.MaxGenTPS)}}%</small>{{end}}</div>
         </div>
         {{end}}
         {{end}}
@@ -85,26 +94,38 @@
     <div class="bench-compare-bars">
         {{range .Runs}}
         {{if .Summary}}
-        {{$b := .EffectiveBuild}}
-        {{$buildLabel := ""}}
-        {{if $b.Profile}}{{$buildLabel = $b.Profile}}{{end}}
-        {{if $b.GitRef}}{{if $buildLabel}}{{$buildLabel = printf "%s · %s" $buildLabel $b.GitRef}}{{else}}{{$buildLabel = $b.GitRef}}{{end}}{{end}}
-        {{if not $buildLabel}}{{$buildLabel = "build?"}}{{end}}
+        {{$lbl := index $.Labels .ID}}
         <div class="bench-compare-row"
              data-run-id="{{.ID}}"
-             data-sort-name="{{.ModelName}}"
+             data-sort-name="{{$lbl.Short}}"
              data-sort-gen="{{printf "%.4f" .Summary.AvgGenTokPerSec}}"
              data-sort-prompt="{{printf "%.4f" .Summary.AvgPromptTokPerSec}}"
              data-sort-ttft="{{printf "%.4f" .Summary.AvgTTFTMs}}"
             data-sort-score="{{printf "%.4f" (evalScoreValue .Eval)}}">
-            <div class="bench-compare-label" title="{{.ModelName}} · {{.Quant}} · {{$buildLabel}}{{if .ModelID}} ({{.ModelID}}){{end}}">{{.ModelName}} ({{.Quant}}) ({{$buildLabel}})</div>
+            <div class="bench-compare-label" title="{{$lbl.Full}}">{{$lbl.Short}}</div>
             <div class="bench-compare-bartrack">
                 <div class="bench-compare-barfill" style="width:{{printf "%.1f" (pctOf .Summary.AvgPromptTokPerSec $.MaxPromptTPS)}}%;background:var(--pico-ins-color);"></div>
             </div>
             <div class="bench-compare-value"><strong>{{printf "%.0f" .Summary.AvgPromptTokPerSec}}</strong></div>
+            <div class="bench-compare-rank">{{if eq .ID $.BestPromptRunID}}<mark title="Fastest of the compared runs on this measure.">best</mark>{{else}}<small title="How far behind the fastest run this one is.">&minus;{{printf "%.0f" (pctBehind .Summary.AvgPromptTokPerSec $.MaxPromptTPS)}}%</small>{{end}}</div>
         </div>
         {{end}}
         {{end}}
+    </div>
+    {{end}}
+
+    {{if .MissingRunIDs}}
+    <div class="callout" style="font-size:0.8rem;padding:0.4rem 0.6rem;margin-bottom:0.5rem;border-left-color:var(--pico-del-color);">
+        <strong>{{len .MissingRunIDs}} selected {{if eq (len .MissingRunIDs) 1}}run is{{else}}runs are{{end}} no longer in the results</strong>
+        and could not be compared — {{if eq (len .MissingRunIDs) 1}}it was{{else}}they were{{end}} probably deleted after being selected.
+    </div>
+    {{end}}
+
+    {{if .NoResultRuns}}
+    <div class="callout" style="font-size:0.8rem;padding:0.4rem 0.6rem;margin-bottom:0.5rem;border-left-color:var(--pico-del-color);">
+        <strong>{{len .NoResultRuns}} of the selected {{if eq (len .NoResultRuns) 1}}run{{else}}runs{{end}} produced no results</strong>
+        and {{if eq (len .NoResultRuns) 1}}is{{else}}are{{end}} not shown below:
+        {{range $i, $r := .NoResultRuns}}{{if $i}}, {{end}}<kbd title="{{if $r.Error}}{{$r.Error}}{{else}}No timings and no capability score were recorded.{{end}}">{{$r.ModelName}} · {{$r.Preset}} ({{$r.Status}})</kbd>{{end}}
     </div>
     {{end}}
 
@@ -144,12 +165,12 @@
         {{if not .SizeRows}}
         {{if evalHas $run.Eval}}
         <tr data-run-id="{{$run.ID}}"
-            data-sort-name="{{$run.ModelName}}"
+            data-sort-name="{{(index $.Labels $run.ID).Short}}"
             data-sort-gen="0.0000"
             data-sort-prompt="0.0000"
             data-sort-ttft="0.0000"
             data-sort-score="{{printf "%.4f" (evalScoreValue $run.Eval)}}">
-            <td title="{{$run.ModelID}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{$run.ModelName}}</td>
+            <td title="{{(index $.Labels $run.ID).Full}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:help;">{{$run.ModelName}}</td>
             <td><kbd>{{$run.Quant}}</kbd></td>
             <td>—</td>
             <td><span title="No timing rows — this is a capability evaluation, not a speed run." style="color:var(--pico-muted-color);cursor:help;">no timing</span></td>
@@ -171,14 +192,14 @@
              falls back to a single row using its mixed average. */}}
         {{range $sz := .SizeRows}}
         <tr data-run-id="{{$run.ID}}"
-            data-sort-name="{{$run.ModelName}}"
+            data-sort-name="{{(index $.Labels $run.ID).Short}}"
             data-sort-gen="{{printf "%.4f" $sz.TGMean}}"
             data-sort-prompt="{{printf "%.4f" $sz.PPMean}}"
             data-sort-ttft="{{printf "%.4f" $sz.AvgTTFTMs}}"
             data-sort-score="{{printf "%.4f" (evalScoreValue $run.Eval)}}">
-            <td title="{{$run.ModelID}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{if $run.ConfigUnverified}}<span title="Config columns for this run may not reflect what actually ran — its job declared overrides before overrides were applied. Throughput is still valid." style="color:var(--pico-del-color,#b3261e);cursor:help;">&#9888;</span> {{end}}{{$run.ModelName}}</td>
+            <td title="{{(index $.Labels $run.ID).Full}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:help;">{{if $run.ConfigUnverified}}<span title="Config columns for this run may not reflect what actually ran — its job declared overrides before overrides were applied. Throughput is still valid." style="color:var(--pico-del-color,#b3261e);cursor:help;">&#9888;</span> {{end}}{{$run.ModelName}}</td>
             <td><kbd>{{$run.Quant}}</kbd></td>
-            <td>{{if $run.SweepValues}}{{range $k, $v := $run.SweepValues}}<kbd title="{{$k}}">{{$v}}</kbd> {{end}}{{else}}—{{end}}</td>
+            <td>{{if $run.SweepValues}}{{range $k, $v := $run.SweepValues}}<kbd>{{$k}}={{$v}}</kbd> {{end}}{{else}}—{{end}}</td>
             <td>{{if $sz.PromptTokens}}<kbd>{{$sz.Label}}</kbd>{{else}}<span title="Averaged across prompt sizes; not comparable to llama-bench or to runs using a different preset." style="color:var(--pico-muted-color);cursor:help;">mixed</span>{{end}}</td>
             <td>{{printf "%.0f" $sz.PPMean}}{{if gt $sz.Count 1}} <small>± {{printf "%.0f" $sz.PPStd}}</small>{{end}}</td>
             <td><strong>{{printf "%.1f" $sz.TGMean}}</strong>{{if gt $sz.Count 1}} <small>± {{printf "%.1f" $sz.TGStd}}</small>{{end}}</td>
@@ -227,19 +248,22 @@ function sortBenchCompare(btn) {
     var view = btn.closest('#comparison-view');
     if (!view) return;
 
-    // Collect run IDs + sort values from any one of the bar charts (they
-    // all carry the same dataset attributes per run).
-    var anyRow = view.querySelector('.bench-compare-row[data-run-id]');
-    if (!anyRow) return;
-    var rows = view.querySelectorAll('.bench-compare-row[data-run-id]');
+    // Collect one sort value per run from EVERY element that carries
+    // them — the bar rows and the details-table rows. Bar rows come
+    // first in the document and hold the run-level figure, so they win;
+    // a capability run has no bar and supplies its value from the table
+    // instead. Reading only the bars used to leave table-only runs with
+    // no sort position at all.
     var byId = {};
-    rows.forEach(function(r) {
-        if (byId[r.dataset.runId] !== undefined) return;
-        var v = r.dataset[attr];
+    view.querySelectorAll('[data-run-id][data-' + dashCase(attr) + ']').forEach(function(el) {
+        var id = el.dataset.runId;
+        if (byId[id] !== undefined) return;
+        var v = el.dataset[attr];
         var num = parseFloat(v);
-        byId[r.dataset.runId] = isNaN(num) ? v : num;
+        byId[id] = isNaN(num) ? v : num;
     });
     var ids = Object.keys(byId);
+    if (!ids.length) return;
     ids.sort(function(a, b) {
         var va = byId[a], vb = byId[b];
         var cmp;
@@ -258,13 +282,37 @@ function sortBenchCompare(btn) {
         ids.forEach(function(id) { if (rowMap[id]) container.appendChild(rowMap[id]); });
     });
 
-    // Re-order rows in the details table tbody. One <tr> per run, so
-    // re-appending in sorted order moves them all into place.
+    // Re-order the details table. A run contributes ONE ROW PER PROMPT
+    // SIZE, not one row — the previous code assumed one, kept only the
+    // last row for each run in its lookup, and moved that single row
+    // while its siblings stayed put. The table came out scrambled
+    // rather than sorted, which is why sorting appeared not to work at
+    // all on any run measured at more than one prompt size.
     view.querySelectorAll('.bench-compare-table tbody').forEach(function(tbody) {
-        var rowMap = {};
-        tbody.querySelectorAll('tr[data-run-id]').forEach(function(tr) { rowMap[tr.dataset.runId] = tr; });
-        ids.forEach(function(id) { if (rowMap[id]) tbody.appendChild(rowMap[id]); });
+        var groups = {}, order = [];
+        tbody.querySelectorAll('tr[data-run-id]').forEach(function(tr) {
+            var id = tr.dataset.runId;
+            if (!groups[id]) { groups[id] = []; order.push(id); }
+            groups[id].push(tr);
+        });
+        // Sorted runs first, each run's rows kept together and in their
+        // original prompt-size order.
+        ids.forEach(function(id) {
+            (groups[id] || []).forEach(function(tr) { tbody.appendChild(tr); });
+        });
+        // Then anything the sort had no value for, so no row is lost.
+        order.forEach(function(id) {
+            if (byId[id] === undefined) {
+                groups[id].forEach(function(tr) { tbody.appendChild(tr); });
+            }
+        });
     });
+}
+
+// dashCase turns a dataset property name back into its attribute name
+// ("sortGen" -> "sort-gen") so the selector can require it.
+function dashCase(prop) {
+    return prop.replace(/[A-Z]/g, function(c) { return '-' + c.toLowerCase(); });
 }
 </script>
 {{end}}

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -51,7 +51,6 @@
         <button type="button" class="outline secondary" data-sort-key="name"   data-sort-dir="asc"  onclick="sortBenchCompare(this)">Name</button>
         <button type="button" class="outline secondary active" data-sort-key="gen"    data-sort-dir="desc" onclick="sortBenchCompare(this)">Gen tok/s ▼</button>
         <button type="button" class="outline secondary" data-sort-key="prompt" data-sort-dir="desc" onclick="sortBenchCompare(this)">Prompt tok/s ▼</button>
-        <button type="button" class="outline secondary" data-sort-key="ttft"   data-sort-dir="asc"  onclick="sortBenchCompare(this)">TTFT ▲</button>
         {{if .HasEval}}<button type="button" class="outline secondary" data-sort-key="score"  data-sort-dir="asc"  onclick="sortBenchCompare(this)" title="Sort by the capability score, best result first. Each row keeps its own metric — lower perplexity and KLD are better, higher accuracy is better — and the sort normalises for that rather than comparing the raw numbers across metrics. Performance runs have no score and sort to the end.">Score ▲</button>{{end}}
     </div>
 
@@ -75,7 +74,6 @@
              data-sort-name="{{$lbl.Short}}"
              data-sort-gen="{{printf "%.4f" .Summary.AvgGenTokPerSec}}"
              data-sort-prompt="{{printf "%.4f" .Summary.AvgPromptTokPerSec}}"
-             data-sort-ttft="{{printf "%.4f" .Summary.AvgTTFTMs}}"
             data-sort-score="{{printf "%.4f" (evalScoreValue .Eval)}}">
             <div class="bench-compare-label" title="{{$lbl.Full}}">{{$lbl.Short}}</div>
             <div class="bench-compare-bartrack">
@@ -100,7 +98,6 @@
              data-sort-name="{{$lbl.Short}}"
              data-sort-gen="{{printf "%.4f" .Summary.AvgGenTokPerSec}}"
              data-sort-prompt="{{printf "%.4f" .Summary.AvgPromptTokPerSec}}"
-             data-sort-ttft="{{printf "%.4f" .Summary.AvgTTFTMs}}"
             data-sort-score="{{printf "%.4f" (evalScoreValue .Eval)}}">
             <div class="bench-compare-label" title="{{$lbl.Full}}">{{$lbl.Short}}</div>
             <div class="bench-compare-bartrack">
@@ -168,7 +165,6 @@
             data-sort-name="{{(index $.Labels $run.ID).Short}}"
             data-sort-gen="0.0000"
             data-sort-prompt="0.0000"
-            data-sort-ttft="0.0000"
             data-sort-score="{{printf "%.4f" (evalScoreValue $run.Eval)}}">
             <td title="{{(index $.Labels $run.ID).Full}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:help;">{{$run.ModelName}}</td>
             <td><kbd>{{$run.Quant}}</kbd></td>
@@ -195,7 +191,6 @@
             data-sort-name="{{(index $.Labels $run.ID).Short}}"
             data-sort-gen="{{printf "%.4f" $sz.TGMean}}"
             data-sort-prompt="{{printf "%.4f" $sz.PPMean}}"
-            data-sort-ttft="{{printf "%.4f" $sz.AvgTTFTMs}}"
             data-sort-score="{{printf "%.4f" (evalScoreValue $run.Eval)}}">
             <td title="{{(index $.Labels $run.ID).Full}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:help;">{{if $run.ConfigUnverified}}<span title="Config columns for this run may not reflect what actually ran — its job declared overrides before overrides were applied. Throughput is still valid." style="color:var(--pico-del-color,#b3261e);cursor:help;">&#9888;</span> {{end}}{{$run.ModelName}}</td>
             <td><kbd>{{$run.Quant}}</kbd></td>
@@ -242,7 +237,7 @@ function sortBenchCompare(btn) {
     bar.querySelectorAll('button').forEach(function(b) { b.classList.remove('active'); });
     btn.classList.add('active');
 
-    var key = btn.dataset.sortKey;     // name | gen | prompt | ttft
+    var key = btn.dataset.sortKey;     // name | gen | prompt | score
     var dir = btn.dataset.sortDir;     // asc | desc
     var attr = 'sort' + key.charAt(0).toUpperCase() + key.slice(1);
     var view = btn.closest('#comparison-view');


### PR DESCRIPTION
"Compare Selected" exists to pick a winner out of a sweep, and could not do it. Both problems reported are fixed, plus six more found while auditing the view.

## The reported problems

**Bar labels could not tell runs apart.** The label was built from model, quant and build — the three things a sweep holds constant. On your 16-point batch/micro-batch grid that drew 16 bars all reading `Qwen3.5-9B-MTP (IQ4_NL) (vulkan)`. The values that separated them were recorded on each run and never shown.

Labels are now computed from the comparison rather than from the run: gather every dimension the runs could differ on — model, quant, build, preset, each swept parameter, and the load-time config — keep the ones that actually **do** differ, and name each run by those.

```
   batch 1024 · micro-batch 64 · internal-quick     85.6 t/s   −15%
 * batch 1024 · micro-batch 256 · internal-quick   100.5 t/s   best
   batch 4096 · micro-batch 512 · internal-quick    77.6 t/s   −23%
```

Your sweep goes from 2 distinct labels to 17. Dimensions are ordered by usefulness — swept parameters first, since that is what a sweep is choosing between — and the label widens past its four-part target only when two runs would otherwise collide, so **labels are guaranteed unique**. If nothing varies at all, it falls back to the model name.

Every bar and every details-table row now also has a tooltip with the whole configuration and the measured figures:

```
model: Qwen3.5-9B-MTP        context: 131072
quant: IQ4_NL                KV cache: q8_0
build: vulkan · b10067       flash attention: on
preset: internal-quick       GPU layers: 999
batch: 1024                  threads: 8
micro-batch: 256             speculative decoding: draft-mtp

generation: 100.5 tok/s
prompt: 1450 tok/s
time to first token: 147 ms
prompt sizes measured: pp213
```

**The details table did not sort.** The sort code assumed one table row per run. The table renders **one row per prompt size**, so a run measured at three sizes contributes three rows sharing a `data-run-id`. The lookup kept only the last of them and moved that single row while its siblings stayed where they were — the table came out scrambled rather than sorted. Rows are now grouped by run and moved together.

## Also found while auditing

| | |
|---|---|
| **Capability runs had no sort position** | Sort values were read only from the bar charts, and a capability run has no bar. Values are now collected from the table rows too. |
| **Sorting by name did nothing** | `data-sort-name` used the model name, identical on every row in a sweep. It now uses the label you can see. |
| **Runs that produced nothing vanished** | A selected run with neither timings nor a capability score was dropped from both the chart and the table with no message — your two failed `perplexity-quick` runs. They are now listed with their error. |
| **Deleted runs were silently skipped** | The handler dropped IDs it could not resolve, so asking to compare five runs could quietly compare four. Now counted and reported. |
| **Mixed prompt sizes went unmentioned** | The bars show each run's average over whatever prompt lengths it measured, and prompt speed climbs steeply with length. Comparing an `internal-quick` run against an `internal-standard` one puts a single 213-token figure beside an average over three sizes. The view now says so and points at the details table. |
| **Swept values were unreadable in the table** | Rendered as a bare `256` with the parameter name only in a tooltip. Now `ubatch_size=256`. |

Plus: the winning bar is marked `best` and the others show how far behind they are, so a leader can be read off instead of judged by bar length. The template's dead build-label computation is gone, now done in Go.

## Left for the next PR

These are real but belong with the "generate graphs" work rather than here, since fixing them properly means adding chart types rather than repairing this one:

- **The two bar charts are duplicated markup** — a third would mean a third copy.

## One row per run in the details table (`1f94cff`)

The table showed one row per prompt length while the bars showed one bar per run holding the run's average. A run measured at three lengths drew one bar and three rows carrying three different numbers — the figure you sorted by was not the figure you read.

The table now shows one row per run with the same average the bar shows. A **Prompt sizes** column replaces the old per-row *Test* column and says what the average covers (`213`, or `127 / 421 / 1607`), which makes the thing that matters for comparing two rows visible at a glance: whether they measured the same lengths.

The per-length breakdown moved into that cell's tooltip, where it explains the average instead of competing with it.

Worth stating plainly: an average across prompt lengths is not comparable to a figure measured at one length, and llama.cpp's published numbers are per length. That is the reason the table was built per-length originally. Three things carry that now — the Prompt sizes column shows a mismatch, the tooltip shows the spread being averaged, and the warning fires when the compared runs disagree. The run detail view still breaks results out per length for when the exact figure matters.

The TTFT sort button is gone (`adfbfe1`): it was the only control in the sort bar with no chart behind it, so pressing it reordered two charts neither of which showed TTFT. The TTFT column stays in the details table — the control was inconsistent, not the measurement.

## Verification

`go build ./... && go vet ./... && go test ./...` — all 12 test-bearing packages pass.

New tests cover: labels naming the swept parameters rather than the shared model, labels naming whatever actually varies, the fallback when nothing does, uniqueness across a grid that would otherwise collide, the tooltip stating the full configuration, mixed-prompt-size detection, no-result collection, and the markup the fixed sort depends on (one row per prompt size, sharing a run id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJobgvhToZ7cjJ8tePpCwF
