### PR TITLE
feat(builds): support llama.cpp semver release tags alongside b-tags

### DIFF
--- a/internal/api/build.go
+++ b/internal/api/build.go
@@ -154,9 +154,33 @@ func (s *Server) handleListRefs(w http.ResponseWriter, r *http.Request) {
 	if isHTMX(r) {
 		respondHTML(w)
 		w.Write([]byte(`<option value="latest">latest</option>`))
-		for _, ref := range refs {
-			w.Write([]byte(`<option value="` + ref + `">` + ref + `</option>`))
+		// Two tag families since upstream added semver releases (Aug
+		// 2026): v* release tags and b* nightlies. Group them so the
+		// picker says which is which; "latest" still means the newest
+		// nightly. Tag names come from the upstream remote — escape them.
+		// Releases are labeled with the nightly they were cut from
+		// ("v0.2.0 (b10500)") so their position on the b-scale is
+		// readable without leaving the picker. Values stay bare tags.
+		anchors := s.builder.ReleaseAnchors()
+		writeGroup := func(label string, match func(string) bool) {
+			opts := ""
+			for _, ref := range refs {
+				if match(ref) {
+					e := html.EscapeString(ref)
+					text := e
+					if n, found := anchors[ref]; found {
+						text = fmt.Sprintf("%s (b%d)", e, n)
+					}
+					opts += `<option value="` + e + `">` + text + `</option>`
+				}
+			}
+			if opts != "" {
+				w.Write([]byte(`<optgroup label="` + label + `">` + opts + `</optgroup>`))
+			}
 		}
+		isRelease := func(ref string) bool { return strings.HasPrefix(ref, "v") }
+		writeGroup("Releases", isRelease)
+		writeGroup("Nightly builds", func(ref string) bool { return !isRelease(ref) })
 		return
 	}
 

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -46,6 +46,13 @@ type BuildResult struct {
 	StartedAt  time.Time         `json:"started_at"`
 	FinishedAt time.Time         `json:"finished_at,omitempty"`
 	Error      string            `json:"error,omitempty"`
+	// CommitCount is `git rev-list --count HEAD` of the built checkout.
+	// llama.cpp's bN nightly tags ARE the master commit count, so this
+	// number ranks builds of ANY ref — semver release tags (v0.x.y,
+	// introduced upstream Aug 2026), branches, bare SHAs — on the same
+	// scale as b-tags. Zero on builds from before the field existed;
+	// those fall back to parsing the b-number out of GitRef.
+	CommitCount int `json:"commit_count,omitempty"`
 }
 
 const buildLogHistorySize = 2000
@@ -63,8 +70,9 @@ type Builder struct {
 	logBcasts   map[string]*broadcast.Broadcaster[string] // build ID → log stream
 	lastBuildID string                                    // most recent build ID
 
-	refsMu     sync.Mutex
-	cachedRefs []string
+	refsMu        sync.Mutex
+	cachedRefs    []string
+	cachedAnchors map[string]int // release tag → its nightly b-number
 
 	// Saved build-flag presets (see flag_presets.go), loaded lazily.
 	fpMu        sync.Mutex
@@ -105,9 +113,9 @@ func (b *Builder) Find(id string) (*BuildResult, bool) {
 	return nil, false
 }
 
-// LatestSuccessfulBuild returns the successful build with the newest GitRef
-// (e.g. "b8779" > "b8778"). Non-numeric refs like branch names or SHAs
-// are ranked below numeric b-tags; among them, newest StartedAt wins.
+// LatestSuccessfulBuild returns the successful build of the newest
+// upstream code: highest buildRank (upstream commit count) first, with
+// unrankable builds below ranked ones and ordered by newest StartedAt.
 // Returns nil if no successful build exists.
 func (b *Builder) LatestSuccessfulBuild() *BuildResult {
 	b.mu.Lock()
@@ -123,8 +131,8 @@ func (b *Builder) LatestSuccessfulBuild() *BuildResult {
 		return nil
 	}
 	sort.SliceStable(ok, func(i, j int) bool {
-		ni, oki := refTagNumber(ok[i].GitRef)
-		nj, okj := refTagNumber(ok[j].GitRef)
+		ni, oki := buildRank(ok[i])
+		nj, okj := buildRank(ok[j])
 		switch {
 		case oki && okj:
 			if ni != nj {
@@ -139,6 +147,18 @@ func (b *Builder) LatestSuccessfulBuild() *BuildResult {
 	})
 	res := ok[0]
 	return &res
+}
+
+// buildRank places a build on llama.cpp's own version scale: the master
+// commit count. Recorded directly on newer builds; recovered from the
+// bN tag (whose N is that same count) on builds from before CommitCount
+// existed. A legacy build of a branch or bare SHA has neither and is
+// unrankable — (0, false).
+func buildRank(r BuildResult) (int, bool) {
+	if r.CommitCount > 0 {
+		return r.CommitCount, true
+	}
+	return refTagNumber(r.GitRef)
 }
 
 // refTagNumber extracts N from refs shaped like "bN" (llama.cpp's release
@@ -282,7 +302,7 @@ func (b *Builder) Build(ctx context.Context, profile string, gitRef string, tag 
 		return nil, fmt.Errorf("repo setup: %w", err)
 	}
 
-	resolvedRef, sha, err := b.checkoutRef(ctx, srcDir, gitRef, logCh)
+	resolvedRef, sha, commitCount, err := b.checkoutRef(ctx, srcDir, gitRef, logCh)
 	if err != nil {
 		close(logCh)
 		return nil, fmt.Errorf("checkout: %w", err)
@@ -290,6 +310,7 @@ func (b *Builder) Build(ctx context.Context, profile string, gitRef string, tag 
 
 	result.GitRef = resolvedRef
 	result.GitSHA = sha
+	result.CommitCount = commitCount
 
 	// Compute ID. Tag wins. If untagged and the bare ID is already taken
 	// by a build with different flags, auto-suffix a short hash of this
@@ -634,21 +655,34 @@ func (b *Builder) ensureRepo(ctx context.Context, srcDir string, logCh chan stri
 	return b.runCmd(ctx, filepath.Dir(srcDir), logCh, "", nil, "git", "clone", llamaCppRepo, filepath.Base(srcDir))
 }
 
-// checkoutRef checks out the given ref and returns (resolvedRef, sha, error).
-// If ref is "latest", it resolves to the latest b* release tag.
-func (b *Builder) checkoutRef(ctx context.Context, srcDir string, ref string, logCh chan string) (string, string, error) {
+// checkoutRef checks out the given ref and returns (resolvedRef, sha,
+// commitCount, error). commitCount is `git rev-list --count HEAD` of the
+// checkout — llama.cpp's own version scale (its bN tags are exactly that
+// count) — and is 0 if counting fails; ranking then falls back to the
+// ref's tag number.
+//
+// If ref is "latest", it resolves to the newest bN nightly tag — the
+// meaning "latest" has always had here. Upstream added semver release
+// tags (v0.x.y) in Aug 2026 alongside the nightlies; those are offered
+// in the ref picker but never chosen implicitly. Should upstream ever
+// stop cutting b-tags, the newest v-tag is the fallback, then HEAD.
+func (b *Builder) checkoutRef(ctx context.Context, srcDir string, ref string, logCh chan string) (string, string, int, error) {
 	if ref == "latest" {
-		// Find latest b* release tag (current llama.cpp release format).
-		// Use --sort=-v:refname for proper version ordering.
-		out, err := exec.CommandContext(ctx, "git", "-C", srcDir, "tag", "--sort=-v:refname", "-l", "b*").Output()
-		if err != nil {
-			return "", "", fmt.Errorf("listing tags: %w%s", err, exitErrDetail(err))
+		// --sort=-v:refname gives proper version ordering within a family.
+		ref = ""
+		for _, family := range []string{"b*", "v*"} {
+			out, err := exec.CommandContext(ctx, "git", "-C", srcDir, "tag", "--sort=-v:refname", "-l", family).Output()
+			if err != nil {
+				return "", "", 0, fmt.Errorf("listing tags: %w%s", err, exitErrDetail(err))
+			}
+			tags := strings.Split(strings.TrimSpace(string(out)), "\n")
+			if len(tags) > 0 && tags[0] != "" {
+				ref = tags[0]
+				break
+			}
 		}
-		tags := strings.Split(strings.TrimSpace(string(out)), "\n")
-		if len(tags) == 0 || tags[0] == "" {
+		if ref == "" {
 			ref = "HEAD"
-		} else {
-			ref = tags[0]
 		}
 		sendLog(logCh, fmt.Sprintf("==> Latest tag: %s", ref))
 	}
@@ -661,18 +695,30 @@ func (b *Builder) checkoutRef(ctx context.Context, srcDir string, ref string, lo
 	// half-updated) can't block future builds with "Please commit your
 	// changes or stash them".
 	if err := b.runCmd(ctx, srcDir, logCh, "", nil, "git", "checkout", "--force", ref); err != nil {
-		return "", "", err
+		return "", "", 0, err
 	}
 
 	out, err := exec.CommandContext(ctx, "git", "-C", srcDir, "rev-parse", "HEAD").Output()
 	if err != nil {
-		return "", "", fmt.Errorf("rev-parse: %w%s", err, exitErrDetail(err))
+		return "", "", 0, fmt.Errorf("rev-parse: %w%s", err, exitErrDetail(err))
 	}
-	return ref, strings.TrimSpace(string(out)), nil
+	sha := strings.TrimSpace(string(out))
+
+	// Best-effort: a build is still usable without its count, it just
+	// ranks by its ref's tag number (or not at all) instead.
+	count := 0
+	if cout, err := exec.CommandContext(ctx, "git", "-C", srcDir, "rev-list", "--count", "HEAD").Output(); err == nil {
+		count, _ = strconv.Atoi(strings.TrimSpace(string(cout)))
+	} else {
+		slog.Warn("counting commits failed; build will rank by ref only", "ref", ref, "error", err)
+	}
+	return ref, sha, count, nil
 }
 
-// FetchRefs pulls the latest tags from the llama.cpp remote and returns the
-// available b* release tags. Results are cached; call this to refresh.
+// FetchRefs pulls the latest tags from the llama.cpp remote and returns
+// the available tags: v* semver release tags first (few, stable), then
+// the b* nightly tags — each family newest-first. Results are cached;
+// call this to refresh.
 //
 // The remote fetch is best-effort: if it fails (no network, transient error,
 // timeout), we still return whatever tags are already in the local clone so
@@ -692,22 +738,44 @@ func (b *Builder) FetchRefs() ([]string, error) {
 		slog.Warn("git fetch failed; returning cached tags", "error", err)
 	}
 
-	out, err := exec.Command("git", "-C", srcDir, "tag", "--sort=-v:refname", "-l", "b*").Output()
-	if err != nil {
-		return nil, fmt.Errorf("listing tags: %w", err)
+	// The two families are listed separately: mixing them in one
+	// -v:refname sort would interleave v0.x.y between b-numbers
+	// meaninglessly. Prefix keeps them distinguishable downstream.
+	var refs []string
+	var releases []string
+	for _, family := range []string{"v*", "b*"} {
+		out, err := exec.Command("git", "-C", srcDir, "tag", "--sort=-v:refname", "-l", family).Output()
+		if err != nil {
+			return nil, fmt.Errorf("listing tags: %w", err)
+		}
+		for _, t := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			if t = strings.TrimSpace(t); t != "" {
+				refs = append(refs, t)
+				if family == "v*" {
+					releases = append(releases, t)
+				}
+			}
+		}
 	}
 
-	tags := strings.Split(strings.TrimSpace(string(out)), "\n")
-	var refs []string
-	for _, t := range tags {
-		t = strings.TrimSpace(t)
-		if t != "" {
-			refs = append(refs, t)
+	// Anchor each release to the nightly scale: its commit count IS the
+	// b-number of the nightly it was cut from (upstream tags releases on
+	// nightlies, and bN = commit count N). Releases are few, so one
+	// rev-list per tag is cheap; failures just leave that tag unanchored.
+	anchors := make(map[string]int, len(releases))
+	for _, tag := range releases {
+		out, err := exec.Command("git", "-C", srcDir, "rev-list", "--count", tag).Output()
+		if err != nil {
+			continue
+		}
+		if n, err := strconv.Atoi(strings.TrimSpace(string(out))); err == nil && n > 0 {
+			anchors[tag] = n
 		}
 	}
 
 	b.refsMu.Lock()
 	b.cachedRefs = refs
+	b.cachedAnchors = anchors
 	b.refsMu.Unlock()
 
 	return refs, nil
@@ -719,6 +787,19 @@ func (b *Builder) CachedRefs() []string {
 	defer b.refsMu.Unlock()
 	out := make([]string, len(b.cachedRefs))
 	copy(out, b.cachedRefs)
+	return out
+}
+
+// ReleaseAnchors returns, for each release tag from the last FetchRefs,
+// the nightly b-number that release corresponds to (its commit count).
+// The UI uses it to label releases like "v0.2.0 (b10500)".
+func (b *Builder) ReleaseAnchors() map[string]int {
+	b.refsMu.Lock()
+	defer b.refsMu.Unlock()
+	out := make(map[string]int, len(b.cachedAnchors))
+	for k, v := range b.cachedAnchors {
+		out[k] = v
+	}
 	return out
 }
 

--- a/internal/builder/builder_refs_test.go
+++ b/internal/builder/builder_refs_test.go
@@ -1,0 +1,172 @@
+package builder
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestBuildRank covers the ranking ladder: a recorded CommitCount wins
+// outright, a bN tag recovers the same scale for legacy builds, and
+// anything else is unrankable.
+func TestBuildRank(t *testing.T) {
+	cases := []struct {
+		name   string
+		build  BuildResult
+		want   int
+		ranked bool
+	}{
+		{"commit count recorded", BuildResult{GitRef: "v0.1.0", CommitCount: 10500}, 10500, true},
+		{"count beats tag parse", BuildResult{GitRef: "b9000", CommitCount: 9001}, 9001, true},
+		{"legacy b-tag", BuildResult{GitRef: "b10400"}, 10400, true},
+		{"legacy branch", BuildResult{GitRef: "master"}, 0, false},
+		{"legacy semver, no count", BuildResult{GitRef: "v0.1.0"}, 0, false},
+		{"legacy sha", BuildResult{GitRef: "a1b2c3d"}, 0, false},
+	}
+	for _, c := range cases {
+		got, ranked := buildRank(c.build)
+		if got != c.want || ranked != c.ranked {
+			t.Errorf("%s: buildRank = (%d, %v), want (%d, %v)", c.name, got, ranked, c.want, c.ranked)
+		}
+	}
+}
+
+// TestLatestSuccessfulBuildAcrossTagSchemes pins the property the semver
+// transition needs: builds rank by upstream commit count wherever it is
+// known, whatever the ref looks like — so a semver-tagged build of newer
+// code beats a legacy b-tag build, and an older semver build does NOT
+// beat a newer nightly.
+func TestLatestSuccessfulBuildAcrossTagSchemes(t *testing.T) {
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	b := &Builder{builds: []BuildResult{
+		{ID: "old-release", GitRef: "v0.1.0", CommitCount: 10300, Status: BuildStatusSuccess, StartedAt: base.Add(3 * time.Hour)},
+		{ID: "legacy-nightly", GitRef: "b10400", Status: BuildStatusSuccess, StartedAt: base},
+		{ID: "new-release", GitRef: "v0.2.0", CommitCount: 10500, Status: BuildStatusSuccess, StartedAt: base.Add(1 * time.Hour)},
+		{ID: "failed-newest", GitRef: "b10600", Status: BuildStatusFailed, StartedAt: base.Add(4 * time.Hour)},
+		{ID: "legacy-branch", GitRef: "master", Status: BuildStatusSuccess, StartedAt: base.Add(5 * time.Hour)},
+	}}
+
+	if got := b.LatestSuccessfulBuild(); got == nil || got.ID != "new-release" {
+		t.Fatalf("latest = %+v, want new-release (count 10500 beats legacy b10400 and older v0.1.0; failed and unrankable builds excluded)", got)
+	}
+
+	// With no rankable builds at all, newest StartedAt wins.
+	b2 := &Builder{builds: []BuildResult{
+		{ID: "older", GitRef: "master", Status: BuildStatusSuccess, StartedAt: base},
+		{ID: "newer", GitRef: "feature", Status: BuildStatusSuccess, StartedAt: base.Add(time.Hour)},
+	}}
+	if got := b2.LatestSuccessfulBuild(); got == nil || got.ID != "newer" {
+		t.Fatalf("latest unrankable = %+v, want newer (StartedAt fallback)", got)
+	}
+}
+
+// gitFixture creates <dataDir>/llama.cpp as a real repo with three
+// commits tagged b1, b2 and v0.1.0 (v0.1.0 on the second commit, the way
+// upstream semver releases point at an existing nightly).
+func gitFixture(t *testing.T) (dataDir, srcDir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dataDir = t.TempDir()
+	srcDir = filepath.Join(dataDir, "llama.cpp")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", srcDir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	for i, tag := range []string{"b1", "b2", ""} {
+		if err := os.WriteFile(filepath.Join(srcDir, "f"), []byte{byte(i)}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		run("add", "f")
+		run("commit", "-q", "-m", "c", "--no-gpg-sign")
+		if tag != "" {
+			run("tag", tag)
+		}
+	}
+	run("tag", "v0.1.0", "b2")
+	return dataDir, srcDir
+}
+
+// TestFetchRefsListsBothTagFamilies verifies releases come first, then
+// nightlies, each newest-first. FetchRefs' remote fetch is best-effort,
+// so a fixture without an origin still lists local tags.
+func TestFetchRefsListsBothTagFamilies(t *testing.T) {
+	dataDir, _ := gitFixture(t)
+	b := &Builder{dataDir: dataDir}
+
+	refs, err := b.FetchRefs()
+	if err != nil {
+		t.Fatalf("FetchRefs: %v", err)
+	}
+	want := []string{"v0.1.0", "b2", "b1"}
+	if len(refs) != len(want) {
+		t.Fatalf("refs = %v, want %v", refs, want)
+	}
+	for i := range want {
+		if refs[i] != want[i] {
+			t.Fatalf("refs = %v, want %v", refs, want)
+		}
+	}
+
+	// The release anchors to the nightly it was cut from: v0.1.0 sits on
+	// the same commit as b2, the second commit, so its b-number is 2.
+	anchors := b.ReleaseAnchors()
+	if anchors["v0.1.0"] != 2 {
+		t.Errorf("anchors = %v, want v0.1.0 → 2", anchors)
+	}
+	if _, ok := anchors["b2"]; ok {
+		t.Errorf("nightly tags must not be anchored: %v", anchors)
+	}
+}
+
+// TestCheckoutRefLatestAndCount verifies "latest" still resolves to the
+// newest NIGHTLY tag (not the semver release), and that the commit count
+// of the checkout is recorded.
+func TestCheckoutRefLatestAndCount(t *testing.T) {
+	_, srcDir := gitFixture(t)
+	b := &Builder{}
+	logCh := make(chan string, 16)
+
+	ref, sha, count, err := b.checkoutRef(context.Background(), srcDir, "latest", logCh)
+	if err != nil {
+		t.Fatalf("checkoutRef: %v", err)
+	}
+	if ref != "b2" {
+		t.Errorf("latest resolved to %q, want b2 (newest nightly, not v0.1.0)", ref)
+	}
+	if sha == "" {
+		t.Error("empty sha")
+	}
+	// b2 is the second of three commits.
+	if count != 2 {
+		t.Errorf("commit count = %d, want 2", count)
+	}
+
+	// The contingency this change exists for: if upstream stops cutting
+	// nightly b-tags, "latest" falls back to the newest semver release.
+	for _, tag := range []string{"b1", "b2"} {
+		if out, err := exec.Command("git", "-C", srcDir, "tag", "-d", tag).CombinedOutput(); err != nil {
+			t.Fatalf("deleting %s: %v\n%s", tag, err, out)
+		}
+	}
+	ref, _, _, err = b.checkoutRef(context.Background(), srcDir, "latest", logCh)
+	if err != nil {
+		t.Fatalf("checkoutRef after b-tag removal: %v", err)
+	}
+	if ref != "v0.1.0" {
+		t.Errorf("latest with no b-tags resolved to %q, want v0.1.0", ref)
+	}
+}


### PR DESCRIPTION
## Summary
llama.cpp introduced semver ([upstream PR #26839](https://github.com/ggml-org/llama.cpp/pull/26839), merged 2026-08-12): periodic releases get `v0.x.y` tags pointing at nightlies; `bN` nightly tags continue for now. Our builder was b-tag-only in three places, all fixed here:

- **Ranking** (`LatestSuccessfulBuild`, which decides the build the router launches with): builds now record `git rev-list --count HEAD` at checkout (new additive `CommitCount` on `BuildResult`). llama.cpp's b-number *is* the master commit count, so this puts semver-tagged, branch, and SHA builds on the same scale as b-tags. Legacy entries rank via their parsed b-tag — no `builds.json` migration.
- **Tag discovery** (`FetchRefs`): lists both families — `v*` releases first, then `b*` nightlies, each newest-first — and anchors each release to its nightly via one `rev-list --count` per release tag.
- **Ref picker** (`handleListRefs`): renders two `<optgroup>`s, with releases labeled by their nightly position:
  ```
  latest
  Releases:        v0.2.0 (b10500)
  Nightly builds:  b10472, b10471, …
  ```
  Option values stay bare tags; upstream tag names are now HTML-escaped.
- **"latest"** keeps meaning the newest nightly (unchanged behavior); falls back to the newest `v*` release if upstream ever stops cutting b-tags, then HEAD — instead of silently freezing on the last b-tag ever made.

Not changed: `refTagNumber`, build IDs, job/benchmark build selection (strictly by build ID), templates, and the prose b-number references in help text.

## Test plan
- [x] `go build ./...`, full `go test ./...` pass
- [x] New `builder_refs_test.go` (first coverage of the builder's ref logic): ranking ladder; cross-scheme latest selection (newer semver build beats legacy b-tag, older release loses to newer nightly, unrankable falls back to StartedAt); git fixture asserting both families list in order, release anchor (`v0.1.0 → b2`), "latest" prefers the nightly over the co-located release, commit count recorded, and the b-tags-gone fallback resolves to the release
- [ ] Live: Builds → Refresh Tags shows the grouped picker; once upstream cuts a `v*` release, build it and confirm it ranks by its commit count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwokkAk6fQYMUbqXuvcZZx