### PR TITLE
fix(setup,builder): make the ROCm host build work on Debian/Ubuntu

### DIFF
--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -65,7 +65,13 @@ sudo systemctl edit llama-toolchest    # add under [Service]:
 
 The package doesn't pull GPU SDKs — install them yourself for the backend you want to compile against:
 
-- **ROCm** — `rocm-hip-devel` (Fedora) / `rocm-dev` (Debian)
+- **ROCm** — `rocm-hip-devel` (Fedora) / `rocm-dev` (Debian/Ubuntu)
+  - The minimal Debian/Ubuntu set, if `rocm-dev` pulls more than you want:
+    `hipcc libamdhip64-dev librocblas-dev libhipblas-dev rocm-cmake`
+  - `libamdhip64-dev` is the one to check first: it ships the
+    `hip-lang-config.cmake` that `enable_language(HIP)` needs, and without it
+    the build stops at "does not contain the HIP runtime CMake package" even
+    though `hipcc` is on PATH.
 - **CUDA** — `cuda-toolkit` (Fedora/Debian via NVIDIA's repo)
 - **Vulkan** — see [Vulkan section in README](../README.md#vulkan)
 

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -184,6 +184,72 @@ host_rocm_prefix() {
     return 1
 }
 
+# Echo every prefix that could hold a ROCm install, one per line. There
+# is no single answer and the consumers disagree: llama.cpp's
+# ggml-hip/CMakeLists.txt takes $ROCM_PATH, else /opt/rocm, else /usr;
+# the builder (internal/builder/builder.go) derives ROCM_PATH from the
+# directory holding hipconfig; and Debian/Ubuntu register /opt/rocm
+# through update-alternatives while the files themselves live under
+# /usr. Checking only one prefix is how a host with a complete toolchain
+# gets told its SDK is missing — probe all of them.
+host_rocm_prefix_candidates() {
+    local -a out=()
+    local p tool
+    [[ -n "${ROCM_PATH:-}" ]] && out+=("${ROCM_PATH}")
+    if p="$(host_rocm_prefix 2>/dev/null)"; then
+        out+=("$p")
+    fi
+    for tool in hipconfig hipcc; do
+        if p="$(host_find_rocm_tool "$tool")"; then
+            out+=("$(dirname "$(dirname "$p")")")
+        fi
+    done
+    out+=(/opt/rocm /usr)
+    printf '%s\n' "${out[@]}" | awk 'NF && !seen[$0]++'
+}
+
+# Whether one ROCm cmake config package is on disk somewhere cmake will
+# look. Three library layouts are in play and they are not
+# interchangeable: AMD's own (<prefix>/lib/cmake/<pkg>), Fedora's
+# (<prefix>/lib64/cmake/<pkg>) and Debian multiarch
+# (<prefix>/lib/x86_64-linux-gnu/cmake/<pkg>) — the last is the one
+# CMakeDetermineHIPCompiler reports in its "expected at one of" error.
+host_rocm_have_cmake_pkg() {
+    local pkg="$1" prefix
+    while read -r prefix; do
+        [[ -n "$prefix" ]] || continue
+        if compgen -G "${prefix}/lib/cmake/${pkg}/${pkg}-config.cmake" >/dev/null 2>&1; then
+            return 0
+        fi
+        if compgen -G "${prefix}/lib64/cmake/${pkg}/${pkg}-config.cmake" >/dev/null 2>&1; then
+            return 0
+        fi
+        if compgen -G "${prefix}/lib/*/cmake/${pkg}/${pkg}-config.cmake" >/dev/null 2>&1; then
+            return 0
+        fi
+    done < <(host_rocm_prefix_candidates)
+    return 1
+}
+
+# The cmake config packages llama.cpp's HIP backend needs, in the order
+# it asks for them. hip-lang is first because enable_language(HIP) — the
+# very first thing ggml-hip does — fails on its absence, and it is the
+# one a "hipcc is installed, so ROCm is fine" check misses: on
+# Debian/Ubuntu hipcc and hip-lang-config.cmake ship in different
+# packages (hipcc vs libamdhip64-dev).
+HOST_ROCM_CMAKE_PKGS=(hip-lang hip rocblas hipblas)
+
+# Echo the cmake config packages that are absent; empty when the host can
+# compile the HIP backend.
+host_rocm_missing_cmake_pkgs() {
+    local pkg
+    local -a absent=()
+    for pkg in "${HOST_ROCM_CMAKE_PKGS[@]}"; do
+        host_rocm_have_cmake_pkg "$pkg" || absent+=("$pkg")
+    done
+    echo "${absent[*]}"
+}
+
 # Whether the host already has everything llama.cpp's HIP backend needs to
 # compile, regardless of how it got there. Package names for ROCm differ
 # between AMD's own repo, Debian/Ubuntu's native packaging, and source or
@@ -194,21 +260,32 @@ host_rocm_prefix() {
 # optional accelerations, not build blockers.
 host_rocm_sdk_usable() {
     host_find_rocm_tool hipcc >/dev/null 2>&1 || return 1
-    local prefix
-    prefix="$(host_rocm_prefix)" || return 1
-    local lib
-    for lib in hip rocblas hipblas; do
-        compgen -G "${prefix}/lib*/cmake/${lib}/${lib}-config.cmake" >/dev/null 2>&1 || return 1
-    done
-    return 0
+    [[ -z "$(host_rocm_missing_cmake_pkgs)" ]]
 }
 
 # Whether an apt package name resolves to something installable. Used to
 # choose between naming schemes rather than emitting a name apt will
 # reject. A package present in the index but with no candidate version
 # (Candidate: (none)) does not count.
+#
+# Deliberately not a pipeline: under `set -o pipefail`, `apt-cache policy
+# | grep -q` reports failure whenever grep short-circuits on the match
+# and apt-cache dies of SIGPIPE, or whenever apt-cache exits non-zero
+# over an unrelated sources.list complaint. Either one makes every
+# package look unavailable, which is how a host that carries the whole
+# ROCm stack in `universe` ends up being handed AMD's package names.
 host_apt_pkg_available() {
-    LC_ALL=C apt-cache policy "$1" 2>/dev/null | grep -q '^ *Candidate: [^(]'
+    local policy
+    policy="$(LC_ALL=C apt-cache policy "$1" 2>/dev/null)" || true
+    grep -q '^[[:space:]]*Candidate:[[:space:]]*[^([:space:]]' <<<"$policy"
+}
+
+# Whether a package is installed, as opposed to merely known to dpkg.
+# `dpkg -s` exits 0 for a removed-but-not-purged package (Status:
+# deinstall ok config-files), which would have us skip installing
+# something that isn't there.
+host_dpkg_installed() {
+    [[ "$(dpkg-query -W -f='${db:Status-Status}' "$1" 2>/dev/null)" == "installed" ]]
 }
 
 # Pick the apt package name to use for one ROCm component. Candidates are
@@ -223,7 +300,7 @@ host_apt_pkg_available() {
 host_apt_rocm_pkg() {
     local pkg
     for pkg in "$@"; do
-        if dpkg -s "$pkg" >/dev/null 2>&1; then
+        if host_dpkg_installed "$pkg"; then
             return 0
         fi
     done
@@ -256,7 +333,19 @@ host_rocm_apt_repo_configured() {
 # anything else means the distro's own packaging.
 host_rocm_prefer_amd_packages() {
     host_rocm_apt_repo_configured && return 0
-    [[ -d /opt/rocm ]] && return 0
+    # An /opt/rocm made of symlinks into /usr is Debian/Ubuntu's own
+    # packaging, not AMD's: the distro registers /opt/rocm through
+    # update-alternatives so software that hardcodes the path still
+    # works, while the files live in /usr. Treating that as "AMD is
+    # installed here" picks AMD's package names on a host whose repos
+    # only carry the distro's — every name then fails to resolve and
+    # apt-get aborts without installing anything (issue #142).
+    if [[ -d /opt/rocm ]]; then
+        local libdir
+        libdir="$(readlink -f /opt/rocm/lib 2>/dev/null || true)"
+        [[ "$libdir" == /usr/* ]] && return 1
+        return 0
+    fi
     return 1
 }
 
@@ -439,9 +528,16 @@ host_missing_gpu_sdk_packages() {
                     # locate package" on distro-packaged hosts.
                     local candidates pkg_choice
                     local -a unresolved=() components=()
+                    #
+                    # hipcc-rocm is listed as an alternative to hipcc, not
+                    # a preference: both ship /usr/bin/hipcc and conflict,
+                    # so on a host that already has one, naming the other
+                    # makes apt swap a working compiler for an identical
+                    # one. Installing fresh still picks hipcc — that is the
+                    # package that pulls the matching clang and device libs.
                     if host_rocm_prefer_amd_packages; then
                         components=(
-                            "hipcc"
+                            "hipcc hipcc-rocm"
                             "rocm-hip-runtime-dev libamdhip64-dev"
                             "rocblas-dev librocblas-dev"
                             "hipblas-dev libhipblas-dev"
@@ -449,7 +545,7 @@ host_missing_gpu_sdk_packages() {
                         )
                     else
                         components=(
-                            "hipcc"
+                            "hipcc hipcc-rocm"
                             "libamdhip64-dev rocm-hip-runtime-dev"
                             "librocblas-dev rocblas-dev"
                             "libhipblas-dev hipblas-dev"
@@ -681,14 +777,46 @@ host_install_gpu_sdk() {
                     missing="$(host_missing_gpu_sdk_packages "$backend")"
                 fi
             fi
-            log "Run: sudo apt-get install $missing"
-            if [[ "$backend" == "cuda" ]]; then
-                log "Note: CUDA toolkit comes from NVIDIA's apt repo, not the distro default. See:"
-                echo "    https://developer.nvidia.com/cuda-downloads?target_os=Linux"
+            # apt-get install is all-or-nothing: a single name it can't
+            # locate aborts the run and installs none of the others. Split
+            # the list so the resolvable packages still land, and say
+            # plainly what no configured repo carries.
+            local pkg
+            local -a apt_pkgs=() apt_unknown=()
+            # shellcheck disable=SC2086  # $missing is a space-separated list
+            for pkg in $missing; do
+                if host_apt_pkg_available "$pkg"; then
+                    apt_pkgs+=("$pkg")
+                else
+                    apt_unknown+=("$pkg")
+                fi
+            done
+            if [[ ${#apt_unknown[@]} -gt 0 ]]; then
+                warn "No configured apt repo carries: ${apt_unknown[*]}"
+                case "$backend" in
+                    cuda)
+                        log "The CUDA toolkit comes from NVIDIA's apt repo, not the distro default. See:"
+                        echo "    https://developer.nvidia.com/cuda-downloads?target_os=Linux"
+                        ;;
+                    rocm)
+                        log "Refresh the index and make sure the component carrying ROCm is enabled:"
+                        echo "    sudo apt-get update"
+                        echo "    sudo add-apt-repository universe   # Ubuntu ships ROCm in universe"
+                        log "Or add AMD's own repo, if they publish for this release:"
+                        echo "    https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html"
+                        ;;
+                    *)
+                        log "Refresh the package index and try again: sudo apt-get update"
+                        ;;
+                esac
             fi
+            if [[ ${#apt_pkgs[@]} -eq 0 ]]; then
+                warn "Nothing installable left — the first llama.cpp build with the $backend profile will fail."
+                return 1
+            fi
+            log "Run: sudo apt-get install ${apt_pkgs[*]}"
             if prompt_confirm "Install now?"; then
-                # shellcheck disable=SC2086
-                sudo apt-get install -y $missing || return 1
+                sudo apt-get install -y "${apt_pkgs[@]}" || return 1
                 ok "$backend SDK packages installed"
             else
                 warn "Skipped — first llama.cpp build with the $backend profile will fail until these are installed."
@@ -702,7 +830,29 @@ host_install_gpu_sdk() {
     esac
     host_warn_cuda_offpath "$backend"
     host_warn_cuda_version_for_gpu "$backend"
+    host_verify_rocm_buildable "$backend"
     host_offer_rocm_optional "$backend"
+    return 0
+}
+
+# Re-probe after installing, and say so when the host still can't compile
+# the HIP backend. Package names resolving is not the same as a usable
+# toolchain: a host can end up with hipcc and no hip-lang-config.cmake,
+# and the only sign of it is cmake failing several minutes into the first
+# build from the UI. Report it here instead.
+host_verify_rocm_buildable() {
+    [[ "$1" == "rocm" ]] || return 0
+    local absent
+    absent="$(host_rocm_missing_cmake_pkgs)"
+    [[ -n "$absent" ]] || return 0
+    warn "ROCm is still not buildable: no cmake config for ${absent}"
+    log "llama.cpp's HIP backend resolves these via find_package(); without"
+    log "them the build fails at 'does not contain the HIP runtime CMake package'."
+    case "$DISTRO_FAMILY" in
+        debian) log "On Debian/Ubuntu they ship in: libamdhip64-dev librocblas-dev libhipblas-dev" ;;
+        fedora) log "On Fedora they ship in: rocm-hip-devel rocblas-devel hipblas-devel" ;;
+    esac
+    log "Searched: $(host_rocm_prefix_candidates | tr '\n' ' ')"
     return 0
 }
 


### PR DESCRIPTION
Fixes #142. Three bugs kept the reporter from ever compiling llama.cpp against ROCm on Ubuntu, and one hard limit remains that the tooling now reports instead of hiding.

Everything below was verified against a fresh Ubuntu 24.04 distrobox container carrying the reporter's exact package set (`hipcc libamdhip64-dev librocblas-dev libhipblas-dev rocm-cmake`), plus a real Fedora ROCm 7.1 host.

## 1. setup.sh installed the wrong package names, then nothing at all

**`/opt/rocm` was read as proof of AMD's packaging.** On Ubuntu that `/opt/rocm` is the *distro's* — registered through update-alternatives with the files under `/usr`. So the script asked apt for `rocm-hip-runtime-dev rocblas-dev hipblas-dev`, which no configured repo carries. `apt-get install` is all-or-nothing, so those three names aborted the run and `hipcc`/`rocm-cmake` — which apt could resolve — never got installed either.

**The usable-SDK probe couldn't see the blocker.** It checked `<prefix>/lib*/cmake/{hip,rocblas,hipblas}` under a single prefix: no `hip-lang` (what `enable_language(HIP)` resolves), and no Debian multiarch `lib/x86_64-linux-gnu/cmake`. On Debian/Ubuntu `hipcc` and `hip-lang-config.cmake` ship in *different* packages, so "hipcc is on PATH" reported a healthy SDK on a host that cannot compile.

**`host_apt_pkg_available` was a pipeline under `pipefail`.** `apt-cache policy | grep -q` reports failure when apt-cache dies of SIGPIPE on grep's short-circuit, or exits non-zero over an unrelated sources complaint — making *every* package look unavailable, which is what sent name resolution to AMD's spelling in the first place.

## 2. cmake couldn't identify a HIP compiler, so it never looked where the config was

With the packages installed by hand, the build still died — and the container reproduces it byte-for-byte, same cmake line number and all:

```
-- The HIP compiler identification is unknown
CMake Error at /usr/share/cmake-3.28/Modules/CMakeDetermineHIPCompiler.cmake:217 (message):
  The ROCm root directory: /usr
  does not contain the HIP runtime CMake package, expected at one of:
   /usr/lib/cmake/hip-lang/hip-lang-config.cmake
   /usr/lib64/cmake/hip-lang/hip-lang-config.cmake
```

— while the file sat at `/usr/lib/x86_64-linux-gnu/cmake/hip-lang/hip-lang-config.cmake`. From `CMakeDetermineHIPCompiler.cmake`: cmake asks `hipconfig --hipclangpath` (which names a directory with no `clang++` in it), falls back to a bare `clang++` on PATH (Ubuntu only installs the versioned `/usr/lib/llvm-17/bin/clang++`), fails to identify a compiler — and `CMAKE_HIP_LIBRARY_ARCHITECTURE` is parsed *from that identification's output*, so the multiarch directory is never added to the search list. The missing path in the error is a symptom, not the cause.

Fix: locate a HIP-capable `clang++` and pass `-DCMAKE_HIP_COMPILER`, as the cuda profile already pins nvcc. Prefer what hipconfig reports, then the ROCm roots, then a distro clang — but only one with the AMD device bitcode beside it, since Debian packages those per LLVM version (`rocm-device-libs-17` → `/usr/lib/llvm-17/lib/clang/17/amdgcn/bitcode`) and the newest clang on the box is regularly the wrong one.

## 3. Our own `ROCM_PATH=/usr` was breaking clang

Pinning the compiler alone did **not** fix it — the container failed identically, and the configure log gave the reason:

```
Found HIP installation: /usr, version 5.7.31921
clang++: error: cannot find ROCm device library; provide its path via '--rocm-path'
or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library
```

Exporting `ROCM_PATH=/usr` — which the builder did on every ROCm host — makes clang treat `/usr` as a self-contained ROCm and hunt for device bitcode at `/usr/amdgcn/bitcode`. Debian and Fedora ship it beside the compiler instead. Arch and AMD's `/opt/rocm` installs genuinely need `ROCM_PATH`, so it stays for those; when ROCm lives in `/usr`, cmake gets `-DCMAKE_HIP_COMPILER_ROCM_ROOT` instead, which costs clang nothing.

## 4. What remains, now reported instead of hidden

With all of the above, the container gets through `enable_language(HIP)` and `find_package(hip)` and stops on llama.cpp's own gate:

```
CMake Error at ggml/src/ggml-hip/CMakeLists.txt:55 (message):
  At least ROCM/HIP V6.1 is required
```

**Ubuntu 24.04 packages ROCm 5.7.** No arrangement of dev packages can build llama.cpp there, and clang 17 rejects `gfx1201` (RDNA4) outright. That needs AMD's ROCm repo or a release shipping 7.x. setup.sh now checks the version floor and says so, rather than leaving it to a git clone and a cmake run to discover.

## 5. A bonus, found while verifying in containers

A *successful* configure still carried:

```
Could NOT find OpenSSL ... (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR)
OpenSSL not found, HTTPS support disabled
```

`LLAMA_OPENSSL` defaults ON and llama.cpp's HTTP client (`common/http.h`, `tools/server`) uses it, so without the headers the server we build silently can't speak HTTPS. Neither a fresh 24.04 nor a fresh 26.04 has them; this Fedora workstation does, which is why it never showed up locally. Added `libssl-dev`/`openssl-devel` to the package's build-toolchain dependencies and to the `deps --host` report (as a warning — the build completes, just degraded).

## Verification

Two containers — Ubuntu 24.04 (ROCm 5.7, cmake 3.28) and Ubuntu 26.04 (ROCm 7.1, cmake 4.2) — plus a Fedora ROCm 7.1 host.

| check | result |
|---|---|
| Reporter's failure reproduced on 24.04 | byte-for-byte, same cmake line |
| Pre-fix on 26.04 | also fails — compiler found but `broken`, identification unknown |
| **Post-fix on 26.04, real llama.cpp, `GPU_TARGETS=gfx1201`** | **configures cleanly, `-- Including HIP backend`, exit 0** |
| Post-fix on 24.04, bare `/usr` and `/opt/rocm` alternatives layouts | both configure through to llama.cpp's version gate |
| Go detection run *inside* each container | 24.04 → `/usr/lib/llvm-17/bin/clang++`; 26.04 → `/usr/lib/llvm-21/bin/clang++` |
| Fedora ROCm 7.1 host | same recipe configures cleanly; version check silent; `deps --host` still `rocm OK` |
| Version floor warning | fires on 24.04 (5.7), silent on 26.04 and Fedora (7.1) |
| OpenSSL report | warns on both fresh containers, `OK` after `libssl-dev`, and the configure then finds OpenSSL 3.5.5 |

Note the 26.04 pre-fix failure differs from 24.04: there `hipconfig` *does* name a real clang, so cmake finds one — but `ROCM_PATH=/usr` still breaks its device-library lookup, giving `Check for working HIP compiler ... broken`. Same root cause, different surface.

Package selection, simulated in a mount namespace with the reporter's layout:

| | before | after |
|---|---|---|
| prefer AMD names | yes | **no** |
| sdk usable | **yes** (wrong) | no |
| missing packages | `hipcc rocm-hip-runtime-dev rocblas-dev hipblas-dev rocm-cmake` | `hipcc libamdhip64-dev librocblas-dev libhipblas-dev rocm-cmake` |

Plus unit tests for the device-libs pairing (clang-17-with-bitcode beats clang-18-without), highest-version-wins, root precedence, and the extra-cmake-flags override. Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go9An1JPRDAuj8nVYwpXLZ
