### PR TITLE
fix(benchmarks): open visualizations in the current tab

### DIFF
--- a/internal/api/bench_visualize.go
+++ b/internal/api/bench_visualize.go
@@ -13,10 +13,11 @@ import (
 //
 // "Compare Selected" is the quick read: which of these won. This is the
 // slower one — where the ridge is in a two-parameter sweep, whether a
-// setting has a knee, whether two parameters interact. It opens in its
-// own tab so its chart library, which is larger than everything else
-// the application serves put together, is never loaded by the pages
-// people use all day.
+// setting has a knee, whether two parameters interact. It is its own
+// page so its chart library, which is larger than everything else the
+// application serves put together, is never loaded by the pages people
+// use all day; navigation stays in the current tab, with "Back to
+// benchmarks" returning to the list.
 //
 // The data is embedded in the page rather than fetched: the payload is
 // a few kilobytes for any realistic selection, and embedding means the

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -125,16 +125,18 @@ function compareSelectedRuns(btn) {
         .then(function(){ view.scrollIntoView({behavior:'smooth'}); });
 }
 
-// The charts open in their own tab: the plotting library is larger than
-// everything else this application serves put together, so the pages
-// people use all day must never load it.
+// The charts are their own PAGE — only it loads the plotting library,
+// which is larger than everything else this application serves put
+// together, so the pages people use all day never load it. It navigates
+// in the current tab: "Back to benchmarks" (or the browser back button)
+// returns here, rather than leaving a pile of chart tabs behind.
 function visualizeSelectedRuns(btn) {
     var root = benchContainer(btn);
     if (!root) return;
     var checks = root.querySelectorAll('.bench-check:checked');
     if (checks.length < 2) { alert('Select at least two benchmarks to visualize.'); return; }
     var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
-    window.open('/benchmarks/visualize?ids=' + encodeURIComponent(ids), '_blank', 'noopener');
+    window.location.href = '/benchmarks/visualize?ids=' + encodeURIComponent(ids);
 }
 
 function exportSelectedRuns(btn, format) {
@@ -735,7 +737,7 @@ function visualizeSelectedCells(btn) {
     var checks = btn.closest('.job-detail').querySelectorAll('.cell-check:checked');
     if (checks.length < 2) { alert('Select at least 2 cells to visualize.'); return; }
     var ids = Array.from(checks).map(function(c){return c.value;}).join(',');
-    window.open('/benchmarks/visualize?ids=' + encodeURIComponent(ids), '_blank', 'noopener');
+    window.location.href = '/benchmarks/visualize?ids=' + encodeURIComponent(ids);
 }
 
 function compareSelectedCells(btn) {


### PR DESCRIPTION
## Summary
- Both Visualize actions (the ad-hoc run list and the job-matrix cell selection in `benchmarks.html`) used `window.open(..., '_blank')`, leaving a pile of chart tabs behind after a session of exploring results. They now navigate in the current tab; the visualize page's existing "Back to benchmarks" button (or browser back) returns to the list.
- The rationale for a separate *page* is unchanged and preserved — only the visualize page loads the Plotly bundle, which is larger than everything else the app serves — that isolation comes from the page split, not the tab split. The design comments in `benchmarks.html` and `bench_visualize.go` now say so.

## Test plan
- [x] `go build ./...`, `go test ./internal/api/` pass; no `window.open` remains in benchmarks.html
- [ ] Live: select runs → Visualize opens in the same tab; "Back to benchmarks" returns; same from a job's cell selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwokkAk6fQYMUbqXuvcZZx