### PR TITLE
fix(builder): make the ROCm host build actually compile on Debian/Ubuntu

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,6 +79,11 @@ nfpms:
           - git
           - gcc-c++
           - make
+          # llama.cpp's LLAMA_OPENSSL defaults ON and its HTTPS client
+          # (common/http.h, tools/server) needs the headers. Without them
+          # cmake only warns, and the server it builds silently cannot
+          # speak HTTPS.
+          - openssl-devel
       deb:
         dependencies:
           - cmake
@@ -86,6 +91,8 @@ nfpms:
           - git
           - build-essential
           - pkg-config
+          # See openssl-devel above.
+          - libssl-dev
     # No BLAS recommend: the CPU build profile doesn't pass -DGGML_BLAS=ON
     # and GPU builds (cuda/rocm/vulkan/metal) don't use BLAS at all, so
     # pulling in openblas-devel/libopenblas-dev would just waste ~270 MiB

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -470,24 +470,46 @@ func (b *Builder) runBuild(ctx context.Context, prof BuildProfile, srcDir string
 			binDir := filepath.Dir(tool)
 			buildEnv = prependPath(buildEnv, binDir)
 			root := filepath.Dir(binDir)
-			buildEnv = setEnvDefault(buildEnv, "ROCM_PATH", root)
-			buildEnv = setEnvDefault(buildEnv, "HIP_PATH", root)
-			if devlib := filepath.Join(root, "amdgcn", "bitcode"); dirExists(devlib) {
-				buildEnv = setEnvDefault(buildEnv, "HIP_DEVICE_LIB_PATH", devlib)
+
+			// Two ROCm layouts, and what helps one breaks the other.
+			//
+			// Arch-family (and AMD's own) install a self-contained ROCm
+			// under /opt/rocm whose clang lives at <root>/lib/llvm/bin;
+			// that clang can't locate its own ROCm and needs ROCM_PATH to
+			// find it. Debian/Ubuntu and Fedora instead spread ROCm across
+			// /usr, and there ROCM_PATH=/usr is actively harmful: clang
+			// takes it as the ROCm root and looks for the device bitcode
+			// at /usr/amdgcn/bitcode, while the distro ships it beside the
+			// compiler in /usr/lib/llvm-N/lib/clang/N/amdgcn/bitcode. It
+			// then fails with "cannot find ROCm device library", which
+			// surfaces as "The HIP compiler identification is unknown" —
+			// and since cmake derives CMAKE_HIP_LIBRARY_ARCHITECTURE from
+			// that identification, it also stops searching the multiarch
+			// directory holding hip-lang-config.cmake and dies on "does
+			// not contain the HIP runtime CMake package" with the config
+			// sitting right there.
+			//
+			// So: point cmake at the root with a cache variable, which
+			// costs clang nothing, and only export ROCM_PATH for the
+			// layout that actually needs it.
+			if root == "/usr" {
+				if !hasCMakeArg(cmakeArgs, "CMAKE_HIP_COMPILER_ROCM_ROOT") {
+					cmakeArgs = append(cmakeArgs, "-DCMAKE_HIP_COMPILER_ROCM_ROOT="+root)
+				}
+			} else {
+				buildEnv = setEnvDefault(buildEnv, "ROCM_PATH", root)
+				buildEnv = setEnvDefault(buildEnv, "HIP_PATH", root)
+				if devlib := filepath.Join(root, "amdgcn", "bitcode"); dirExists(devlib) {
+					buildEnv = setEnvDefault(buildEnv, "HIP_DEVICE_LIB_PATH", devlib)
+				}
 			}
 		}
-		// cmake's enable_language(HIP) asks `hipconfig --hipclangpath` where
-		// the HIP clang lives and otherwise falls back to a bare "clang++" on
-		// PATH. On Debian/Ubuntu neither answer lands: hipconfig points at a
-		// directory that doesn't exist, and the clang HIP needs is installed
-		// as the versioned /usr/lib/llvm-N/bin/clang++ with no unversioned
-		// symlink. cmake then reports "The HIP compiler identification is
-		// unknown", and — because it derives CMAKE_HIP_LIBRARY_ARCHITECTURE
-		// from that identification — stops searching the multiarch directory
-		// where the distro put hip-lang-config.cmake. The build dies on
-		// "does not contain the HIP runtime CMake package" with the config
-		// sitting right there. Pin the compiler ourselves, exactly as the
-		// cuda profile pins nvcc below.
+		// cmake asks `hipconfig --hipclangpath` for the HIP clang and
+		// otherwise falls back to a bare "clang++" on PATH. On Debian/Ubuntu
+		// neither answer lands: hipconfig names a directory with no clang++
+		// in it, and the clang HIP needs is installed as the versioned
+		// /usr/lib/llvm-N/bin/clang++ with no unversioned symlink. Pin it
+		// ourselves, exactly as the cuda profile pins nvcc below.
 		if !hasCMakeArg(cmakeArgs, "CMAKE_HIP_COMPILER") {
 			if hipcc := findHIPCompiler(buildEnv); hipcc != "" {
 				cmakeArgs = append(cmakeArgs, "-DCMAKE_HIP_COMPILER="+hipcc)

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -476,6 +476,24 @@ func (b *Builder) runBuild(ctx context.Context, prof BuildProfile, srcDir string
 				buildEnv = setEnvDefault(buildEnv, "HIP_DEVICE_LIB_PATH", devlib)
 			}
 		}
+		// cmake's enable_language(HIP) asks `hipconfig --hipclangpath` where
+		// the HIP clang lives and otherwise falls back to a bare "clang++" on
+		// PATH. On Debian/Ubuntu neither answer lands: hipconfig points at a
+		// directory that doesn't exist, and the clang HIP needs is installed
+		// as the versioned /usr/lib/llvm-N/bin/clang++ with no unversioned
+		// symlink. cmake then reports "The HIP compiler identification is
+		// unknown", and — because it derives CMAKE_HIP_LIBRARY_ARCHITECTURE
+		// from that identification — stops searching the multiarch directory
+		// where the distro put hip-lang-config.cmake. The build dies on
+		// "does not contain the HIP runtime CMake package" with the config
+		// sitting right there. Pin the compiler ourselves, exactly as the
+		// cuda profile pins nvcc below.
+		if !hasCMakeArg(cmakeArgs, "CMAKE_HIP_COMPILER") {
+			if hipcc := findHIPCompiler(buildEnv); hipcc != "" {
+				cmakeArgs = append(cmakeArgs, "-DCMAKE_HIP_COMPILER="+hipcc)
+				sendLog(fmt.Sprintf("==> Using HIP compiler at %s", hipcc))
+			}
+		}
 	}
 	if prof.Backend == "cuda" {
 		if nvcc, dir := findNVCC(); nvcc != "" {
@@ -1026,6 +1044,128 @@ func findNVCC() (string, string) {
 	return "", ""
 }
 
+// hasCMakeArg reports whether -D<name>=... was already supplied, so a
+// user-provided value in the build's extra cmake flags wins over ours.
+func hasCMakeArg(args []string, name string) bool {
+	prefix := "-D" + name + "="
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// findHIPCompiler locates a clang++ that can compile HIP device code, for
+// cmake's CMAKE_HIP_COMPILER. Returns "" when nothing suitable is found,
+// leaving cmake to its own search.
+//
+// Order matters. A ROCm install that ships its own llvm knows best, so ask
+// hipconfig first and then look in the usual ROCm roots. Only then fall
+// back to a distro-packaged clang, and only one that actually has the
+// AMD device bitcode beside it: on Debian/Ubuntu the ROCm device libs are
+// packaged per-LLVM-version (rocm-device-libs-17 installs into
+// /usr/lib/llvm-17/lib/clang/17/amdgcn/bitcode), so the newest clang on
+// the system is often the wrong one. Pairing on the bitcode picks the
+// clang the distro actually built its HIP stack against.
+func findHIPCompiler(env []string) string {
+	if p := hipconfigClangPath(env); p != "" {
+		return p
+	}
+	var roots []string
+	if rp := envValue(env, "ROCM_PATH"); rp != "" {
+		roots = append(roots, rp)
+	}
+	roots = append(roots, "/opt/rocm", "/usr/lib/rocm", "/usr/lib64/rocm")
+	if c := hipClangInRoots(roots); c != "" {
+		return c
+	}
+	return newestDistroHIPClang("/usr/lib")
+}
+
+// hipClangInRoots returns the first <root>/llvm/bin/clang++ that exists.
+func hipClangInRoots(roots []string) string {
+	for _, r := range roots {
+		if c := filepath.Join(r, "llvm", "bin", "clang++"); isExecutable(c) {
+			return c
+		}
+	}
+	return ""
+}
+
+// hipconfigClangPath asks hipconfig where the HIP clang is and returns
+// <path>/clang++ if that file exists. Empty when hipconfig is missing,
+// fails, or names a directory that isn't there — which is the common case
+// on Debian/Ubuntu and the reason this whole function exists.
+func hipconfigClangPath(env []string) string {
+	tool := FindROCmTool("hipconfig")
+	if tool == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, tool, "--hipclangpath")
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return ""
+	}
+	if c := filepath.Join(dir, "clang++"); isExecutable(c) {
+		return c
+	}
+	return ""
+}
+
+// newestDistroHIPClang returns the highest-versioned
+// <libDir>/llvm-N/bin/clang++ that has AMD device bitcode installed
+// alongside it, or "" if none does.
+func newestDistroHIPClang(libDir string) string {
+	matches, err := filepath.Glob(filepath.Join(libDir, "llvm-*", "bin", "clang++"))
+	if err != nil {
+		return ""
+	}
+	best, bestVer := "", -1
+	for _, m := range matches {
+		if !isExecutable(m) {
+			continue
+		}
+		llvmRoot := filepath.Dir(filepath.Dir(m))
+		bitcode, err := filepath.Glob(filepath.Join(llvmRoot, "lib", "clang", "*", "amdgcn", "bitcode"))
+		if err != nil || len(bitcode) == 0 {
+			continue
+		}
+		ver, err := strconv.Atoi(strings.TrimPrefix(filepath.Base(llvmRoot), "llvm-"))
+		if err != nil {
+			continue
+		}
+		if ver > bestVer {
+			best, bestVer = m, ver
+		}
+	}
+	return best
+}
+
+// isExecutable reports whether path is a regular file with an execute bit.
+func isExecutable(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir() && st.Mode()&0o111 != 0
+}
+
+// envValue returns the value of KEY in a KEY=value environment slice.
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return strings.TrimPrefix(kv, prefix)
+		}
+	}
+	return ""
+}
+
 // setEnvDefault returns env with KEY=value appended unless KEY is
 // already present — an inherited value stays authoritative.
 func setEnvDefault(env []string, key, value string) []string {
@@ -1066,4 +1206,3 @@ func prependPath(env []string, dir string) []string {
 	}
 	return out
 }
-

--- a/internal/builder/hip_compiler_test.go
+++ b/internal/builder/hip_compiler_test.go
@@ -1,0 +1,112 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mkclang creates an executable stub at path, plus its parent dirs.
+func mkclang(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Debian/Ubuntu package the ROCm device libs per LLVM version
+// (rocm-device-libs-17 -> /usr/lib/llvm-17/lib/clang/17/amdgcn/bitcode),
+// so the newest clang on the box is regularly the wrong one to hand cmake.
+// Pair on the bitcode, not on the version number alone.
+func TestNewestDistroHIPClangSkipsClangWithoutDeviceLibs(t *testing.T) {
+	lib := t.TempDir()
+	mkclang(t, filepath.Join(lib, "llvm-17", "bin", "clang++"))
+	if err := os.MkdirAll(filepath.Join(lib, "llvm-17", "lib", "clang", "17", "amdgcn", "bitcode"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Newer, but no device libs — this is the trap.
+	mkclang(t, filepath.Join(lib, "llvm-21", "bin", "clang++"))
+
+	got := newestDistroHIPClang(lib)
+	want := filepath.Join(lib, "llvm-17", "bin", "clang++")
+	if got != want {
+		t.Errorf("newestDistroHIPClang() = %q, want %q", got, want)
+	}
+}
+
+func TestNewestDistroHIPClangPrefersHighestWithDeviceLibs(t *testing.T) {
+	lib := t.TempDir()
+	for _, v := range []string{"17", "21"} {
+		mkclang(t, filepath.Join(lib, "llvm-"+v, "bin", "clang++"))
+		if err := os.MkdirAll(filepath.Join(lib, "llvm-"+v, "lib", "clang", v, "amdgcn", "bitcode"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := newestDistroHIPClang(lib)
+	want := filepath.Join(lib, "llvm-21", "bin", "clang++")
+	if got != want {
+		t.Errorf("newestDistroHIPClang() = %q, want %q", got, want)
+	}
+}
+
+func TestNewestDistroHIPClangEmptyWhenNoneUsable(t *testing.T) {
+	lib := t.TempDir()
+	mkclang(t, filepath.Join(lib, "llvm-21", "bin", "clang++"))
+	if got := newestDistroHIPClang(lib); got != "" {
+		t.Errorf("newestDistroHIPClang() = %q, want \"\" (no device libs anywhere)", got)
+	}
+}
+
+// A ROCm install that ships its own llvm is authoritative; the roots are
+// consulted in order so $ROCM_PATH beats the fallback locations.
+func TestHIPClangInRootsUsesFirstMatch(t *testing.T) {
+	dir := t.TempDir()
+	rocmPath := filepath.Join(dir, "rocm")
+	optRocm := filepath.Join(dir, "opt-rocm")
+	mkclang(t, filepath.Join(optRocm, "llvm", "bin", "clang++"))
+
+	// $ROCM_PATH has no llvm of its own — fall through to the next root.
+	if got, want := hipClangInRoots([]string{rocmPath, optRocm}), filepath.Join(optRocm, "llvm", "bin", "clang++"); got != want {
+		t.Errorf("hipClangInRoots() = %q, want %q", got, want)
+	}
+
+	mkclang(t, filepath.Join(rocmPath, "llvm", "bin", "clang++"))
+	if got, want := hipClangInRoots([]string{rocmPath, optRocm}), filepath.Join(rocmPath, "llvm", "bin", "clang++"); got != want {
+		t.Errorf("hipClangInRoots() = %q, want %q (first root wins)", got, want)
+	}
+}
+
+func TestHIPClangInRootsEmptyWhenAbsent(t *testing.T) {
+	if got := hipClangInRoots([]string{t.TempDir()}); got != "" {
+		t.Errorf("hipClangInRoots() = %q, want \"\"", got)
+	}
+}
+
+// An explicit -DCMAKE_HIP_COMPILER in the build's extra cmake flags must
+// win over anything we detect.
+func TestHasCMakeArg(t *testing.T) {
+	args := []string{"..", "-G", "Ninja", "-DGGML_HIP=ON", "-DCMAKE_HIP_COMPILER=/custom/clang++"}
+	if !hasCMakeArg(args, "CMAKE_HIP_COMPILER") {
+		t.Error("hasCMakeArg did not see an explicit CMAKE_HIP_COMPILER")
+	}
+	if hasCMakeArg(args, "CMAKE_CUDA_COMPILER") {
+		t.Error("hasCMakeArg matched a flag that isn't present")
+	}
+	// Prefix-only matches must not count.
+	if hasCMakeArg([]string{"-DCMAKE_HIP_COMPILER_LAUNCHER=ccache"}, "CMAKE_HIP_COMPILER") {
+		t.Error("hasCMakeArg matched CMAKE_HIP_COMPILER_LAUNCHER as CMAKE_HIP_COMPILER")
+	}
+}
+
+func TestEnvValue(t *testing.T) {
+	env := []string{"PATH=/usr/bin", "ROCM_PATH=/opt/rocm", "HIP_PATH=/opt/rocm"}
+	if got := envValue(env, "ROCM_PATH"); got != "/opt/rocm" {
+		t.Errorf("envValue(ROCM_PATH) = %q, want /opt/rocm", got)
+	}
+	if got := envValue(env, "MISSING"); got != "" {
+		t.Errorf("envValue(MISSING) = %q, want \"\"", got)
+	}
+}

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -231,6 +231,45 @@ host_rocm_have_cmake_pkg() {
     return 1
 }
 
+# Echo the clang++ that can compile HIP device code, or nothing. Mirrors
+# findHIPCompiler in internal/builder/builder.go so setup.sh and the
+# builder agree on what counts as a usable HIP compiler. Ask hipconfig
+# first (a ROCm that ships its own llvm knows best), then the usual ROCm
+# roots, then a distro clang — but only one with the AMD device bitcode
+# beside it, since Debian/Ubuntu package those per LLVM version and the
+# newest clang on the box is regularly the wrong one.
+host_find_hip_clang() {
+    local hipconfig dir root
+    if hipconfig="$(host_find_rocm_tool hipconfig)"; then
+        dir="$("$hipconfig" --hipclangpath 2>/dev/null)" || dir=""
+        if [[ -n "$dir" && -x "${dir}/clang++" ]]; then
+            echo "${dir}/clang++"
+            return 0
+        fi
+    fi
+    for root in "${ROCM_PATH:-}" /opt/rocm /usr/lib/rocm /usr/lib64/rocm; do
+        [[ -n "$root" ]] || continue
+        if [[ -x "${root}/llvm/bin/clang++" ]]; then
+            echo "${root}/llvm/bin/clang++"
+            return 0
+        fi
+    done
+    local best="" best_ver=-1 candidate ver
+    for candidate in /usr/lib/llvm-*/bin/clang++; do
+        [[ -x "$candidate" ]] || continue
+        root="$(dirname "$(dirname "$candidate")")"
+        compgen -G "${root}/lib/clang/*/amdgcn/bitcode" >/dev/null 2>&1 || continue
+        ver="${root##*/llvm-}"
+        [[ "$ver" =~ ^[0-9]+$ ]] || continue
+        if (( ver > best_ver )); then
+            best="$candidate"
+            best_ver="$ver"
+        fi
+    done
+    [[ -n "$best" ]] || return 1
+    echo "$best"
+}
+
 # The cmake config packages llama.cpp's HIP backend needs, in the order
 # it asks for them. hip-lang is first because enable_language(HIP) — the
 # very first thing ggml-hip does — fails on its absence, and it is the
@@ -842,6 +881,19 @@ host_install_gpu_sdk() {
 # build from the UI. Report it here instead.
 host_verify_rocm_buildable() {
     [[ "$1" == "rocm" ]] || return 0
+    # enable_language(HIP) needs a clang that can target amdgcn. cmake asks
+    # hipconfig where it is and otherwise looks for a bare "clang++" on
+    # PATH; on Debian/Ubuntu neither lands, because the HIP clang installs
+    # as /usr/lib/llvm-N/bin/clang++ with no unversioned symlink. The
+    # builder passes -DCMAKE_HIP_COMPILER when it can find one — say so
+    # here when it can't, since nothing else will.
+    if ! host_find_hip_clang >/dev/null; then
+        warn "No HIP-capable clang++ found — llama.cpp's ROCm build needs one."
+        case "$DISTRO_FAMILY" in
+            debian) log "On Debian/Ubuntu it comes with hipcc (which pulls the matching clang-N and rocm-device-libs-N)." ;;
+            fedora) log "On Fedora it ships in rocm-llvm, at /usr/lib64/rocm/llvm/bin/clang++." ;;
+        esac
+    fi
     local absent
     absent="$(host_rocm_missing_cmake_pkgs)"
     [[ -n "$absent" ]] || return 0

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -84,9 +84,9 @@ host_check_build_toolchain() {
         warn "Missing build prerequisites: ${missing[*]}"
         log "These are needed to build the llama-toolchest binary and (later) llama.cpp from the UI."
         log "Install via your package manager:"
-        echo "    Debian/Ubuntu:  sudo apt-get install golang cmake ninja-build git build-essential"
-        echo "    Fedora:         sudo dnf install golang cmake ninja-build git gcc-c++ make"
-        echo "    Arch:           sudo pacman -S go cmake ninja git base-devel"
+        echo "    Debian/Ubuntu:  sudo apt-get install golang cmake ninja-build git build-essential libssl-dev"
+        echo "    Fedora:         sudo dnf install golang cmake ninja-build git gcc-c++ make openssl-devel"
+        echo "    Arch:           sudo pacman -S go cmake ninja git base-devel openssl"
         return 1
     fi
     return 0
@@ -1487,6 +1487,20 @@ host_report_toolchain_deps() {
             exit_code=1
         fi
     done
+    # Headers, not a binary — the openssl CLI is installed nearly
+    # everywhere while the dev package usually isn't. llama.cpp's
+    # LLAMA_OPENSSL defaults ON; without these cmake only warns
+    # ("OpenSSL not found, HTTPS support disabled") and the server it
+    # builds can't fetch over HTTPS. Not a build blocker, so this warns
+    # rather than failing the report.
+    if [[ -e /usr/include/openssl/ssl.h ]]; then
+        printf "    %-7s %s\n" "openssl" "OK"
+    else
+        local ssl_pkg="libssl-dev"
+        [[ "$DISTRO_FAMILY" == "fedora" ]] && ssl_pkg="openssl-devel"
+        printf "    %-7s %s\n" "openssl" "missing headers — llama.cpp will build without HTTPS support"
+        printf "            %s %s\n" "$inst_cmd" "$ssl_pkg"
+    fi
     return $exit_code
 }
 

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -270,6 +270,23 @@ host_find_hip_clang() {
     echo "$best"
 }
 
+# llama.cpp's HIP backend hard-fails below this — see the version gate in
+# ggml/src/ggml-hip/CMakeLists.txt ("At least ROCM/HIP V6.1 is required").
+# Worth checking up front: Ubuntu 24.04 packages ROCm 5.7, so a host can
+# have every dev package installed, a working HIP compiler, and still be
+# unable to build.
+HOST_ROCM_MIN_VERSION="6.1"
+
+# Echo the installed ROCm version as major.minor (e.g. "6.4"), or nothing
+# if it can't be determined.
+host_rocm_version() {
+    local hipconfig raw
+    hipconfig="$(host_find_rocm_tool hipconfig)" || return 1
+    raw="$("$hipconfig" --version 2>/dev/null)" || return 1
+    [[ "$raw" =~ ([0-9]+)\.([0-9]+) ]] || return 1
+    echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+}
+
 # The cmake config packages llama.cpp's HIP backend needs, in the order
 # it asks for them. hip-lang is first because enable_language(HIP) — the
 # very first thing ggml-hip does — fails on its absence, and it is the
@@ -892,6 +909,19 @@ host_verify_rocm_buildable() {
         case "$DISTRO_FAMILY" in
             debian) log "On Debian/Ubuntu it comes with hipcc (which pulls the matching clang-N and rocm-device-libs-N)." ;;
             fedora) log "On Fedora it ships in rocm-llvm, at /usr/lib64/rocm/llvm/bin/clang++." ;;
+        esac
+    fi
+    local version
+    if version="$(host_rocm_version)" && ! host_version_ge "$version" "$HOST_ROCM_MIN_VERSION"; then
+        warn "ROCm ${version} is too old — llama.cpp's HIP backend requires ${HOST_ROCM_MIN_VERSION} or newer."
+        log "The build will stop at \"At least ROCM/HIP V6.1 is required\" no matter"
+        log "which dev packages are installed. Recent GPUs need newer still: RDNA4"
+        log "(gfx1201) isn't recognised by compilers before ROCm 6.3."
+        case "$DISTRO_FAMILY" in
+            debian) log "Ubuntu 24.04 packages ROCm 5.7. Either add AMD's ROCm repo:"
+                    echo "    https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html"
+                    log "or move to a release whose own packages are new enough (25.10+ ship 7.x)." ;;
+            fedora) log "Update rocm-hip-devel, or use AMD's repo for a newer release." ;;
         esac
     fi
     local absent


### PR DESCRIPTION
Follow-up to #145, which landed the packaging half of #142 before this half existed. #145 got the right dev packages installed; this makes cmake able to use them. Verified in clean Ubuntu 24.04 and 26.04 containers plus a Fedora ROCm 7.1 host.

## The failure

With every dev package installed by hand, the build still died:

```
-- The HIP compiler identification is unknown
CMake Error at CMakeDetermineHIPCompiler.cmake:217 (message):
  The ROCm root directory: /usr
  does not contain the HIP runtime CMake package, expected at one of:
   /usr/lib/cmake/hip-lang/hip-lang-config.cmake
   /usr/lib64/cmake/hip-lang/hip-lang-config.cmake
```

— while the file sat at `/usr/lib/x86_64-linux-gnu/cmake/hip-lang/hip-lang-config.cmake`. The missing multiarch path is a symptom three steps downstream of the real fault.

## Root cause: our own `ROCM_PATH`

The configure log gives it away:

```
Found HIP installation: /usr, version 5.7.31921
clang++: error: cannot find ROCm device library; provide its path via '--rocm-path'
or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library
```

The builder exported `ROCM_PATH=<dirname of hipconfig>` on every ROCm host. On Debian and Fedora that resolves to `/usr`, and clang then treats `/usr` as a self-contained ROCm and looks for device bitcode at `/usr/amdgcn/bitcode`. Those distros ship it beside the compiler instead, in `/usr/lib/llvm-N/lib/clang/N/amdgcn/bitcode`. clang fails, so cmake can't identify the HIP compiler — and `CMAKE_HIP_LIBRARY_ARCHITECTURE` is parsed *out of that identification's output*, so the multiarch directory never enters the hip-lang search list.

Arch and AMD's `/opt/rocm` installs genuinely need `ROCM_PATH` (their clang can't find its ROCm otherwise), so it stays for those. When ROCm lives in `/usr`, cmake gets `-DCMAKE_HIP_COMPILER_ROCM_ROOT` instead, which costs clang nothing.

## Second cause: no HIP compiler to find

cmake asks `hipconfig --hipclangpath` and otherwise falls back to a bare `clang++` on PATH. On 24.04 hipconfig names a directory with no `clang++` in it, and Debian only installs the versioned `/usr/lib/llvm-N/bin/clang++` — no unversioned symlink — so nothing is found at all.

Locate a HIP-capable `clang++` and pass `-DCMAKE_HIP_COMPILER`, the way the cuda profile already pins nvcc. Prefer what hipconfig reports, then the ROCm roots, then a distro clang — but only one with the AMD device bitcode beside it, since Debian packages those per LLVM version (`rocm-device-libs-17` → `/usr/lib/llvm-17/...`) and the newest clang on the box is regularly the wrong one. An explicit value in the build's extra cmake flags still wins.

## Also here

- **ROCm version floor.** Past the above, llama.cpp stops on its own gate: `At least ROCM/HIP V6.1 is required`. Ubuntu 24.04 packages ROCm 5.7, so nothing can build there, and clang 17 rejects `gfx1201` outright. setup.sh now reports this at install time instead of leaving it to a clone and a cmake run.
- **OpenSSL headers.** A *successful* configure still carried `OpenSSL not found, HTTPS support disabled`. `LLAMA_OPENSSL` defaults ON and llama.cpp's HTTP client uses it, so the server we build silently can't speak HTTPS. Neither fresh Ubuntu ships the headers; Fedora workstations do, which is why it never showed up locally. Added `libssl-dev`/`openssl-devel` to the package deps and to `deps --host` (warning, not failure — the build completes, just degraded).

## Verification

| check | result |
|---|---|
| Reporter's failure reproduced on 24.04 | byte-for-byte, same cmake line |
| Pre-fix on 26.04 | also fails — compiler found but `broken`, identification unknown |
| **Post-fix on 26.04, real llama.cpp, `GPU_TARGETS=gfx1201`** | **`-- Including HIP backend`, configure done, exit 0** |
| Post-fix on 24.04, bare `/usr` and `/opt/rocm` alternatives layouts | both configure through to llama.cpp's version gate |
| Go detection run *inside* each container | 24.04 → `/usr/lib/llvm-17/bin/clang++`; 26.04 → `/usr/lib/llvm-21/bin/clang++` |
| Fedora ROCm 7.1 host | same recipe configures cleanly; no regression; `deps --host` still `rocm OK` |
| Version floor warning | fires on 24.04 (5.7), silent on 26.04 and Fedora (7.1) |
| OpenSSL report | warns on both fresh containers, `OK` after `libssl-dev`; configure then finds OpenSSL 3.5.5 |

The 26.04 pre-fix failure differs from 24.04: there `hipconfig` does name a real clang, so cmake finds one — but `ROCM_PATH=/usr` still breaks its device-library lookup, giving `Check for working HIP compiler ... broken`. Same root cause, different surface.

Unit tests cover the device-libs pairing (clang-17-with-bitcode beats clang-18-without), highest-version-wins, root precedence, and the extra-cmake-flags override. Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go9An1JPRDAuj8nVYwpXLZ