### PR TITLE
feat(models): remember which sampling preset is applied

### DIFF
--- a/internal/api/sampling_presets_render_test.go
+++ b/internal/api/sampling_presets_render_test.go
@@ -44,6 +44,7 @@ func TestSamplingPresetsPartialRenders(t *testing.T) {
 	topK := 20
 	cfg := &models.ModelConfig{
 		Enabled: true, GPULayers: 999, ContextSize: 8192, Threads: 8,
+		SamplingPreset: "thinking",
 	}
 	presets := []models.SamplingPreset{
 		{
@@ -95,6 +96,14 @@ func TestSamplingPresetsPartialRenders(t *testing.T) {
 	}
 	if !strings.Contains(out, "Thinking mode") {
 		t.Errorf("expected option label; output=\n%s", out)
+	}
+	// The applied preset persists on the config and its option renders
+	// selected, so reopening the panel shows which preset is running.
+	if !strings.Contains(out, `value="thinking" title="From README — for enable_thinking=True" selected`) {
+		t.Errorf("expected the stored preset's option to render selected; output=\n%s", out)
+	}
+	if !strings.Contains(out, `name="sampling_preset"`) {
+		t.Errorf("expected picker to be a named form field so the selection is saved; output=\n%s", out)
 	}
 }
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -855,6 +855,14 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		cfg.DirectIO = r.FormValue("direct_io") == "on"
 		cfg.ExtraFlags = r.FormValue("extra_flags")
 
+		// "__clear__" is the picker's action entry, not a preset name; it
+		// never reaches here in normal flow (the JS resets the picker before
+		// the save fires) but must not be stored if it does.
+		if preset := r.FormValue("sampling_preset"); preset != "__clear__" {
+			cfg.SamplingPreset = preset
+		} else {
+			cfg.SamplingPreset = ""
+		}
 		cfg.Temperature = parseOptionalFloat(r.FormValue("temperature"))
 		cfg.TopP = parseOptionalFloat(r.FormValue("top_p"))
 		cfg.TopK = parseOptionalInt(r.FormValue("top_k"))

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -163,6 +163,13 @@ type ModelConfig struct {
 	// chat-template auto-detection is wrong or absent. nil = use detection.
 	ReasoningOverride *ReasoningCapability `json:"reasoning,omitempty"`
 
+	// SamplingPreset names the publisher preset whose values currently fill
+	// the sampling fields below, so the UI can show which preset is running.
+	// Cleared when the user hand-edits a sampling field: at that point the
+	// values are no longer the preset's. Purely descriptive — launch and
+	// request behavior read only the individual fields.
+	SamplingPreset string `json:"sampling_preset,omitempty"`
+
 	// Sampling parameters — nil means use llama.cpp server default.
 	Temperature     *float64 `json:"temperature,omitempty"`
 	TopP            *float64 `json:"top_p,omitempty"`

--- a/web/templates/partials/model_config.html
+++ b/web/templates/partials/model_config.html
@@ -388,24 +388,24 @@
     <small style="display: block; opacity: 0.7;">This model ships embedded sampling defaults — llama-server already applies them when the fields below are blank. Pick a preset to see or override the values.</small>
     {{end}}
     {{if .SamplingPresets}}
-    <label title="Apply a sampling preset recommended by the model's publisher — gathered at download time from the GGUF file's embedded defaults, the Unsloth docs, and the base model's generation_config.json. Fills in the fields below — you can edit afterward.">
+    <label title="Apply a sampling preset recommended by the model's publisher — gathered at download time from the GGUF file's embedded defaults, the Unsloth docs, and the base model's generation_config.json. Fills in the fields below and stays selected so you can see which preset is running. Editing a field by hand deselects it — the values are yours from then on.">
         Preset
-        <select class="sampling-preset-picker"
+        <select class="sampling-preset-picker" name="sampling_preset"
                 data-presets="{{.SamplingPresetsJSON}}"
                 onchange="applySamplingPreset(this);">
-            <option value="">— pick to apply —</option>
+            <option value="">— none —</option>
             {{range .SamplingPresets}}
-            <option value="{{.Name}}" title="{{.Description}}">{{.Label}}{{if ne .Name "default"}} ({{.Name}}){{end}}</option>
+            <option value="{{.Name}}" title="{{.Description}}" {{if eq $.Config.SamplingPreset .Name}}selected{{end}}>{{.Label}}{{if ne .Name "default"}} ({{.Name}}){{end}}</option>
             {{end}}
             <option value="__clear__">Clear all (use server defaults)</option>
         </select>
     </label>
     <script>
     if (typeof window.applySamplingPreset !== 'function') {
+        window.samplingPresetFields = ['temperature','top_p','top_k','min_p','presence_penalty','repeat_penalty'];
         window.applySamplingPreset = function(sel) {
             if (sel.value === '') return;
             var form = sel.closest('form');
-            var fields = ['temperature','top_p','top_k','min_p','presence_penalty','repeat_penalty'];
             var clear = sel.value === '__clear__';
             var preset = null;
             if (!clear) {
@@ -415,17 +415,33 @@
                 } catch (e) { return; }
                 if (!preset) return;
             }
-            fields.forEach(function(name) {
+            window.samplingPresetFields.forEach(function(name) {
                 var inp = form.querySelector('[name="'+name+'"]');
                 if (!inp) return;
                 var v = clear ? null : preset[name];
                 inp.value = (v === undefined || v === null) ? '' : v;
             });
-            sel.value = '';
-            // Fire one synthetic change to trigger the existing auto-save.
-            var trig = form.querySelector('[name="temperature"]') || form;
-            trig.dispatchEvent(new Event('change', {bubbles: true}));
+            // "Clear all" is an action, not a state — reset the picker so
+            // "__clear__" is never what gets saved. A named preset stays
+            // selected: the picker is a form field now, so the selection is
+            // saved with the values and re-rendered on the next open.
+            if (clear) sel.value = '';
+            // No synthetic change needed: the user's change on the picker
+            // itself bubbles to the form and fires the auto-save, which
+            // serializes the already-filled fields after its debounce.
         };
+        // Hand-editing a sampling field means the values are no longer the
+        // preset's — deselect it so the saved state doesn't claim otherwise.
+        // Delegated from the document because the form is replaced on every
+        // auto-save swap. Preset application can't trip this: it fills
+        // inputs without dispatching events on them.
+        document.addEventListener('change', function(e) {
+            var t = e.target;
+            if (!t.name || window.samplingPresetFields.indexOf(t.name) === -1) return;
+            var form = t.closest('form');
+            var sel = form && form.querySelector('.sampling-preset-picker');
+            if (sel && sel.value) sel.value = '';
+        });
     }
     </script>
     {{end}}


### PR DESCRIPTION
## Summary
- The sampling Preset picker in the model config panel reset itself to the placeholder right after applying, so there was no way to see which preset a model was running after closing and reopening the panel.
- The picker is now a named form field backed by a new `sampling_preset` field on `ModelConfig`: applying a preset saves the selection together with the values, and the option renders selected the next time the panel opens (or after an app restart).
- Hand-editing any sampling field deselects the preset before the auto-save fires, so the saved state never claims a preset whose values have been modified. "Clear all" remains an action — it clears the fields, resets the picker, and stores no preset name (`__clear__` is also guarded server-side).
- The field is purely descriptive: launch flags and per-request sampling overrides still read only the individual sampling values, so inference behavior is unchanged.

## Test plan
- [x] `go build ./...`, `go test ./internal/api/ ./internal/models/` pass
- [x] Render test extended: stored preset's option renders `selected`, picker is a named field
- [ ] Apply a preset, close and reopen the config panel: picker shows the preset, fields hold its values
- [ ] Edit temperature by hand: picker returns to "— none —" and stays that way after reopen
- [ ] "Clear all": fields blank, picker back to "— none —"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwokkAk6fQYMUbqXuvcZZx