### PR TITLE
fix(models): surface rejected config saves instead of freezing silently

### DIFF
--- a/web/templates/partials/model_config.html
+++ b/web/templates/partials/model_config.html
@@ -1,11 +1,18 @@
 {{define "model_config"}}
+{{/* A rejected save (validation 400, server error) leaves the form
+     unswapped, and htmx is silent about it — without the error handlers
+     the form just looks frozen: nothing the user changes appears to do
+     anything, including changes whose re-render would reveal new fields
+     (picking a speculative-decoding mode). Surface the response text. */}}
 <form id="model-config-form"
       hx-put="/api/models/{{.ModelID}}/config"
       hx-target="this"
       hx-swap="outerHTML focus-scroll:false show:none"
       hx-trigger="submit, change delay:500ms"
-      hx-on::before-request="window._cfgScrollY=window.scrollY"
-      hx-on::after-settle="window.scrollTo({top:window._cfgScrollY,behavior:'instant'})">
+      hx-on::before-request="window._cfgScrollY=window.scrollY; var e=this.querySelector('.cfg-save-error'); if(e){e.style.display='none';}"
+      hx-on::after-settle="window.scrollTo({top:window._cfgScrollY,behavior:'instant'})"
+      hx-on::response-error="var e=this.querySelector('.cfg-save-error'); if(e){e.textContent='Not saved: '+(event.detail.xhr.responseText.trim()||('server returned '+event.detail.xhr.status)); e.style.display='block';}"
+      hx-on::send-error="var e=this.querySelector('.cfg-save-error'); if(e){e.textContent='Not saved: could not reach the server.'; e.style.display='block';}">
 
     <div class="model-config-header">
         <span>Configure <span class="mc-owner">— {{.ModelID}}</span></span>
@@ -501,6 +508,7 @@
                style="opacity: 0.7; cursor: default;">
     </label>
 
+    <small class="cfg-save-error" style="display:none;color:var(--pico-del-color);font-weight:600;"></small>
     <small style="color: var(--pico-muted-color);">Changes are saved automatically. Launch parameters require a server restart to apply.</small>
 </form>
 {{end}}


### PR DESCRIPTION
## Summary
- The model config form auto-saves on change and re-renders itself from the response — all conditional sections (speculative-decoding parameter fields, draft pickers) appear through that round trip. When the save is **rejected** (validation 400, server 500, network failure), htmx leaves the form unswapped and silent: the form looks frozen and e.g. picking a speculative-decoding mode appears to do nothing.
- Reported as "selecting any speculative decoding mode no longer shows its parameter fields". The flow itself is intact (verified end-to-end with a headless-browser rig driving the real partial + htmx against a stub server). The plausible trigger: the batch-pair validation added in #124 — a config saved with micro-batch > effective batch *before* that validation existed makes every subsequent save 400 invisibly.
- The form now surfaces the failure in red above the footer ("Not saved: micro-batch 4096 exceeds the default batch size of 2048 — raise Batch (-b) to at least 4096"), covers network errors too, and clears the message when the next save attempt starts.

## Test plan
- [x] `go build ./...`, `go test ./internal/api/` pass
- [x] Headless rig, 200 path: changing Mode to MTP saves and re-renders with Draft Max/Min/Min Probability fields — unchanged behavior
- [x] Headless rig, 400 path: form stays, red "Not saved: …" message shows the server's reason
- [ ] Live: open the affected model's config, change any field, confirm the red message names the actual rejection; fix the named field and confirm spec-mode fields appear again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwokkAk6fQYMUbqXuvcZZx