### PR TITLE
fix(benchmarks): solid background in exported chart PNGs

### DIFF
--- a/web/templates/visualize.html
+++ b/web/templates/visualize.html
@@ -573,9 +573,18 @@ main.container { max-width: none; }
 
     // Plotly paints its own background, so the charts are told the
     // page's colours rather than assuming a white page.
+    //
+    // The background is the RESOLVED card colour, not transparent. On
+    // screen the two are indistinguishable — the plot sits on the card
+    // either way — but the toolbar's PNG snapshot bakes in whatever
+    // these are: a transparent export put this theme's pale labels on
+    // nothing, which reads as a checkerboard with the axes missing in
+    // any image viewer.
     function themed() {
         var css = getComputedStyle(document.body);
-        return { paper: 'rgba(0,0,0,0)', plot: 'rgba(0,0,0,0)',
+        var bg = (css.getPropertyValue('--pico-card-background-color') || '').trim()
+                 || '#fff';
+        return { paper: bg, plot: bg,
                  font: css.getPropertyValue('--pico-color') || '#333',
                  grid: css.getPropertyValue('--pico-muted-border-color') || '#ccc' };
     }


### PR DESCRIPTION
## Summary
- The visualize page's "download as PNG" toolbar button produced images with a transparent background and seemingly missing axes. Cause: the charts set `paper_bgcolor`/`plot_bgcolor` to fully transparent so the page theme shows through on screen, and Plotly's snapshot bakes exactly those layout colours into the PNG — transparent pixels plus label/grid colours chosen for a dark page, which vanish on a white viewer (checkerboard effect).
- `themed()` now resolves `--pico-card-background-color` and uses it as a solid chart background. Visually identical on screen — the plot sits on the card either way — and it follows the active theme (dark, Graphite, terminal, light), but exports now match what's on screen.

## Test plan
- [x] `go build ./...`, `go test ./internal/api/` pass
- [x] Headless-browser verification: rendered a chart, exported via `Plotly.toImage` (same path as the toolbar button), displayed the result on a white page — solid background, axes and labels legible
- [ ] In the live app: download a PNG from the toolbar and open it in an image viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwokkAk6fQYMUbqXuvcZZx