### PR TITLE
fix(setup): don't offer AMD's ROCm repo where AMD publishes none

### DIFF
--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -429,19 +429,22 @@ host_install_amd_rocm_repo_debian() {
         return 1
     fi
 
+    # Ask AMD what they publish before asking the user anything. AMD
+    # covers LTS releases and lags the interim ones — there is no build
+    # for Ubuntu 26.04's 'resolute', for instance — and prompting for a
+    # repository that cannot be added is worse than noise: in a
+    # non-interactive run the unanswerable prompt aborts the install.
+    local rocm_url="https://repo.radeon.com/rocm/apt/latest"
+    if ! curl -fsI "${rocm_url}/dists/${codename}/Release" >/dev/null 2>&1; then
+        log "AMD publishes no ROCm build for '${codename}' — using the distro's packages."
+        return 1
+    fi
+
     log "AMD's ROCm apt repository is not configured."
     log "Without it, apt only sees the ROCm version your distro packages, which"
     log "may be too old for a recent GPU."
     if ! prompt_confirm "Add AMD's ROCm repository now? (repo.radeon.com, codename ${codename})"; then
         warn "Skipped — continuing with the packages apt already knows about."
-        return 1
-    fi
-
-    local rocm_url="https://repo.radeon.com/rocm/apt/latest"
-    if ! curl -fsI "${rocm_url}/dists/${codename}/Release" >/dev/null 2>&1; then
-        warn "AMD publishes no ROCm build for '${codename}' at ${rocm_url}."
-        log "Pick a supported release from:"
-        echo "    https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html"
         return 1
     fi
 


### PR DESCRIPTION
Last piece of #142, split out because #147 merged while this was still in flight.

Running `setup.sh install --rocm` on a fresh Ubuntu 26.04 asks:

```
==> AMD's ROCm apt repository is not configured.
Add AMD's ROCm repository now? (repo.radeon.com, codename resolute)
```

and only *afterwards* discovers that AMD publishes nothing for `resolute`. Interactively that's a pointless question. Non-interactively it's worse — the unanswerable prompt aborts the entire install before a single package is fetched:

```
✗ Non-interactive shell and --yes not given; cannot answer:
  'Add AMD's ROCm repository now? (repo.radeon.com, codename resolute)'
```

Probe the repository first, and fall through quietly to the distro's packages when there's no build for this codename. AMD covers the LTS releases, so the prompt still appears where it earns its keep.

| release | AMD's repo | distro |
|---|---|---|
| 24.04 noble | ROCm 7.2.4 | 5.7 — prompt is genuinely useful |
| 26.04 resolute | nothing published | 7.1 — prompt was pure noise |

Verified in both containers: silent on resolute, still prompts on noble.

Found by running the full `install --rocm --yes` on a pristine 26.04 container, which also confirmed the end state of the #145/#147 work: cmake, ninja-build, git, build-essential, pkg-config, hipcc, libamdhip64-dev, librocblas-dev, libhipblas-dev and rocm-cmake all installed, and a HIP project configuring against `/usr/lib/llvm-21/bin/clang++` with nothing but setup.sh having run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go9An1JPRDAuj8nVYwpXLZ