### PR TITLE
feat(models): search and download from ModelScope alongside HuggingFace

### DIFF
--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tmac1973/llama-toolchest/internal/backup"
 	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 )
 
 // handleBackupExport serves the configuration backup as a JSON download.
@@ -132,6 +133,10 @@ func (s *Server) restoreDeps() backup.Deps {
 			if in.LogLevel != nil && *in.LogLevel != "" && s.cfg.LogLevel != *in.LogLevel {
 				s.cfg.LogLevel = *in.LogLevel
 				changed = append(changed, "log_level")
+			}
+			if in.DefaultModelSource != nil && s.cfg.DefaultModelSource != *in.DefaultModelSource {
+				s.cfg.DefaultModelSource = modelsource.NormalizeSource(*in.DefaultModelSource)
+				changed = append(changed, "default_model_source")
 			}
 			if in.HFToken != nil && s.cfg.HFToken != *in.HFToken {
 				s.cfg.HFToken = *in.HFToken

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -137,6 +137,10 @@ func (s *Server) restoreDeps() backup.Deps {
 				s.cfg.HFToken = *in.HFToken
 				changed = append(changed, "hf_token")
 			}
+			if in.MSToken != nil && s.cfg.MSToken != *in.MSToken {
+				s.cfg.MSToken = *in.MSToken
+				changed = append(changed, "ms_token")
+			}
 			if in.APIKey != nil && s.cfg.APIKey != *in.APIKey {
 				s.cfg.APIKey = *in.APIKey
 				changed = append(changed, "api_key")

--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/tmac1973/llama-toolchest/internal/huggingface"
 	"github.com/tmac1973/llama-toolchest/internal/models"
-	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 )
 
 // hfFileView decorates a HuggingFace ModelFile with local-state flags used
@@ -45,7 +44,7 @@ func (s *Server) handleHFSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	source := modelsource.NormalizeSource(r.URL.Query().Get("source"))
+	source := s.requestSource(r.URL.Query().Get("source"))
 	results, err := s.sourceClient(source).Search(r.Context(), query)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -74,7 +73,7 @@ func (s *Server) handleHFModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	source := modelsource.NormalizeSource(r.URL.Query().Get("source"))
+	source := s.requestSource(r.URL.Query().Get("source"))
 	detail, err := s.sourceClient(source).GetModel(r.Context(), modelID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -132,7 +131,7 @@ func (s *Server) handleHFDownload(w http.ResponseWriter, r *http.Request) {
 		req.Size, _ = strconv.ParseInt(r.FormValue("size"), 10, 64)
 		req.Source = r.FormValue("source")
 	}
-	req.Source = modelsource.NormalizeSource(req.Source)
+	req.Source = s.requestSource(req.Source)
 
 	// Inline mode: callers whose swap target can't host the table-shaped
 	// download_progress partial (the restore report rows, the pending

--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/tmac1973/llama-toolchest/internal/huggingface"
 	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 )
 
 // hfFileView decorates a HuggingFace ModelFile with local-state flags used
@@ -30,6 +31,7 @@ type hfFileView struct {
 // hfModelView is the template payload for the HF file-list partial.
 type hfModelView struct {
 	ID             string
+	Source         string // which host these files came from
 	Files          []hfFileView
 	AvailableBytes int64 // free - margin - in-flight
 	FreeBytes      int64
@@ -43,16 +45,22 @@ func (s *Server) handleHFSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := s.hfClient.Search(r.Context(), query)
+	source := modelsource.NormalizeSource(r.URL.Query().Get("source"))
+	results, err := s.sourceClient(source).Search(r.Context(), query)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 
-	// htmx: return HTML partial
+	// htmx: return HTML partial. The source travels with the results so
+	// each row can link to the right host and start a download against
+	// the source it was found on.
 	if isHTMX(r) {
 		respondHTML(w)
-		s.renderPartial(w, "hf_results", struct{ Results any }{Results: results})
+		s.renderPartial(w, "hf_results", struct {
+			Results any
+			Source  string
+		}{Results: results, Source: source})
 		return
 	}
 
@@ -66,7 +74,8 @@ func (s *Server) handleHFModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	detail, err := s.hfClient.GetModel(r.Context(), modelID)
+	source := modelsource.NormalizeSource(r.URL.Query().Get("source"))
+	detail, err := s.sourceClient(source).GetModel(r.Context(), modelID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
@@ -75,6 +84,7 @@ func (s *Server) handleHFModel(w http.ResponseWriter, r *http.Request) {
 	available := s.downloader.AvailableForDownload()
 	view := hfModelView{
 		ID:             detail.ID,
+		Source:         source,
 		Files:          make([]hfFileView, 0, len(detail.Files)),
 		AvailableBytes: available,
 		FreeBytes:      s.downloader.FreeBytes(),
@@ -107,6 +117,7 @@ func (s *Server) handleHFDownload(w http.ResponseWriter, r *http.Request) {
 		ModelID  string `json:"model_id"`
 		Filename string `json:"filename"`
 		Size     int64  `json:"size"`
+		Source   string `json:"source"`
 	}
 
 	if r.Header.Get("Content-Type") == "application/json" {
@@ -119,7 +130,9 @@ func (s *Server) handleHFDownload(w http.ResponseWriter, r *http.Request) {
 		req.ModelID = r.FormValue("model_id")
 		req.Filename = r.FormValue("filename")
 		req.Size, _ = strconv.ParseInt(r.FormValue("size"), 10, 64)
+		req.Source = r.FormValue("source")
 	}
+	req.Source = modelsource.NormalizeSource(req.Source)
 
 	// Inline mode: callers whose swap target can't host the table-shaped
 	// download_progress partial (the restore report rows, the pending
@@ -155,7 +168,7 @@ func (s *Server) handleHFDownload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	downloadID, err := s.downloader.Start(r.Context(), req.ModelID, req.Filename, req.Size)
+	downloadID, err := s.downloader.Start(r.Context(), req.Source, req.ModelID, req.Filename, req.Size)
 	if err != nil {
 		if inline && isHTMX(r) {
 			inlineRespond(err.Error(), true)
@@ -398,7 +411,7 @@ func (s *Server) handleHFDownloadCancel(w http.ResponseWriter, r *http.Request) 
 }
 
 // onDownloadComplete is called by the downloader when a file finishes.
-func (s *Server) onDownloadComplete(downloadID, modelID, filename string, sizeBytes int64) {
+func (s *Server) onDownloadComplete(source, downloadID, modelID, filename string, sizeBytes int64) {
 	safeName := huggingface.SafeModelID(modelID)
 	filePath := filepath.Join(s.cfg.ModelsPath(), safeName, filename)
 
@@ -428,6 +441,7 @@ func (s *Server) onDownloadComplete(downloadID, modelID, filename string, sizeBy
 		Filename:     filename,
 		Quant:        models.ParseQuant(filename),
 		SizeBytes:    sizeBytes,
+		Source:       source,
 		FilePath:     filePath,
 		VRAMEstGB:    models.EstimateVRAM(sizeBytes),
 		DownloadedAt: time.Now(),

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 )
 
 func (s *Server) handleListEmbeddingModels(w http.ResponseWriter, r *http.Request) {
@@ -138,7 +139,8 @@ func (s *Server) handleDownloadEmbeddingPreset(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	downloadID, err := s.downloader.Start(r.Context(), repo, filename, 0)
+	// Curated embedding presets are HuggingFace repos by construction.
+	downloadID, err := s.downloader.Start(r.Context(), modelsource.SourceHuggingFace, repo, filename, 0)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/internal/api/modelsource_test.go
+++ b/internal/api/modelsource_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tmac1973/llama-toolchest/internal/config"
 	"github.com/tmac1973/llama-toolchest/internal/modelscope"
 	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 	"github.com/tmac1973/llama-toolchest/web"
@@ -93,22 +94,50 @@ func TestFileListCarriesSourceIntoDownload(t *testing.T) {
 	}
 }
 
-// The browse page's only new control is the source radio; both options
-// must be present and HuggingFace preselected.
-func TestBrowsePageHasSourceRadio(t *testing.T) {
+// The browse page's only new control is the source radio, and its
+// initial position comes from the configured default — the whole point
+// of the setting.
+func TestBrowsePageRadioFollowsConfiguredDefault(t *testing.T) {
 	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
 		"templates/layout.html", "templates/models_browse.html")
 	if err != nil {
 		t.Fatalf("parse templates: %v", err)
 	}
-	var buf bytes.Buffer
-	if err := base.ExecuteTemplate(&buf, "content", nil); err != nil {
-		t.Fatalf("execute: %v", err)
+	render := func(def string) string {
+		var buf bytes.Buffer
+		data := struct {
+			pageData
+			DefaultSource string
+		}{DefaultSource: def}
+		if err := base.ExecuteTemplate(&buf, "content", data); err != nil {
+			t.Fatalf("execute (default=%q): %v", def, err)
+		}
+		return buf.String()
 	}
-	out := buf.String()
-	for _, want := range []string{`name="source" value="hf" checked`, `name="source" value="modelscope"`} {
-		if !strings.Contains(out, want) {
-			t.Errorf("browse page missing %q; output=\n%s", want, out)
+
+	// checkedValue reports which radio carries the checked attribute.
+	checkedValue := func(out string) string {
+		for _, v := range []string{"hf", "modelscope"} {
+			i := strings.Index(out, `value="`+v+`"`)
+			if i < 0 {
+				t.Fatalf("radio %q missing from the page", v)
+			}
+			rest := out[i:]
+			if end := strings.Index(rest, ">"); end > 0 && strings.Contains(rest[:end], "checked") {
+				return v
+			}
+		}
+		return ""
+	}
+
+	for _, tc := range []struct{ configured, want string }{
+		{"", "hf"},                   // unset falls back to HuggingFace
+		{"hf", "hf"},                 //
+		{"modelscope", "modelscope"}, // the setting takes effect
+		{"nonsense", "hf"},           // an unrecognized value must not leave nothing selected
+	} {
+		if got := checkedValue(render(tc.configured)); got != tc.want {
+			t.Errorf("default %q: %q is checked, want %q", tc.configured, got, tc.want)
 		}
 	}
 }
@@ -119,5 +148,52 @@ func TestModelScopeClientIsASource(t *testing.T) {
 	var c modelsource.Client = modelscope.NewClient("")
 	if _, err := c.GetModel(context.Background(), "not-an-id"); err == nil {
 		t.Error("GetModel should reject an id that isn't owner/name")
+	}
+}
+
+// The configured default answers "where should this new request go", not
+// "where did this model come from". A model downloaded before ModelScope
+// existed has an empty stored source and came from HuggingFace; setting
+// the default to ModelScope must not repoint its link at a host it was
+// never on.
+func TestDefaultSourceDoesNotRewriteStoredRecords(t *testing.T) {
+	s := &Server{cfg: &config.Config{DefaultModelSource: modelsource.SourceModelScope}}
+
+	// A new request with no explicit source follows the preference...
+	if got := s.requestSource(""); got != modelsource.SourceModelScope {
+		t.Errorf("requestSource(\"\") = %q, want the configured default", got)
+	}
+	// ...while an explicit one still wins.
+	if got := s.requestSource(modelsource.SourceHuggingFace); got != modelsource.SourceHuggingFace {
+		t.Errorf("requestSource(hf) = %q, want hf", got)
+	}
+	// But a stored record with no source is still HuggingFace, whatever
+	// the preference says — this is what the model-card link uses.
+	if got := modelsource.NormalizeSource(""); got != modelsource.SourceHuggingFace {
+		t.Errorf("NormalizeSource(\"\") = %q, want hf regardless of preference", got)
+	}
+	url := s.sourceClient(modelsource.NormalizeSource("")).ModelURL("unsloth/Qwen3-8B-GGUF")
+	if !strings.HasPrefix(url, "https://huggingface.co/") {
+		t.Errorf("pre-existing model links to %q, want huggingface.co", url)
+	}
+}
+
+// An unset or unrecognized preference must resolve to HuggingFace rather
+// than leaving the browse page with nothing selected.
+func TestDefaultModelSourceFallback(t *testing.T) {
+	for _, tc := range []struct{ configured, want string }{
+		{"", modelsource.SourceHuggingFace},
+		{"hf", modelsource.SourceHuggingFace},
+		{"nonsense", modelsource.SourceHuggingFace},
+		{"modelscope", modelsource.SourceModelScope},
+	} {
+		s := &Server{cfg: &config.Config{DefaultModelSource: tc.configured}}
+		if got := s.defaultModelSource(); got != tc.want {
+			t.Errorf("configured %q: defaultModelSource = %q, want %q", tc.configured, got, tc.want)
+		}
+	}
+	// A nil config must not panic — the render tests construct bare Servers.
+	if got := (&Server{}).defaultModelSource(); got != modelsource.SourceHuggingFace {
+		t.Errorf("zero Server: %q, want hf", got)
 	}
 }

--- a/internal/api/modelsource_test.go
+++ b/internal/api/modelsource_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/modelscope"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
+	"github.com/tmac1973/llama-toolchest/web"
+)
+
+// An empty or unrecognized source must resolve to HuggingFace: every
+// download record and registry entry written before ModelScope existed
+// has an empty source, and links and re-downloads have to keep working.
+func TestSourceClientDefaultsToHuggingFace(t *testing.T) {
+	s := &Server{}
+	for _, id := range []string{"", "hf", "nonsense", "HUGGINGFACE"} {
+		got := s.sourceClient(id).ModelURL("unsloth/Qwen3-8B-GGUF")
+		if !strings.HasPrefix(got, "https://huggingface.co/") {
+			t.Errorf("sourceClient(%q).ModelURL = %q, want a huggingface.co URL", id, got)
+		}
+	}
+	got := s.sourceClient(modelsource.SourceModelScope).ModelURL("unsloth/Qwen3-8B-GGUF")
+	if !strings.HasPrefix(got, "https://modelscope.cn/") {
+		t.Errorf("modelscope source gave %q, want a modelscope.cn URL", got)
+	}
+}
+
+// The link next to a search result must point at the host the result came
+// from — sending someone to a HuggingFace URL for a ModelScope-only repo
+// is a 404 with no explanation.
+func TestSearchResultsLinkToTheirOwnSource(t *testing.T) {
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	results := []modelsource.SearchResult{{ID: "unsloth/Qwen3-8B-GGUF", Downloads: 5, Likes: 1}}
+
+	for _, tc := range []struct{ source, wantHost, wantName string }{
+		{modelsource.SourceHuggingFace, "https://huggingface.co/unsloth/Qwen3-8B-GGUF", "HuggingFace"},
+		{modelsource.SourceModelScope, "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF", "ModelScope"},
+	} {
+		var buf bytes.Buffer
+		data := struct {
+			Results any
+			Source  string
+		}{Results: results, Source: tc.source}
+		if err := base.ExecuteTemplate(&buf, "hf_results", data); err != nil {
+			t.Fatalf("%s: execute: %v", tc.source, err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, tc.wantHost) {
+			t.Errorf("%s: results do not link to %s; output=\n%s", tc.source, tc.wantHost, out)
+		}
+		if !strings.Contains(out, "Open on "+tc.wantName) {
+			t.Errorf("%s: link title does not name %s", tc.source, tc.wantName)
+		}
+		// The Files button has to carry the source, or expanding a
+		// ModelScope result would list files from HuggingFace.
+		if !strings.Contains(out, "source="+tc.source) {
+			t.Errorf("%s: Files request does not carry the source", tc.source)
+		}
+	}
+}
+
+// The download button posts the source back, so the bytes are fetched
+// from the host the user was actually browsing.
+func TestFileListCarriesSourceIntoDownload(t *testing.T) {
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	view := hfModelView{
+		ID:     "unsloth/Qwen3-8B-GGUF",
+		Source: modelsource.SourceModelScope,
+		Files: []hfFileView{{
+			ModelFile:  modelsource.File{Filename: "Qwen3-8B-Q4_K_M.gguf", Size: 100, Quant: "Q4_K_M"},
+			FitsOnDisk: true,
+		}},
+		AvailableBytes: 1 << 40,
+	}
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, "hf_files", view); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"source":"modelscope"`) {
+		t.Errorf("download button does not post the source; output=\n%s", buf.String())
+	}
+}
+
+// The browse page's only new control is the source radio; both options
+// must be present and HuggingFace preselected.
+func TestBrowsePageHasSourceRadio(t *testing.T) {
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/models_browse.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, "content", nil); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{`name="source" value="hf" checked`, `name="source" value="modelscope"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("browse page missing %q; output=\n%s", want, out)
+		}
+	}
+}
+
+// The ModelScope client must satisfy the same contract the API layer
+// programs against, or none of the above holds together.
+func TestModelScopeClientIsASource(t *testing.T) {
+	var c modelsource.Client = modelscope.NewClient("")
+	if _, err := c.GetModel(context.Background(), "not-an-id"); err == nil {
+		t.Error("GetModel should reject an id that isn't owner/name")
+	}
+}

--- a/internal/api/ms_token_test.go
+++ b/internal/api/ms_token_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"bytes"
+	"html/template"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/config"
+	"github.com/tmac1973/llama-toolchest/web"
+)
+
+// renderSettings renders the settings page with the two token flags set
+// as given. The struct mirrors the handler's anonymous one; a mismatch
+// shows up here as a template execution error.
+func renderSettings(t *testing.T, hasHF, hasMS bool) string {
+	t.Helper()
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/settings.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	data := struct {
+		pageData
+		ProxyEndpoint    string
+		LlamaPort        int
+		HasAPIKey        bool
+		HasHFToken       bool
+		HasMSToken       bool
+		HasExtURL        bool
+		ExternalURL      string
+		DataDir          string
+		ModelsDir        string
+		DefaultModelsDir string
+		AutoStart        bool
+		RuntimeEnvOpts   []config.RuntimeEnvOption
+		RuntimeEnv       map[string]string
+		RuntimeEnvExtra  string
+		EnvBackends      []string
+		ActiveBackend    string
+		EnvWarnings      []string
+		EffectiveEnv     []envLine
+	}{HasHFToken: hasHF, HasMSToken: hasMS}
+
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, "content", data); err != nil {
+		t.Fatalf("execute settings page: %v", err)
+	}
+	return buf.String()
+}
+
+func TestSettingsPageHasBothTokenFields(t *testing.T) {
+	out := renderSettings(t, false, false)
+	for _, want := range []string{`name="hf_token"`, `name="ms_token"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("settings page missing %s", want)
+		}
+	}
+}
+
+// A set token is never echoed back into the page — only its presence is,
+// via the placeholder. Rendering the value would leak it to anyone who
+// can view the page or a screenshot of it.
+func TestSettingsPagePlaceholdersReportPresenceOnly(t *testing.T) {
+	set := renderSettings(t, true, true)
+	if strings.Count(set, "(token is set)") != 2 {
+		t.Errorf("both fields should report a set token; got %d occurrences", strings.Count(set, "(token is set)"))
+	}
+	unset := renderSettings(t, false, false)
+	if strings.Contains(unset, "(token is set)") {
+		t.Error("unset tokens should not claim to be set")
+	}
+	if !strings.Contains(unset, "ms_...") {
+		t.Error("unset ModelScope field should show its placeholder hint")
+	}
+}
+
+// Saving one token must not blank the other: the form posts both fields
+// and an empty one means "leave it alone", not "clear it". Getting this
+// wrong would wipe a working HuggingFace token the first time someone
+// saved a ModelScope one.
+func TestUpdateSettingsLeavesTheOtherTokenAlone(t *testing.T) {
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{HFToken: "hf_existing", MSToken: "ms_existing", DataDir: dir},
+		configPath: filepath.Join(dir, "llama-toolchest.yaml"),
+	}
+
+	form := url.Values{"ms_token": {"ms_new"}, "hf_token": {""}}
+	req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.handleUpdateSettings(httptest.NewRecorder(), req)
+
+	if s.cfg.MSToken != "ms_new" {
+		t.Errorf("MSToken = %q, want ms_new", s.cfg.MSToken)
+	}
+	if s.cfg.HFToken != "hf_existing" {
+		t.Errorf("HFToken = %q, want the existing value kept", s.cfg.HFToken)
+	}
+}
+
+// The JSON path treats a present key as authoritative, including an
+// explicit empty string, which is how a token gets cleared.
+func TestUpdateSettingsJSONSetsAndClears(t *testing.T) {
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{MSToken: "ms_existing", DataDir: dir},
+		configPath: filepath.Join(dir, "llama-toolchest.yaml"),
+	}
+	put := func(body string) {
+		req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		s.handleUpdateSettings(httptest.NewRecorder(), req)
+	}
+
+	put(`{"ms_token":"ms_new"}`)
+	if s.cfg.MSToken != "ms_new" {
+		t.Errorf("MSToken = %q, want ms_new", s.cfg.MSToken)
+	}
+	put(`{"ms_token":""}`)
+	if s.cfg.MSToken != "" {
+		t.Errorf("MSToken = %q, want it cleared by an explicit empty value", s.cfg.MSToken)
+	}
+	// An absent key leaves the value alone.
+	s.cfg.MSToken = "ms_kept"
+	put(`{"llama_port":9999}`)
+	if s.cfg.MSToken != "ms_kept" {
+		t.Errorf("MSToken = %q, want it untouched when the key is absent", s.cfg.MSToken)
+	}
+}
+
+// The token must reach the config file, or it is forgotten on restart.
+func TestUpdateSettingsPersistsMSToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "llama-toolchest.yaml")
+	s := &Server{cfg: &config.Config{DataDir: dir}, configPath: path}
+
+	req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(`{"ms_token":"ms_persisted"}`))
+	req.Header.Set("Content-Type", "application/json")
+	s.handleUpdateSettings(httptest.NewRecorder(), req)
+
+	saved, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	if !strings.Contains(string(saved), "ms_persisted") {
+		t.Errorf("ms_token missing from the saved config:\n%s", saved)
+	}
+}

--- a/internal/api/ms_token_test.go
+++ b/internal/api/ms_token_test.go
@@ -31,6 +31,7 @@ func renderSettings(t *testing.T, hasHF, hasMS bool) string {
 		HasAPIKey        bool
 		HasHFToken       bool
 		HasMSToken       bool
+		DefaultSource    string
 		HasExtURL        bool
 		ExternalURL      string
 		DataDir          string
@@ -149,5 +150,89 @@ func TestUpdateSettingsPersistsMSToken(t *testing.T) {
 	}
 	if !strings.Contains(string(saved), "ms_persisted") {
 		t.Errorf("ms_token missing from the saved config:\n%s", saved)
+	}
+}
+
+func TestSettingsPageDefaultSourceSelect(t *testing.T) {
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/settings.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	render := func(def string) string {
+		data := struct {
+			pageData
+			ProxyEndpoint    string
+			LlamaPort        int
+			HasAPIKey        bool
+			HasHFToken       bool
+			HasMSToken       bool
+			DefaultSource    string
+			HasExtURL        bool
+			ExternalURL      string
+			DataDir          string
+			ModelsDir        string
+			DefaultModelsDir string
+			AutoStart        bool
+			RuntimeEnvOpts   []config.RuntimeEnvOption
+			RuntimeEnv       map[string]string
+			RuntimeEnvExtra  string
+			EnvBackends      []string
+			ActiveBackend    string
+			EnvWarnings      []string
+			EffectiveEnv     []envLine
+		}{DefaultSource: def}
+		var buf bytes.Buffer
+		if err := base.ExecuteTemplate(&buf, "content", data); err != nil {
+			t.Fatalf("execute (default=%q): %v", def, err)
+		}
+		return buf.String()
+	}
+
+	// The selected option must reflect the stored preference, or saving
+	// the form would silently reset it to HuggingFace.
+	ms := render("modelscope")
+	if !strings.Contains(ms, `value="modelscope" selected`) {
+		t.Error("ModelScope preference not preselected on the settings page")
+	}
+	if strings.Contains(ms, `value="hf" selected`) {
+		t.Error("both options marked selected")
+	}
+	hf := render("")
+	if !strings.Contains(hf, `value="hf" selected`) {
+		t.Error("unset preference should preselect HuggingFace")
+	}
+	if !strings.Contains(hf, `name="default_model_source"`) {
+		t.Error("settings page missing the default source control")
+	}
+}
+
+// The preference round-trips through the settings API, and an
+// unrecognized value is normalized rather than stored.
+func TestUpdateSettingsDefaultSource(t *testing.T) {
+	dir := t.TempDir()
+	s := &Server{cfg: &config.Config{DataDir: dir}, configPath: filepath.Join(dir, "c.yaml")}
+	put := func(body string) {
+		req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		s.handleUpdateSettings(httptest.NewRecorder(), req)
+	}
+
+	put(`{"default_model_source":"modelscope"}`)
+	if s.cfg.DefaultModelSource != "modelscope" {
+		t.Errorf("DefaultModelSource = %q, want modelscope", s.cfg.DefaultModelSource)
+	}
+	put(`{"default_model_source":"nonsense"}`)
+	if s.cfg.DefaultModelSource != "hf" {
+		t.Errorf("DefaultModelSource = %q, want an unrecognized value normalized to hf", s.cfg.DefaultModelSource)
+	}
+
+	// Form path: a select always posts, so presence means chosen.
+	form := url.Values{"default_model_source": {"modelscope"}}
+	req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.handleUpdateSettings(httptest.NewRecorder(), req)
+	if s.cfg.DefaultModelSource != "modelscope" {
+		t.Errorf("form path: DefaultModelSource = %q, want modelscope", s.cfg.DefaultModelSource)
 	}
 }

--- a/internal/api/ms_token_test.go
+++ b/internal/api/ms_token_test.go
@@ -2,15 +2,22 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"html/template"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/tmac1973/llama-toolchest/internal/config"
+	"github.com/tmac1973/llama-toolchest/internal/huggingface"
+	"github.com/tmac1973/llama-toolchest/internal/modelscope"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
+	"github.com/tmac1973/llama-toolchest/internal/presets"
 	"github.com/tmac1973/llama-toolchest/web"
 )
 
@@ -54,6 +61,28 @@ func renderSettings(t *testing.T, hasHF, hasMS bool) string {
 	return buf.String()
 }
 
+// newSettingsServer builds the minimum Server that handleUpdateSettings
+// needs: a config, somewhere to persist it, and the live clients whose
+// credentials a save now pushes into.
+func newSettingsServer(t *testing.T, cfg *config.Config) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	cfg.DataDir = dir
+	s := &Server{
+		cfg:        cfg,
+		configPath: filepath.Join(dir, "llama-toolchest.yaml"),
+		hfClient:   huggingface.NewClient(cfg.HFToken),
+		msClient:   modelscope.NewClient(cfg.MSToken),
+		presets:    presets.NewFetcher(filepath.Join(dir, "cache"), cfg.HFToken),
+		downloader: huggingface.NewDownloader(dir, dir, cfg.HFToken),
+	}
+	s.downloader.RegisterProvider(modelsource.SourceModelScope, huggingface.Provider{
+		URL:   s.msClient.DownloadURL,
+		Token: cfg.MSToken,
+	})
+	return s
+}
+
 func TestSettingsPageHasBothTokenFields(t *testing.T) {
 	out := renderSettings(t, false, false)
 	for _, want := range []string{`name="hf_token"`, `name="ms_token"`} {
@@ -85,11 +114,7 @@ func TestSettingsPagePlaceholdersReportPresenceOnly(t *testing.T) {
 // wrong would wipe a working HuggingFace token the first time someone
 // saved a ModelScope one.
 func TestUpdateSettingsLeavesTheOtherTokenAlone(t *testing.T) {
-	dir := t.TempDir()
-	s := &Server{
-		cfg:        &config.Config{HFToken: "hf_existing", MSToken: "ms_existing", DataDir: dir},
-		configPath: filepath.Join(dir, "llama-toolchest.yaml"),
-	}
+	s := newSettingsServer(t, &config.Config{HFToken: "hf_existing", MSToken: "ms_existing"})
 
 	form := url.Values{"ms_token": {"ms_new"}, "hf_token": {""}}
 	req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(form.Encode()))
@@ -107,11 +132,7 @@ func TestUpdateSettingsLeavesTheOtherTokenAlone(t *testing.T) {
 // The JSON path treats a present key as authoritative, including an
 // explicit empty string, which is how a token gets cleared.
 func TestUpdateSettingsJSONSetsAndClears(t *testing.T) {
-	dir := t.TempDir()
-	s := &Server{
-		cfg:        &config.Config{MSToken: "ms_existing", DataDir: dir},
-		configPath: filepath.Join(dir, "llama-toolchest.yaml"),
-	}
+	s := newSettingsServer(t, &config.Config{MSToken: "ms_existing"})
 	put := func(body string) {
 		req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
@@ -136,9 +157,8 @@ func TestUpdateSettingsJSONSetsAndClears(t *testing.T) {
 
 // The token must reach the config file, or it is forgotten on restart.
 func TestUpdateSettingsPersistsMSToken(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "llama-toolchest.yaml")
-	s := &Server{cfg: &config.Config{DataDir: dir}, configPath: path}
+	s := newSettingsServer(t, &config.Config{})
+	path := s.configPath
 
 	req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(`{"ms_token":"ms_persisted"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -210,8 +230,7 @@ func TestSettingsPageDefaultSourceSelect(t *testing.T) {
 // The preference round-trips through the settings API, and an
 // unrecognized value is normalized rather than stored.
 func TestUpdateSettingsDefaultSource(t *testing.T) {
-	dir := t.TempDir()
-	s := &Server{cfg: &config.Config{DataDir: dir}, configPath: filepath.Join(dir, "c.yaml")}
+	s := newSettingsServer(t, &config.Config{})
 	put := func(body string) {
 		req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
@@ -235,4 +254,77 @@ func TestUpdateSettingsDefaultSource(t *testing.T) {
 	if s.cfg.DefaultModelSource != "modelscope" {
 		t.Errorf("form path: DefaultModelSource = %q, want modelscope", s.cfg.DefaultModelSource)
 	}
+}
+
+// The point of applying credentials on save: a token set in Settings must
+// reach the next outbound request, not the next restart. Assert on the
+// Authorization header a client actually sends, since that is the only
+// thing that decides whether a gated repo downloads.
+func TestSavedTokenReachesTheWire(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte(`{"Code":200,"Success":true,"Data":{"Model":{"Models":[]}}}`))
+	}))
+	defer srv.Close()
+
+	s := newSettingsServer(t, &config.Config{})
+	ms := modelscope.NewClient("")
+	ms.SetHTTPClientForTest(srv.Client(), srv.URL)
+	s.msClient = ms
+
+	// Before: no credential.
+	if _, err := ms.Search(context.Background(), "q"); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("unexpected Authorization before a token was set: %q", gotAuth)
+	}
+
+	// Save a token through the real handler.
+	req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(`{"ms_token":"ms_live"}`))
+	req.Header.Set("Content-Type", "application/json")
+	s.handleUpdateSettings(httptest.NewRecorder(), req)
+
+	// After: the very next request carries it, with no restart.
+	if _, err := ms.Search(context.Background(), "q"); err != nil {
+		t.Fatalf("search after save: %v", err)
+	}
+	if gotAuth != "Bearer ms_live" {
+		t.Errorf("Authorization = %q, want the token saved a moment ago", gotAuth)
+	}
+}
+
+// Swapping a token while requests are in flight must not race: that is
+// the reason the token lives behind a lock inside each client rather than
+// the Server swapping client pointers. Run with -race to mean anything.
+func TestTokenSwapIsSafeUnderConcurrency(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Code":200,"Success":true,"Data":{"Model":{"Models":[]}}}`))
+	}))
+	defer srv.Close()
+
+	c := modelscope.NewClient("start")
+	c.SetHTTPClientForTest(srv.Client(), srv.URL)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				c.Search(context.Background(), "q")
+			}
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				c.SetToken("tok")
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -830,6 +830,26 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 	}
 }
 
+// applySourceCredentials pushes the currently configured tokens into the
+// live clients, the preset fetcher and the downloader's providers.
+//
+// The alternative — rebuilding the clients — would mean reassigning
+// pointers that request handlers read from other goroutines. Instead each
+// holder owns its token behind its own lock and this only swaps the
+// values, so nothing a concurrent request is already using changes
+// underneath it. In-flight downloads pick the new credential up on their
+// next file, because the provider is read per file rather than captured
+// for the whole job.
+//
+// Callers must hold cfgMu, which every settings mutation already does.
+func (s *Server) applySourceCredentialsLocked() {
+	s.hfClient.SetToken(s.cfg.HFToken)
+	s.msClient.SetToken(s.cfg.MSToken)
+	s.presets.SetToken(s.cfg.HFToken)
+	s.downloader.SetProviderToken(modelsource.SourceHuggingFace, s.cfg.HFToken)
+	s.downloader.SetProviderToken(modelsource.SourceModelScope, s.cfg.MSToken)
+}
+
 // requestSource resolves which model source a browse request is aimed
 // at: the explicit parameter when there is one, otherwise the user's
 // configured default.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -22,6 +22,8 @@ import (
 	"github.com/tmac1973/llama-toolchest/internal/evaluate"
 	"github.com/tmac1973/llama-toolchest/internal/huggingface"
 	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/modelscope"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 	"github.com/tmac1973/llama-toolchest/internal/monitor"
 	"github.com/tmac1973/llama-toolchest/internal/presets"
 	"github.com/tmac1973/llama-toolchest/internal/process"
@@ -36,6 +38,7 @@ type Server struct {
 	router      chi.Router
 	builder     *builder.Builder
 	hfClient    *huggingface.Client
+	msClient    *modelscope.Client
 	downloader  *huggingface.Downloader
 	registry    *models.Registry
 	presets     *presets.Fetcher
@@ -166,6 +169,7 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 		configPath:     configPath,
 		builder:        bld,
 		hfClient:       huggingface.NewClient(cfg.HFToken),
+		msClient:       modelscope.NewClient(cfg.MSToken),
 		downloader:     huggingface.NewDownloader(cfg.DataDir, cfg.ModelsPath(), cfg.HFToken),
 		registry:       models.NewRegistry(cfg.DataDir, cfg.ModelsPath()),
 		presets:        presets.NewFetcher(filepath.Join(cfg.DataDir, "cache", "presets"), cfg.HFToken),
@@ -178,6 +182,13 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 	s.env = newJobEnv(s)
 	s.jobs = benchmark.NewJobQueue(s.bench, s.env)
 	s.downloader.SetOnComplete(s.onDownloadComplete)
+	// The downloader is source-agnostic apart from URL construction and
+	// auth; teach it where ModelScope files live so a download started
+	// against that source resolves correctly.
+	s.downloader.RegisterProvider(modelsource.SourceModelScope, huggingface.Provider{
+		URL:   s.msClient.DownloadURL,
+		Token: cfg.MSToken,
+	})
 	s.registry.BackfillGGUFMeta()
 	if n := s.registry.DeduplicateModels(); n > 0 {
 		slog.Info("removed duplicate model entries", "count", n)
@@ -348,12 +359,18 @@ func (s *Server) templateFuncs() template.FuncMap {
 			// Default to layer mode (no tensor parallelism) for rough estimates
 			return models.VRAMFitLabel(estimatedGB, perGPU, numGPUs, 0)
 		},
-		// hasHFRepo reports whether a model_id looks like an org/repo
-		// pair we can deep-link to on huggingface.co — i.e. it has at
-		// least one slash and isn't an absolute path. Scanned local
-		// models without that shape don't get a link.
-		"hasHFRepo": func(modelID string) bool {
-			return strings.Contains(modelID, "/") && !strings.HasPrefix(modelID, "/")
+		// sourceModelURL is the repository page for a model, asked of that
+		// source's own client so each host spells its own URLs. Empty when
+		// the id isn't a linkable owner/name pair, which is how the
+		// templates decide whether to render a link at all.
+		"sourceModelURL": func(source, modelID string) string {
+			return s.sourceClient(source).ModelURL(modelID)
+		},
+		"sourceName": func(source string) string {
+			if modelsource.NormalizeSource(source) == modelsource.SourceModelScope {
+				return "ModelScope"
+			}
+			return "HuggingFace"
 		},
 		"version": func() string {
 			v := s.version
@@ -801,4 +818,14 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 		slog.Error("template render error", "name", name, "error", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}
+}
+
+// sourceClient returns the client for a source id, defaulting to
+// HuggingFace for an empty or unrecognized one so old links and any
+// caller that predates the source parameter keep working.
+func (s *Server) sourceClient(source string) modelsource.Client {
+	if modelsource.NormalizeSource(source) == modelsource.SourceModelScope {
+		return s.msClient
+	}
+	return s.hfClient
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -621,6 +621,7 @@ func (s *Server) handleSettingsPage(w http.ResponseWriter, r *http.Request) {
 		LlamaPort        int
 		HasAPIKey        bool
 		HasHFToken       bool
+		HasMSToken       bool
 		HasExtURL        bool
 		ExternalURL      string
 		DataDir          string
@@ -640,6 +641,7 @@ func (s *Server) handleSettingsPage(w http.ResponseWriter, r *http.Request) {
 		LlamaPort:        s.cfg.LlamaPort,
 		HasAPIKey:        s.cfg.APIKey != "",
 		HasHFToken:       s.cfg.HFToken != "",
+		HasMSToken:       s.cfg.MSToken != "",
 		HasExtURL:        s.cfg.ExternalURL != "",
 		ExternalURL:      s.cfg.ExternalURL,
 		DataDir:          s.cfg.DataDir,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -587,7 +587,13 @@ func (s *Server) handleBenchmarksPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleModelsBrowsePage(w http.ResponseWriter, r *http.Request) {
-	s.render(w, "models_browse.html", pageData{Title: "Browse HuggingFace", Nav: "browse"})
+	s.render(w, "models_browse.html", struct {
+		pageData
+		DefaultSource string
+	}{
+		pageData:      pageData{Title: "Download Models", Nav: "browse"},
+		DefaultSource: s.defaultModelSource(),
+	})
 }
 
 func (s *Server) handleServicePage(w http.ResponseWriter, r *http.Request) {
@@ -622,6 +628,7 @@ func (s *Server) handleSettingsPage(w http.ResponseWriter, r *http.Request) {
 		HasAPIKey        bool
 		HasHFToken       bool
 		HasMSToken       bool
+		DefaultSource    string
 		HasExtURL        bool
 		ExternalURL      string
 		DataDir          string
@@ -642,6 +649,7 @@ func (s *Server) handleSettingsPage(w http.ResponseWriter, r *http.Request) {
 		HasAPIKey:        s.cfg.APIKey != "",
 		HasHFToken:       s.cfg.HFToken != "",
 		HasMSToken:       s.cfg.MSToken != "",
+		DefaultSource:    s.defaultModelSource(),
 		HasExtURL:        s.cfg.ExternalURL != "",
 		ExternalURL:      s.cfg.ExternalURL,
 		DataDir:          s.cfg.DataDir,
@@ -820,6 +828,34 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 		slog.Error("template render error", "name", name, "error", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}
+}
+
+// requestSource resolves which model source a browse request is aimed
+// at: the explicit parameter when there is one, otherwise the user's
+// configured default.
+//
+// Deliberately not the same as modelsource.NormalizeSource, which maps an
+// empty id onto HuggingFace. That one answers a question about a stored
+// record — a model downloaded before a second source existed came from
+// HuggingFace, and no preference set later changes where it came from.
+// This one answers a question about a new request, where the preference
+// is exactly what should apply. Conflating them would make every
+// pre-existing model's "open model page" link follow the preference and
+// point at a host it was never on.
+func (s *Server) requestSource(explicit string) string {
+	if explicit != "" {
+		return modelsource.NormalizeSource(explicit)
+	}
+	return s.defaultModelSource()
+}
+
+// defaultModelSource is the configured browse default, falling back to
+// HuggingFace when unset or unrecognized.
+func (s *Server) defaultModelSource() string {
+	if s.cfg == nil {
+		return modelsource.SourceHuggingFace
+	}
+	return modelsource.NormalizeSource(s.cfg.DefaultModelSource)
 }
 
 // sourceClient returns the client for a source id, defaulting to

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -170,6 +170,10 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Persist config
 	s.saveConfigLocked()
+	// A token saved here has to reach the live clients, or it would only
+	// take effect on the next restart while the page cheerfully reports
+	// it as set.
+	s.applySourceCredentialsLocked()
 
 	if isHTMX(r) {
 		respondHTML(w)

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/tmac1973/llama-toolchest/internal/config"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,6 +22,7 @@ type settingsResponse struct {
 	HasAPIKey     bool   `json:"has_api_key"`
 	HasHFToken    bool   `json:"has_hf_token"`
 	HasMSToken    bool   `json:"has_ms_token"`
+	DefaultSource string `json:"default_model_source"`
 	DataDir       string `json:"data_dir"`
 }
 
@@ -38,6 +40,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		HasAPIKey:     s.cfg.APIKey != "",
 		HasHFToken:    s.cfg.HFToken != "",
 		HasMSToken:    s.cfg.MSToken != "",
+		DefaultSource: s.defaultModelSource(),
 		DataDir:       s.cfg.DataDir,
 	}
 
@@ -68,6 +71,8 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			APIKey    *string `json:"api_key,omitempty"`
 			HFToken   *string `json:"hf_token,omitempty"`
 			MSToken   *string `json:"ms_token,omitempty"`
+
+			DefaultModelSource *string `json:"default_model_source,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -85,6 +90,11 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		if update.MSToken != nil {
 			s.cfg.MSToken = *update.MSToken
 		}
+		// Normalized on the way in so an unrecognized value can't be
+		// persisted and then silently mean HuggingFace forever after.
+		if update.DefaultModelSource != nil {
+			s.cfg.DefaultModelSource = modelsource.NormalizeSource(*update.DefaultModelSource)
+		}
 	} else {
 		r.ParseForm()
 		if v := r.FormValue("api_key"); v != "" {
@@ -95,6 +105,12 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		}
 		if v := r.FormValue("ms_token"); v != "" {
 			s.cfg.MSToken = v
+		}
+		// A select always posts a value, so presence of the field means
+		// the user chose; unlike the token fields there is no "left
+		// blank means leave alone" case.
+		if r.Form.Has("default_model_source") {
+			s.cfg.DefaultModelSource = modelsource.NormalizeSource(r.FormValue("default_model_source"))
 		}
 		if r.Form.Has("external_url") {
 			s.cfg.ExternalURL = r.FormValue("external_url")

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -20,6 +20,7 @@ type settingsResponse struct {
 	ProxyEndpoint string `json:"proxy_endpoint"`
 	HasAPIKey     bool   `json:"has_api_key"`
 	HasHFToken    bool   `json:"has_hf_token"`
+	HasMSToken    bool   `json:"has_ms_token"`
 	DataDir       string `json:"data_dir"`
 }
 
@@ -36,6 +37,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		ProxyEndpoint: fmt.Sprintf("http://localhost%s/v1", s.cfg.ListenAddr),
 		HasAPIKey:     s.cfg.APIKey != "",
 		HasHFToken:    s.cfg.HFToken != "",
+		HasMSToken:    s.cfg.MSToken != "",
 		DataDir:       s.cfg.DataDir,
 	}
 
@@ -65,6 +67,7 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			LlamaPort *int    `json:"llama_port,omitempty"`
 			APIKey    *string `json:"api_key,omitempty"`
 			HFToken   *string `json:"hf_token,omitempty"`
+			MSToken   *string `json:"ms_token,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -79,6 +82,9 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		if update.HFToken != nil {
 			s.cfg.HFToken = *update.HFToken
 		}
+		if update.MSToken != nil {
+			s.cfg.MSToken = *update.MSToken
+		}
 	} else {
 		r.ParseForm()
 		if v := r.FormValue("api_key"); v != "" {
@@ -86,6 +92,9 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		}
 		if v := r.FormValue("hf_token"); v != "" {
 			s.cfg.HFToken = v
+		}
+		if v := r.FormValue("ms_token"); v != "" {
+			s.cfg.MSToken = v
 		}
 		if r.Form.Has("external_url") {
 			s.cfg.ExternalURL = r.FormValue("external_url")

--- a/internal/api/settings_page_render_test.go
+++ b/internal/api/settings_page_render_test.go
@@ -32,6 +32,7 @@ func TestSettingsPageRendersEnvSection(t *testing.T) {
 		HasAPIKey        bool
 		HasHFToken       bool
 		HasMSToken       bool
+		DefaultSource    string
 		HasExtURL        bool
 		ExternalURL      string
 		DataDir          string

--- a/internal/api/settings_page_render_test.go
+++ b/internal/api/settings_page_render_test.go
@@ -31,6 +31,7 @@ func TestSettingsPageRendersEnvSection(t *testing.T) {
 		LlamaPort        int
 		HasAPIKey        bool
 		HasHFToken       bool
+		HasMSToken       bool
 		HasExtURL        bool
 		ExternalURL      string
 		DataDir          string

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -62,6 +62,7 @@ type Settings struct {
 	AutoStart *bool   `json:"auto_start,omitempty"`
 	LogLevel  *string `json:"log_level,omitempty"`
 	HFToken   *string `json:"hf_token,omitempty"` // only with includeSecrets, and only when non-empty
+	MSToken   *string `json:"ms_token,omitempty"` // ModelScope; same rules as HFToken
 	APIKey    *string `json:"api_key,omitempty"`  // only with includeSecrets, and only when non-empty
 }
 
@@ -117,6 +118,9 @@ func Assemble(cfg *config.Config, b *builder.Builder, reg *models.Registry, gpus
 	if includeSecrets {
 		if cfg.HFToken != "" {
 			s.HFToken = ptr(cfg.HFToken)
+		}
+		if cfg.MSToken != "" {
+			s.MSToken = ptr(cfg.MSToken)
 		}
 		if cfg.APIKey != "" {
 			s.APIKey = ptr(cfg.APIKey)

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -61,9 +61,12 @@ type Settings struct {
 	ModelsMax *int    `json:"models_max,omitempty"`
 	AutoStart *bool   `json:"auto_start,omitempty"`
 	LogLevel  *string `json:"log_level,omitempty"`
-	HFToken   *string `json:"hf_token,omitempty"` // only with includeSecrets, and only when non-empty
-	MSToken   *string `json:"ms_token,omitempty"` // ModelScope; same rules as HFToken
-	APIKey    *string `json:"api_key,omitempty"`  // only with includeSecrets, and only when non-empty
+	// DefaultModelSource is a plain preference, not a secret, so it
+	// travels with every backup.
+	DefaultModelSource *string `json:"default_model_source,omitempty"`
+	HFToken            *string `json:"hf_token,omitempty"` // only with includeSecrets, and only when non-empty
+	MSToken            *string `json:"ms_token,omitempty"` // ModelScope; same rules as HFToken
+	APIKey             *string `json:"api_key,omitempty"`  // only with includeSecrets, and only when non-empty
 }
 
 // RuntimeEnv mirrors the global EnvSet: curated variable values plus the
@@ -110,6 +113,11 @@ func Assemble(cfg *config.Config, b *builder.Builder, reg *models.Registry, gpus
 		ModelsMax: ptr(cfg.ModelsMax),
 		AutoStart: ptr(cfg.AutoStart),
 		LogLevel:  ptr(cfg.LogLevel),
+	}
+	// Only when set: an empty value would restore as "no preference",
+	// which the target already has, so there is nothing to say.
+	if cfg.DefaultModelSource != "" {
+		s.DefaultModelSource = ptr(cfg.DefaultModelSource)
 	}
 	// Secrets: only with the explicit flag, and never as empty strings —
 	// an empty emitted secret could blank a target's credential on

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -23,7 +23,7 @@ func testState(t *testing.T) (*config.Config, *builder.Builder, *models.Registry
 	cfg := &config.Config{
 		ListenAddr: ":3000", DataDir: dataDir, LlamaPort: 8080,
 		LogLevel: "info", ModelsMax: 2, AutoStart: true,
-		HFToken: "hf_secret_token", APIKey: "api_secret_key",
+		HFToken: "hf_secret_token", MSToken: "ms_secret_token", APIKey: "api_secret_key",
 		RuntimeEnv:      map[string]string{"ROCBLAS_USE_HIPBLASLT": "1"},
 		RuntimeEnvExtra: "FOO=bar",
 	}
@@ -99,14 +99,14 @@ func TestAssembleNoSecretsByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, secret := range []string{"hf_secret_token", "api_secret_key", "hf_token", "api_key"} {
+	for _, secret := range []string{"hf_secret_token", "ms_secret_token", "api_secret_key", "hf_token", "ms_token", "api_key"} {
 		if bytes.Contains(data, []byte(secret)) {
 			t.Errorf("secrets-off export contains %q", secret)
 		}
 	}
 
 	withSecrets, _ := Assemble(cfg, b, reg, nil, true).Marshal()
-	for _, want := range []string{`"hf_token": "hf_secret_token"`, `"api_key": "api_secret_key"`} {
+	for _, want := range []string{`"hf_token": "hf_secret_token"`, `"ms_token": "ms_secret_token"`, `"api_key": "api_secret_key"`} {
 		if !bytes.Contains(withSecrets, []byte(want)) {
 			t.Errorf("secrets-on export missing %s", want)
 		}
@@ -118,7 +118,7 @@ func TestAssembleNoSecretsByDefault(t *testing.T) {
 // credential on restore.
 func TestAssembleNeverEmitsEmptySecrets(t *testing.T) {
 	cfg, b, reg := testState(t)
-	cfg.HFToken, cfg.APIKey = "", ""
+	cfg.HFToken, cfg.MSToken, cfg.APIKey = "", "", ""
 	data, _ := Assemble(cfg, b, reg, nil, true).Marshal()
 	for _, key := range []string{"hf_token", "api_key"} {
 		if bytes.Contains(data, []byte(key)) {

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -139,6 +139,10 @@ func Apply(f *File, sel Selections, deps Deps) Report {
 			s.HFToken = nil
 			rep.Warnings = append(rep.Warnings, "settings: empty hf_token ignored")
 		}
+		if s.MSToken != nil && *s.MSToken == "" {
+			s.MSToken = nil
+			rep.Warnings = append(rep.Warnings, "settings: empty ms_token ignored")
+		}
 		if s.APIKey != nil && *s.APIKey == "" {
 			s.APIKey = nil
 			rep.Warnings = append(rep.Warnings, "settings: empty api_key ignored")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	LlamaPort   int    `yaml:"llama_port"`   // default 8080
 	ExternalURL string `yaml:"external_url"` // e.g. "http://myserver:3000" for links
 	HFToken     string `yaml:"hf_token"`     // optional HuggingFace token
+	// MSToken is the ModelScope access token. Only needed for gated or
+	// private repositories; public ones, which is everything the browse
+	// UI surfaces, download anonymously.
+	MSToken     string `yaml:"ms_token,omitempty"`
 	APIKey      string `yaml:"api_key"`      // optional API key for /v1/* proxy
 	LogLevel    string `yaml:"log_level"`    // default "info"
 	ActiveBuild string `yaml:"active_build"` // which llama.cpp build to use

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,11 @@ type Config struct {
 	LlamaPort   int    `yaml:"llama_port"`   // default 8080
 	ExternalURL string `yaml:"external_url"` // e.g. "http://myserver:3000" for links
 	HFToken     string `yaml:"hf_token"`     // optional HuggingFace token
+	// DefaultModelSource preselects one of the model sources on the
+	// browse page. It only sets the radio's initial position; the choice
+	// is still per-search. Empty means HuggingFace.
+	DefaultModelSource string `yaml:"default_model_source,omitempty"`
+
 	// MSToken is the ModelScope access token. Only needed for gated or
 	// private repositories; public ones, which is everything the browse
 	// UI surfaces, download anonymously.

--- a/internal/huggingface/client.go
+++ b/internal/huggingface/client.go
@@ -6,13 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
-	"sort"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 )
 
 const baseURL = "https://huggingface.co/api"
@@ -23,31 +21,16 @@ type Client struct {
 	token      string
 }
 
-// ModelSearchResult represents a model from HF search.
-type ModelSearchResult struct {
-	ID        string   `json:"id"`
-	Author    string   `json:"author"`
-	Downloads int      `json:"downloads"`
-	Likes     int      `json:"likes"`
-	Tags      []string `json:"tags"`
-	License   string   `json:"license,omitempty"`
-}
-
-// ModelFile represents a single GGUF file (or grouped shard set) in a model repo.
-type ModelFile struct {
-	Filename  string   `json:"filename"`
-	Size      int64    `json:"size"`
-	Quant     string   `json:"quant"`
-	VRAMEstGB float64  `json:"vram_est_gb"`
-	Shards    []string `json:"shards,omitempty"` // all shard filenames if split; nil for single files
-	IsMMProj  bool     `json:"is_mmproj,omitempty"` // true for vision projector files
-}
-
-// ModelDetail holds model info with filtered GGUF files.
-type ModelDetail struct {
-	ID    string      `json:"id"`
-	Files []ModelFile `json:"files"`
-}
+// The search and file types are shared with the other model sources, so
+// they are declared once in modelsource and aliased here. An alias, not a
+// copy: huggingface.ModelFile and modelsource.File are the same type, so
+// a client for another source can return values this package's callers
+// accept without conversion.
+type (
+	ModelSearchResult = modelsource.SearchResult
+	ModelFile         = modelsource.File
+	ModelDetail       = modelsource.Detail
+)
 
 func NewClient(token string) *Client {
 	return &Client{
@@ -180,83 +163,14 @@ func (c *Client) setAuth(req *http.Request) {
 	}
 }
 
-// estimateVRAM returns estimated VRAM in GB.
-// Uses file size * 1.1 as a rough estimate (overhead for KV cache and buffers).
-func estimateVRAM(sizeBytes int64) float64 {
-	return float64(sizeBytes) * 1.1 / (1024 * 1024 * 1024)
-}
+// The GGUF file helpers below are not HuggingFace-specific — shard naming
+// and size arithmetic are properties of the files, not of the host — so
+// they live in modelsource and are forwarded here for existing callers.
+var (
+	groupShards  = modelsource.GroupShards
+	estimateVRAM = modelsource.EstimateVRAM
+)
 
-// shardPattern matches split GGUF filenames like "model-00001-of-00005.gguf"
-var shardPattern = regexp.MustCompile(`^(.+)-(\d{5})-of-(\d{5})\.gguf$`)
-
-// groupShards merges split GGUF shard files into single entries.
-// e.g., 5 files "model-0000N-of-00005.gguf" become one entry with combined size.
-func groupShards(files []ModelFile) []ModelFile {
-	type shardGroup struct {
-		base   string
-		total  int
-		shards []ModelFile
-	}
-	groups := map[string]*shardGroup{}
-	var singles []ModelFile
-
-	for _, f := range files {
-		m := shardPattern.FindStringSubmatch(f.Filename)
-		if m == nil {
-			singles = append(singles, f)
-			continue
-		}
-		base := m[1]
-		total, _ := strconv.Atoi(m[3])
-		g, ok := groups[base]
-		if !ok {
-			g = &shardGroup{base: base, total: total}
-			groups[base] = g
-		}
-		g.shards = append(g.shards, f)
-	}
-
-	var result []ModelFile
-	for _, g := range groups {
-		sort.Slice(g.shards, func(i, j int) bool {
-			return g.shards[i].Filename < g.shards[j].Filename
-		})
-		var totalSize int64
-		var shardNames []string
-		for _, s := range g.shards {
-			totalSize += s.Size
-			shardNames = append(shardNames, s.Filename)
-		}
-		result = append(result, ModelFile{
-			Filename:  g.shards[0].Filename,
-			Size:      totalSize,
-			Quant:     g.shards[0].Quant,
-			VRAMEstGB: estimateVRAM(totalSize),
-			Shards:    shardNames,
-		})
-	}
-
-	// Sort grouped entries by filename for stable ordering
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Filename < result[j].Filename
-	})
-
-	return append(result, singles...)
-}
-
-// ExpandShards returns all shard filenames for a split GGUF, or a single-element
-// slice for non-split files. Exported for use by the downloader.
-func ExpandShards(filename string) []string {
-	m := shardPattern.FindStringSubmatch(filename)
-	if m == nil {
-		return []string{filename}
-	}
-	base := m[1]
-	total, _ := strconv.Atoi(m[3])
-	shards := make([]string, total)
-	for i := range total {
-		shards[i] = fmt.Sprintf("%s-%05d-of-%05d.gguf", base, i+1, total)
-	}
-	return shards
-}
-
+// ExpandShards returns all shard filenames for a split GGUF, or a
+// single-element slice for an unsplit one.
+func ExpandShards(filename string) []string { return modelsource.ExpandShards(filename) }

--- a/internal/huggingface/client.go
+++ b/internal/huggingface/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tmac1973/llama-toolchest/internal/models"
@@ -18,7 +19,25 @@ const baseURL = "https://huggingface.co/api"
 // Client is a HuggingFace API client.
 type Client struct {
 	httpClient *http.Client
-	token      string
+
+	// token is guarded because Settings can replace it while a search or
+	// a listing is in flight on another goroutine.
+	mu    sync.RWMutex
+	token string
+}
+
+// SetToken replaces the access token, so one saved in Settings applies to
+// the next request rather than the next restart.
+func (c *Client) SetToken(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.token = token
+}
+
+func (c *Client) authToken() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.token
 }
 
 // The search and file types are shared with the other model sources, so
@@ -167,8 +186,8 @@ func (c *Client) ModelURL(modelID string) string {
 }
 
 func (c *Client) setAuth(req *http.Request) {
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
+	if tok := c.authToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 }
 

--- a/internal/huggingface/client.go
+++ b/internal/huggingface/client.go
@@ -157,6 +157,15 @@ func (c *Client) populateFileSizes(ctx context.Context, modelID string, detail *
 	}
 }
 
+// ModelURL returns the human-facing page for a repository, for the link
+// next to a search result.
+func (c *Client) ModelURL(modelID string) string {
+	if modelID == "" || strings.HasPrefix(modelID, "/") || !strings.Contains(modelID, "/") {
+		return ""
+	}
+	return "https://huggingface.co/" + modelID
+}
+
 func (c *Client) setAuth(req *http.Request) {
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)

--- a/internal/huggingface/downloader.go
+++ b/internal/huggingface/downloader.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/tmac1973/llama-toolchest/internal/broadcast"
+
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 )
 
 // DownloadStatus tracks progress of a model download.
@@ -62,26 +64,70 @@ func (dl *download) last() DownloadStatus {
 }
 
 // CompletionFunc is called when a download finishes successfully.
-type CompletionFunc func(downloadID, modelID, filename string, sizeBytes int64)
+type CompletionFunc func(source, downloadID, modelID, filename string, sizeBytes int64)
 
 // Downloader manages resumable GGUF downloads from HuggingFace.
+// Provider supplies the per-source parts of a download: where a file
+// lives and how to authenticate for it. The rest of the downloader —
+// resume, shard handling, disk accounting, progress — is the same
+// whichever host the bytes come from.
+type Provider struct {
+	// URL returns the download URL for one file in a repository.
+	URL func(modelID, filename string) string
+	// Token is the bearer token for this source, empty for anonymous.
+	Token string
+}
+
 type Downloader struct {
 	dataDir    string
 	modelsDir  string
 	token      string
 	onComplete CompletionFunc
 
+	// providers is keyed by modelsource source id. A download names its
+	// source; an unknown or empty one falls back to HuggingFace, which is
+	// what every download recorded before this existed came from.
+	providers map[string]Provider
+
 	mu     sync.Mutex
 	active map[string]*download
 }
 
 func NewDownloader(dataDir, modelsDir, token string) *Downloader {
-	return &Downloader{
+	d := &Downloader{
 		dataDir:   dataDir,
 		modelsDir: modelsDir,
 		token:     token,
 		active:    make(map[string]*download),
+		providers: make(map[string]Provider),
 	}
+	d.providers[modelsource.SourceHuggingFace] = Provider{
+		URL:   func(modelID, filename string) string { return hfDownloadURL(modelID, filename) },
+		Token: token,
+	}
+	return d
+}
+
+// RegisterProvider adds or replaces the provider for a source.
+func (d *Downloader) RegisterProvider(source string, p Provider) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.providers[source] = p
+}
+
+// provider returns the provider for a source, falling back to
+// HuggingFace so an empty source keeps behaving as it always did.
+func (d *Downloader) provider(source string) Provider {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if p, ok := d.providers[source]; ok && p.URL != nil {
+		return p
+	}
+	return d.providers[modelsource.SourceHuggingFace]
+}
+
+func hfDownloadURL(modelID, filename string) string {
+	return fmt.Sprintf("https://huggingface.co/%s/resolve/main/%s", modelID, filename)
 }
 
 // SetOnComplete registers a callback invoked when a download finishes.
@@ -94,7 +140,7 @@ func (d *Downloader) SetOnComplete(fn CompletionFunc) {
 // in-flight reservation in AvailableForDownload is accurate from the moment
 // Start returns, before the download goroutine has done its own HEAD. Pass 0
 // when the size is unknown.
-func (d *Downloader) Start(ctx context.Context, modelID, filename string, expectedBytes int64) (string, error) {
+func (d *Downloader) Start(ctx context.Context, source, modelID, filename string, expectedBytes int64) (string, error) {
 	// Create a stable download ID — replace all slashes to keep it URL-safe
 	safeName := SafeModelID(modelID)
 	safeFilename := SafeFileID(filename)
@@ -142,7 +188,7 @@ func (d *Downloader) Start(ctx context.Context, modelID, filename string, expect
 	d.active[downloadID] = dl
 	d.mu.Unlock()
 
-	go d.run(dlCtx, downloadID, modelID, filename, dl)
+	go d.run(dlCtx, source, downloadID, modelID, filename, dl)
 
 	return downloadID, nil
 }
@@ -250,7 +296,7 @@ func (d *Downloader) Cancel(downloadID string) error {
 	return nil
 }
 
-func (d *Downloader) run(ctx context.Context, downloadID, modelID, filename string, dl *download) {
+func (d *Downloader) run(ctx context.Context, source, downloadID, modelID, filename string, dl *download) {
 	defer close(dl.done)
 	// Cancelled before we ever ran (pause immediately after resume, or a
 	// test's admission-only Start): report the terminal status and exit
@@ -292,7 +338,7 @@ func (d *Downloader) run(ctx context.Context, downloadID, modelID, filename stri
 	// Get combined total size via HEAD requests for accurate progress
 	var combinedTotal int64
 	if len(filenames) > 1 {
-		combinedTotal = d.fetchCombinedSize(ctx, modelID, filenames)
+		combinedTotal = d.fetchCombinedSize(ctx, source, modelID, filenames)
 	}
 
 	// Download each file (single file or all shards sequentially)
@@ -310,7 +356,7 @@ func (d *Downloader) run(ctx context.Context, downloadID, modelID, filename stri
 			label = fmt.Sprintf("%s [%d/%d]", fn, i+1, len(filenames))
 		}
 
-		downloaded, err := d.downloadFile(ctx, downloadID, modelID, fn, label, modelDir, totalDownloaded, combinedTotal, dl)
+		downloaded, err := d.downloadFile(ctx, source, downloadID, modelID, fn, label, modelDir, totalDownloaded, combinedTotal, dl)
 		if err != nil {
 			// A mid-file cancellation surfaces as ctx.Err() from downloadFile —
 			// report it as "cancelled" like the between-files check above, not
@@ -337,22 +383,23 @@ func (d *Downloader) run(ctx context.Context, downloadID, modelID, filename stri
 	slog.Info("download complete", "model", modelID, "file", filename, "shards", len(filenames), "size", totalDownloaded)
 
 	if d.onComplete != nil {
-		d.onComplete(downloadID, modelID, filenames[0], totalDownloaded)
+		d.onComplete(source, downloadID, modelID, filenames[0], totalDownloaded)
 	}
 }
 
 // fetchCombinedSize does HEAD requests to get the total size of all shard files.
-func (d *Downloader) fetchCombinedSize(ctx context.Context, modelID string, filenames []string) int64 {
+func (d *Downloader) fetchCombinedSize(ctx context.Context, source, modelID string, filenames []string) int64 {
 	client := &http.Client{Timeout: 30 * time.Second}
+	p := d.provider(source)
 	var total int64
 	for _, fn := range filenames {
-		dlURL := fmt.Sprintf("https://huggingface.co/%s/resolve/main/%s", modelID, fn)
+		dlURL := p.URL(modelID, fn)
 		req, err := http.NewRequestWithContext(ctx, "HEAD", dlURL, nil)
 		if err != nil {
 			continue
 		}
-		if d.token != "" {
-			req.Header.Set("Authorization", "Bearer "+d.token)
+		if p.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+p.Token)
 		}
 		resp, err := client.Do(req)
 		if err != nil {
@@ -368,7 +415,7 @@ func (d *Downloader) fetchCombinedSize(ctx context.Context, modelID string, file
 
 // downloadFile downloads a single file, reporting progress with a base offset for multi-shard tracking.
 // Returns the number of bytes downloaded for this file.
-func (d *Downloader) downloadFile(ctx context.Context, downloadID, modelID, filename, label, modelDir string,
+func (d *Downloader) downloadFile(ctx context.Context, source, downloadID, modelID, filename, label, modelDir string,
 	baseDownloaded, combinedTotal int64, dl *download) (int64, error) {
 
 	sendProgress := func(status DownloadStatus) {
@@ -392,14 +439,14 @@ func (d *Downloader) downloadFile(ctx context.Context, downloadID, modelID, file
 		existingSize = info.Size()
 	}
 
-	dlURL := fmt.Sprintf("https://huggingface.co/%s/resolve/main/%s", modelID, filename)
-	req, err := http.NewRequestWithContext(ctx, "GET", dlURL, nil)
+	p := d.provider(source)
+	req, err := http.NewRequestWithContext(ctx, "GET", p.URL(modelID, filename), nil)
 	if err != nil {
 		return 0, err
 	}
 
-	if d.token != "" {
-		req.Header.Set("Authorization", "Bearer "+d.token)
+	if p.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+p.Token)
 	}
 	if existingSize > 0 {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", existingSize))
@@ -416,8 +463,15 @@ func (d *Downloader) downloadFile(ctx context.Context, downloadID, modelID, file
 		return 0, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
+	// Whether the body is the whole file or just the tail we asked for
+	// cannot be decided from the status code alone. ModelScope answers a
+	// ranged request with 200 plus a Content-Range header rather than the
+	// 206 the RFC requires (see modelscope.DownloadURL), and reading that
+	// as "the server ignored my Range" would truncate the partial file
+	// below and write only the tail into it — a corrupt model that looks
+	// complete. A Content-Range header means partial, whatever the status.
 	fileTotal := resp.ContentLength
-	if resp.StatusCode == http.StatusPartialContent {
+	if responseIsPartial(resp) {
 		fileTotal += existingSize
 	} else {
 		existingSize = 0
@@ -493,4 +547,11 @@ func (d *Downloader) downloadFile(ctx context.Context, downloadID, modelID, file
 	}
 
 	return downloaded, nil
+}
+
+// responseIsPartial reports whether a response to a ranged request
+// carries only part of the file. See the call site for why the status
+// code is not sufficient on its own.
+func responseIsPartial(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusPartialContent || resp.Header.Get("Content-Range") != ""
 }

--- a/internal/huggingface/downloader.go
+++ b/internal/huggingface/downloader.go
@@ -81,7 +81,6 @@ type Provider struct {
 type Downloader struct {
 	dataDir    string
 	modelsDir  string
-	token      string
 	onComplete CompletionFunc
 
 	// providers is keyed by modelsource source id. A download names its
@@ -97,7 +96,6 @@ func NewDownloader(dataDir, modelsDir, token string) *Downloader {
 	d := &Downloader{
 		dataDir:   dataDir,
 		modelsDir: modelsDir,
-		token:     token,
 		active:    make(map[string]*download),
 		providers: make(map[string]Provider),
 	}
@@ -106,6 +104,21 @@ func NewDownloader(dataDir, modelsDir, token string) *Downloader {
 		Token: token,
 	}
 	return d
+}
+
+// SetProviderToken updates one source's credential in place, keeping its
+// URL builder. Used when a token is saved in Settings; in-flight
+// downloads pick it up on their next file, since the provider is read
+// per file rather than captured for the whole job.
+func (d *Downloader) SetProviderToken(source, token string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	p, ok := d.providers[source]
+	if !ok {
+		return
+	}
+	p.Token = token
+	d.providers[source] = p
 }
 
 // RegisterProvider adds or replaces the provider for a source.

--- a/internal/huggingface/downloader_test.go
+++ b/internal/huggingface/downloader_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/tmac1973/llama-toolchest/internal/broadcast"
+
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 )
 
 // seedActive injects a download entry with the given last status, simulating
@@ -27,7 +29,7 @@ func TestStartRefusesWhileDownloading(t *testing.T) {
 	d := NewDownloader(t.TempDir(), t.TempDir(), "")
 	seedActive(d, "org--Repo-GGUF--file", "downloading")
 
-	if _, err := d.Start(context.Background(), "org/Repo-GGUF", "file.gguf", 0); err == nil {
+	if _, err := d.Start(context.Background(), modelsource.SourceHuggingFace, "org/Repo-GGUF", "file.gguf", 0); err == nil {
 		t.Fatal("Start should refuse while the same download is in progress")
 	}
 }
@@ -40,7 +42,7 @@ func TestStartReplacesTerminalEntry(t *testing.T) {
 		d := NewDownloader(t.TempDir(), t.TempDir(), "")
 		seedActive(d, "org--Repo-GGUF--file", status)
 
-		id, err := d.Start(context.Background(), "org/Repo-GGUF", "file.gguf", 0)
+		id, err := d.Start(context.Background(), modelsource.SourceHuggingFace, "org/Repo-GGUF", "file.gguf", 0)
 		if err != nil {
 			t.Fatalf("Start after %q entry: %v", status, err)
 		}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -68,6 +68,12 @@ type Model struct {
 	VRAMEstGB    float64   `json:"vram_est_gb"`
 	DownloadedAt time.Time `json:"downloaded_at"`
 
+	// Source is the repository host this model was downloaded from, one
+	// of the modelsource ids. Empty on records written before a second
+	// source existed, and on models found by a disk scan, both of which
+	// are treated as HuggingFace.
+	Source string `json:"source,omitempty"`
+
 	// PLEBytes is the size of the per-layer / n-gram embedding table, when
 	// the model has one (Gemma-3N, Gemma-4, Qwen4-Exp). Zero everywhere
 	// else, which is what makes it double as the "does this model have a

--- a/internal/modelscope/client.go
+++ b/internal/modelscope/client.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tmac1973/llama-toolchest/internal/models"
@@ -48,7 +49,25 @@ const (
 // repositories, which is all of them that matter here, need no auth.
 type Client struct {
 	httpClient *http.Client
-	token      string
+
+	// token is guarded because Settings can replace it while a search or
+	// a listing is in flight on another goroutine.
+	mu    sync.RWMutex
+	token string
+}
+
+// SetToken replaces the access token, so one saved in Settings applies to
+// the next request rather than the next restart.
+func (c *Client) SetToken(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.token = token
+}
+
+func (c *Client) authToken() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.token
 }
 
 func NewClient(token string) *Client {
@@ -310,7 +329,7 @@ func ResponseIsPartial(resp *http.Response) bool {
 }
 
 func (c *Client) setAuth(req *http.Request) {
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
+	if tok := c.authToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 }

--- a/internal/modelscope/client.go
+++ b/internal/modelscope/client.go
@@ -1,0 +1,316 @@
+// Package modelscope searches and resolves GGUF models on ModelScope
+// (modelscope.cn), Alibaba's model hub, as an alternative to HuggingFace.
+//
+// The endpoints here were established by probing the live service: the
+// search call is the one modelscope.cn's own web UI issues, and is not
+// part of a published REST contract. That has a practical consequence
+// this package is built around — the API answers a malformed request with
+// HTTP 200 and a plausible-looking result set rather than an error. A
+// misspelled sort key returns zero models; an unrecognized filter key is
+// ignored and unfiltered results come back. So responses are checked for
+// the shape we asked for rather than trusted, and Search reports a filter
+// that did not take effect instead of quietly handing back safetensors
+// repositories.
+//
+// The same "answers 200 where it means something else" theme shows up in
+// the download path, where a ranged request comes back as 200 with a
+// Content-Range header. See DownloadURL.
+package modelscope
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
+)
+
+const (
+	baseURL = "https://modelscope.cn"
+	apiBase = baseURL + "/api/v1"
+
+	// revision is ModelScope's default branch name. HuggingFace calls the
+	// equivalent "main".
+	revision = "master"
+
+	// searchLimit matches the HuggingFace client's page size so both
+	// sources fill the results list to the same depth.
+	searchLimit = 50
+)
+
+// Client is a ModelScope API client. An empty token is fine: the public
+// repositories, which is all of them that matter here, need no auth.
+type Client struct {
+	httpClient *http.Client
+	token      string
+}
+
+func NewClient(token string) *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		token:      token,
+	}
+}
+
+// searchRequest is the body modelscope.cn's web UI sends.
+//
+// The Criterion field name is load-bearing and easy to get wrong: some
+// ModelScope SDK versions use "SingleCriterion", which this endpoint
+// accepts and silently ignores, returning unfiltered results. Likewise
+// SortBy must be "DownloadsCount" — "Downloads" is accepted and returns
+// an empty list.
+type searchRequest struct {
+	Name       string      `json:"Name"`
+	PageSize   int         `json:"PageSize"`
+	PageNumber int         `json:"PageNumber"`
+	SortBy     string      `json:"SortBy"`
+	Criterion  []criterion `json:"Criterion"`
+}
+
+type criterion struct {
+	Category  string   `json:"category"`
+	Predicate string   `json:"predicate"`
+	Values    []string `json:"values"`
+}
+
+type searchResponse struct {
+	Code    int    `json:"Code"`
+	Success bool   `json:"Success"`
+	Message string `json:"Message"`
+	Data    struct {
+		Model struct {
+			Models []struct {
+				Name      string   `json:"Name"`
+				Path      string   `json:"Path"` // the owner/org
+				Downloads int      `json:"Downloads"`
+				Stars     int      `json:"Stars"`
+				Tags      []string `json:"Tags"`
+				Libraries []string `json:"Libraries"`
+				License   string   `json:"License"`
+			} `json:"Models"`
+		} `json:"Model"`
+	} `json:"Data"`
+}
+
+// Search queries ModelScope for GGUF models, most-downloaded first.
+func (c *Client) Search(ctx context.Context, query string) ([]modelsource.SearchResult, error) {
+	body, err := json.Marshal(searchRequest{
+		Name:       query,
+		PageSize:   searchLimit,
+		PageNumber: 1,
+		SortBy:     "DownloadsCount",
+		Criterion: []criterion{
+			{Category: "libraries", Predicate: "contains", Values: []string{"gguf"}},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// PUT, not POST — the endpoint rejects POST.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, apiBase+"/dolphin/models", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.setAuth(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ModelScope API returned %d", resp.StatusCode)
+	}
+
+	var raw searchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+	if !raw.Success {
+		return nil, fmt.Errorf("ModelScope search failed: %s", raw.Message)
+	}
+
+	found := raw.Data.Model.Models
+	results := make([]modelsource.SearchResult, 0, len(found))
+	dropped := 0
+	for _, m := range found {
+		// Defence against the silent-filter failure described above: drop
+		// anything that isn't actually a GGUF repository, so a change to
+		// the criterion contract degrades to fewer results rather than to
+		// a list of models nothing here can load.
+		if !hasLibrary(m.Libraries, "gguf") {
+			dropped++
+			continue
+		}
+		results = append(results, modelsource.SearchResult{
+			ID:        m.Path + "/" + m.Name,
+			Author:    m.Path,
+			Downloads: m.Downloads,
+			Likes:     m.Stars,
+			Tags:      m.Tags,
+			License:   m.License,
+		})
+	}
+	// Every result being wrong means the server-side filter stopped
+	// working, which is worth surfacing rather than showing an empty list
+	// that reads as "no such model".
+	if dropped > 0 && len(results) == 0 {
+		return nil, fmt.Errorf("ModelScope returned %d models, none of them GGUF: the search filter is no longer being applied", dropped)
+	}
+	return results, nil
+}
+
+func hasLibrary(libs []string, want string) bool {
+	for _, l := range libs {
+		if strings.EqualFold(l, want) {
+			return true
+		}
+	}
+	return false
+}
+
+type filesResponse struct {
+	Code    int    `json:"Code"`
+	Success bool   `json:"Success"`
+	Message string `json:"Message"`
+	Data    struct {
+		Files []struct {
+			Name string `json:"Name"` // basename
+			Path string `json:"Path"` // path within the repo, which is what we want
+			Size int64  `json:"Size"`
+			Type string `json:"Type"` // "blob" or "tree"
+		} `json:"Files"`
+	} `json:"Data"`
+}
+
+// GetModel fetches a repository's GGUF files. Unlike the HuggingFace
+// client this needs a single request: ModelScope's file listing carries
+// sizes, where HuggingFace returns names and sizes from separate
+// endpoints.
+func (c *Client) GetModel(ctx context.Context, modelID string) (*modelsource.Detail, error) {
+	owner, name, ok := splitID(modelID)
+	if !ok {
+		return nil, fmt.Errorf("invalid ModelScope model id %q, want owner/name", modelID)
+	}
+
+	u := fmt.Sprintf("%s/models/%s/%s/repo/files?Revision=%s&Recursive=True",
+		apiBase, url.PathEscape(owner), url.PathEscape(name), revision)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ModelScope API returned %d", resp.StatusCode)
+	}
+
+	var raw filesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+	if !raw.Success {
+		return nil, fmt.Errorf("ModelScope file listing failed: %s", raw.Message)
+	}
+
+	detail := &modelsource.Detail{ID: modelID}
+	for _, f := range raw.Data.Files {
+		if f.Type == "tree" {
+			continue
+		}
+		// Path carries any subdirectory (quant folders like "UD-IQ1_M/"),
+		// which is what the download URL and the shard grouping need.
+		rel := f.Path
+		if rel == "" {
+			rel = f.Name
+		}
+		if !strings.HasSuffix(strings.ToLower(rel), ".gguf") {
+			continue
+		}
+		detail.Files = append(detail.Files, modelsource.File{
+			Filename:  rel,
+			Size:      f.Size,
+			Quant:     models.ParseQuant(rel),
+			IsMMProj:  models.IsMMProjFile(rel),
+			VRAMEstGB: modelsource.EstimateVRAM(f.Size),
+		})
+	}
+	detail.Files = modelsource.GroupShards(detail.Files)
+	return detail, nil
+}
+
+// DownloadURL returns a range-capable URL for one file.
+//
+// Two forms serve the same bytes and the choice between them is a real
+// trade-off, measured rather than assumed:
+//
+//   - This one, /api/v1/.../repo, is served by modelscope.cn directly and
+//     was reachable on every attempt from outside China.
+//   - The browser-facing /models/<id>/resolve/<rev>/<file> redirects to a
+//     signed cdn-lfs-cn-1.modelscope.cn link. That CDN answers a ranged
+//     request with a correct 206, but timed out on one attempt in three
+//     from here, and the signed URL expires.
+//
+// Reliability wins, but it comes with a caveat the caller must handle:
+// this endpoint answers a ranged request with status 200 and a
+// Content-Range header, where RFC 9110 requires 206. The body really is
+// just the requested range. Code that resumes a download by sending
+// Range and treats 200 as "the server ignored my Range and is sending
+// the whole file" will silently append a tail to a partial file and
+// produce a corrupt result — so a 200 carrying Content-Range must be
+// read as partial. See ResponseIsPartial.
+func (c *Client) DownloadURL(modelID, filename string) string {
+	owner, name, ok := splitID(modelID)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%s/models/%s/%s/repo?Revision=%s&FilePath=%s",
+		apiBase, url.PathEscape(owner), url.PathEscape(name), revision, url.QueryEscape(filename))
+}
+
+// ModelURL returns the human-facing page for a repository, for the link
+// next to a search result.
+func (c *Client) ModelURL(modelID string) string {
+	owner, name, ok := splitID(modelID)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%s/models/%s/%s", baseURL, url.PathEscape(owner), url.PathEscape(name))
+}
+
+// splitID splits "owner/name". ModelScope ids have exactly one slash.
+func splitID(modelID string) (owner, name string, ok bool) {
+	owner, name, ok = strings.Cut(modelID, "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", false
+	}
+	return owner, name, true
+}
+
+// ResponseIsPartial reports whether a response to a ranged request
+// carries only part of the file. It exists because ModelScope answers
+// with 200 plus Content-Range rather than the 206 the RFC requires (see
+// DownloadURL), so a status check alone is not enough to tell a resumed
+// download from a restarted one.
+func ResponseIsPartial(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusPartialContent || resp.Header.Get("Content-Range") != ""
+}
+
+func (c *Client) setAuth(req *http.Request) {
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+}

--- a/internal/modelscope/client_test.go
+++ b/internal/modelscope/client_test.go
@@ -1,0 +1,259 @@
+package modelscope
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestClient points a Client at a stub server by rewriting the request
+// host, so the real URL-building code under test still runs.
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	c := NewClient("")
+	c.httpClient = srv.Client()
+	c.httpClient.Transport = rewriteHost{base: srv.URL, rt: srv.Client().Transport}
+	return c, srv
+}
+
+type rewriteHost struct {
+	base string
+	rt   http.RoundTripper
+}
+
+func (r rewriteHost) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(r.base, "http://")
+	return r.rt.RoundTrip(req)
+}
+
+// The search body is the part most likely to break silently against the
+// live service, so pin its exact shape: "Criterion" (not
+// "SingleCriterion") and SortBy "DownloadsCount" (not "Downloads").
+func TestSearchRequestShape(t *testing.T) {
+	var got searchRequest
+	var method, path string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &got)
+		// Assert on the raw JSON keys too — the struct would happily
+		// decode a body that spelled the field differently.
+		var rawKeys map[string]json.RawMessage
+		json.Unmarshal(body, &rawKeys)
+		if _, ok := rawKeys["Criterion"]; !ok {
+			t.Errorf("request body has no Criterion key; keys=%v", keysOf(rawKeys))
+		}
+		if _, ok := rawKeys["SingleCriterion"]; ok {
+			t.Error("request used SingleCriterion, which this endpoint ignores")
+		}
+		w.Write([]byte(`{"Code":200,"Success":true,"Data":{"Model":{"Models":[]}}}`))
+	})
+	defer srv.Close()
+
+	if _, err := c.Search(context.Background(), "qwen3"); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if method != http.MethodPut {
+		t.Errorf("method = %s, want PUT (the endpoint rejects POST)", method)
+	}
+	if path != "/api/v1/dolphin/models" {
+		t.Errorf("path = %s", path)
+	}
+	if got.SortBy != "DownloadsCount" {
+		t.Errorf("SortBy = %q, want DownloadsCount (\"Downloads\" returns an empty list)", got.SortBy)
+	}
+	if got.Name != "qwen3" || got.PageSize != searchLimit {
+		t.Errorf("Name/PageSize = %q/%d", got.Name, got.PageSize)
+	}
+	if len(got.Criterion) != 1 || got.Criterion[0].Category != "libraries" ||
+		got.Criterion[0].Values[0] != "gguf" {
+		t.Errorf("Criterion = %+v, want libraries contains gguf", got.Criterion)
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestSearchMapsFields(t *testing.T) {
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Code":200,"Success":true,"Data":{"Model":{"Models":[
+		  {"Name":"Qwen3-8B-GGUF","Path":"unsloth","Downloads":23553,"Stars":13,
+		   "Tags":["unsloth","gguf"],"Libraries":["gguf","pytorch"],"License":"apache-2.0"}]}}}`))
+	})
+	defer srv.Close()
+
+	got, err := c.Search(context.Background(), "qwen")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d results, want 1", len(got))
+	}
+	r := got[0]
+	// ID is owner/name assembled from two fields — HuggingFace returns it
+	// pre-joined, and everything downstream assumes that shape.
+	if r.ID != "unsloth/Qwen3-8B-GGUF" {
+		t.Errorf("ID = %q, want unsloth/Qwen3-8B-GGUF", r.ID)
+	}
+	if r.Author != "unsloth" || r.Downloads != 23553 || r.License != "apache-2.0" {
+		t.Errorf("bad mapping: %+v", r)
+	}
+	// ModelScope has no "likes"; stars are the closest equivalent and are
+	// what the results list renders.
+	if r.Likes != 13 {
+		t.Errorf("Likes = %d, want 13 (from Stars)", r.Likes)
+	}
+}
+
+// If the server-side filter stops applying, non-GGUF repos come back with
+// HTTP 200. Those must never reach the results list.
+func TestSearchDropsNonGGUFResults(t *testing.T) {
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Code":200,"Success":true,"Data":{"Model":{"Models":[
+		  {"Name":"Meta-Llama-3.1-8B","Path":"LLM-Research","Libraries":["safetensors","pytorch"]},
+		  {"Name":"Llama-3.2-3B-Instruct-GGUF","Path":"unsloth","Libraries":["gguf","pytorch"]}]}}}`))
+	})
+	defer srv.Close()
+
+	got, err := c.Search(context.Background(), "llama")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "unsloth/Llama-3.2-3B-Instruct-GGUF" {
+		t.Errorf("got %+v, want only the GGUF repo", got)
+	}
+}
+
+// Filter failure across the board is an error, not an empty list: an empty
+// list reads as "no such model" and would send people hunting for a
+// spelling mistake.
+func TestSearchReportsTotalFilterFailure(t *testing.T) {
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Code":200,"Success":true,"Data":{"Model":{"Models":[
+		  {"Name":"Meta-Llama-3.1-8B","Path":"LLM-Research","Libraries":["safetensors"]}]}}}`))
+	})
+	defer srv.Close()
+
+	_, err := c.Search(context.Background(), "llama")
+	if err == nil {
+		t.Fatal("want an error when every result is non-GGUF")
+	}
+	if !strings.Contains(err.Error(), "filter") {
+		t.Errorf("error should name the filter as the cause, got: %v", err)
+	}
+}
+
+func TestGetModelFilesAndShards(t *testing.T) {
+	var gotPath, gotQuery string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		w.Write([]byte(`{"Code":200,"Success":true,"Data":{"Files":[
+		  {"Name":"README.md","Path":"README.md","Size":100,"Type":"blob"},
+		  {"Name":"UD-IQ1_M","Path":"UD-IQ1_M","Size":0,"Type":"tree"},
+		  {"Name":"m-UD-IQ1_M-00001-of-00002.gguf","Path":"UD-IQ1_M/m-UD-IQ1_M-00001-of-00002.gguf","Size":1000,"Type":"blob"},
+		  {"Name":"m-UD-IQ1_M-00002-of-00002.gguf","Path":"UD-IQ1_M/m-UD-IQ1_M-00002-of-00002.gguf","Size":2000,"Type":"blob"},
+		  {"Name":"mmproj-F16.gguf","Path":"mmproj-F16.gguf","Size":500,"Type":"blob"}]}}`))
+	})
+	defer srv.Close()
+
+	detail, err := c.GetModel(context.Background(), "unsloth/Model-GGUF")
+	if err != nil {
+		t.Fatalf("GetModel: %v", err)
+	}
+	if gotPath != "/api/v1/models/unsloth/Model-GGUF/repo/files" {
+		t.Errorf("path = %s", gotPath)
+	}
+	// ModelScope's default branch is master, not main.
+	if !strings.Contains(gotQuery, "Revision=master") || !strings.Contains(gotQuery, "Recursive=True") {
+		t.Errorf("query = %s", gotQuery)
+	}
+
+	// README dropped, tree entry dropped, the two shards grouped into one.
+	if len(detail.Files) != 2 {
+		t.Fatalf("got %d files, want 2 (grouped shard set + mmproj): %+v", len(detail.Files), detail.Files)
+	}
+	for _, f := range detail.Files {
+		switch {
+		case len(f.Shards) > 0:
+			if f.Size != 3000 {
+				t.Errorf("grouped shard size = %d, want 3000", f.Size)
+			}
+			if len(f.Shards) != 2 {
+				t.Errorf("want 2 shards, got %d", len(f.Shards))
+			}
+			// The subdirectory has to survive: it is part of the download path.
+			if !strings.HasPrefix(f.Shards[0], "UD-IQ1_M/") {
+				t.Errorf("shard lost its subdirectory: %q", f.Shards[0])
+			}
+		case f.IsMMProj:
+			if f.Filename != "mmproj-F16.gguf" {
+				t.Errorf("mmproj filename = %q", f.Filename)
+			}
+		default:
+			t.Errorf("unexpected file %+v", f)
+		}
+	}
+}
+
+func TestGetModelRejectsBadID(t *testing.T) {
+	c := NewClient("")
+	for _, id := range []string{"noslash", "/name", "owner/", "a/b/c"} {
+		if _, err := c.GetModel(context.Background(), id); err == nil {
+			t.Errorf("GetModel(%q) should have failed", id)
+		}
+	}
+}
+
+func TestURLs(t *testing.T) {
+	c := NewClient("")
+	got := c.DownloadURL("unsloth/Qwen3-8B-GGUF", "UD-IQ1_M/m-00001-of-00002.gguf")
+	want := "https://modelscope.cn/api/v1/models/unsloth/Qwen3-8B-GGUF/repo?Revision=master&FilePath=UD-IQ1_M%2Fm-00001-of-00002.gguf"
+	if got != want {
+		t.Errorf("DownloadURL =\n  %s\nwant\n  %s", got, want)
+	}
+	if got := c.ModelURL("unsloth/Qwen3-8B-GGUF"); got != "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF" {
+		t.Errorf("ModelURL = %s", got)
+	}
+	if got := c.ModelURL("nonsense"); got != "" {
+		t.Errorf("ModelURL of a malformed id = %q, want empty", got)
+	}
+}
+
+// A resumed download is told apart from a restarted one by this helper,
+// because ModelScope labels a partial body 200. Getting it wrong appends
+// a tail to a partial file and silently corrupts the result.
+func TestResponseIsPartial(t *testing.T) {
+	mk := func(status int, contentRange string) *http.Response {
+		h := http.Header{}
+		if contentRange != "" {
+			h.Set("Content-Range", contentRange)
+		}
+		return &http.Response{StatusCode: status, Header: h}
+	}
+	tests := []struct {
+		name string
+		resp *http.Response
+		want bool
+	}{
+		{"conforming 206", mk(206, "bytes 100-1123/2275379008"), true},
+		{"ModelScope's 200 with Content-Range", mk(200, "bytes 100-1123/2275379008"), true},
+		{"plain 200, whole file", mk(200, ""), false},
+		{"206 without the header", mk(206, ""), true},
+	}
+	for _, tt := range tests {
+		if got := ResponseIsPartial(tt.resp); got != tt.want {
+			t.Errorf("%s: ResponseIsPartial = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/internal/modelscope/live_test.go
+++ b/internal/modelscope/live_test.go
@@ -1,0 +1,128 @@
+package modelscope
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The endpoints this package uses are not a published contract — they are
+// what modelscope.cn's own web UI calls. These tests validate those
+// assumptions against the live service rather than code correctness, so
+// they are opt-in: set MODELSCOPE_LIVE_TEST=1.
+func liveClient(t *testing.T) (*Client, context.Context, context.CancelFunc) {
+	t.Helper()
+	if os.Getenv("MODELSCOPE_LIVE_TEST") != "1" {
+		t.Skip("set MODELSCOPE_LIVE_TEST=1 to run against the live ModelScope API")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	return NewClient(os.Getenv("MODELSCOPE_TOKEN")), ctx, cancel
+}
+
+func TestLiveSearch(t *testing.T) {
+	c, ctx, cancel := liveClient(t)
+	defer cancel()
+
+	got, err := c.Search(ctx, "qwen3")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("no results for \"qwen3\"")
+	}
+	for _, r := range got {
+		if !strings.Contains(r.ID, "/") {
+			t.Errorf("result id %q is not owner/name", r.ID)
+		}
+		if r.Author == "" {
+			t.Errorf("result %q has no author", r.ID)
+		}
+	}
+	// Sorted most-downloaded first, which is what SortBy=DownloadsCount
+	// buys us; if that key ever stops being honored this is what notices.
+	if len(got) > 1 && got[0].Downloads < got[len(got)-1].Downloads {
+		t.Errorf("results not sorted by downloads: first=%d last=%d",
+			got[0].Downloads, got[len(got)-1].Downloads)
+	}
+	t.Logf("%d results, top: %s (%d downloads)", len(got), got[0].ID, got[0].Downloads)
+}
+
+func TestLiveGetModel(t *testing.T) {
+	c, ctx, cancel := liveClient(t)
+	defer cancel()
+
+	const id = "unsloth/Qwen3-8B-GGUF"
+	detail, err := c.GetModel(ctx, id)
+	if err != nil {
+		t.Fatalf("GetModel: %v", err)
+	}
+	if len(detail.Files) == 0 {
+		t.Fatalf("no GGUF files in %s", id)
+	}
+	for _, f := range detail.Files {
+		if f.Size <= 0 {
+			t.Errorf("%s has no size — the file listing stopped carrying Size", f.Filename)
+		}
+		if f.Quant == "" && !f.IsMMProj {
+			t.Errorf("%s: quant not parsed", f.Filename)
+		}
+	}
+	t.Logf("%s: %d entries, first: %s (%.2f GiB, quant %s)",
+		id, len(detail.Files), detail.Files[0].Filename,
+		float64(detail.Files[0].Size)/(1<<30), detail.Files[0].Quant)
+}
+
+// The downloader resumes by re-requesting with a Range header, so a
+// download URL that does not honor ranges would break resume without
+// failing outright. This pins both halves of the real behavior: the range
+// is honored, and it comes back labelled 200 rather than 206 — the quirk
+// ResponseIsPartial exists for. If ModelScope ever starts returning a
+// conforming 206, the second assertion fails and this comment is what
+// explains that the change is welcome.
+func TestLiveDownloadURLHonorsRange(t *testing.T) {
+	c, ctx, cancel := liveClient(t)
+	defer cancel()
+
+	const id = "unsloth/Qwen3-8B-GGUF"
+	detail, err := c.GetModel(ctx, id)
+	if err != nil {
+		t.Fatalf("GetModel: %v", err)
+	}
+	var target string
+	var best int64
+	for _, f := range detail.Files {
+		if len(f.Shards) == 0 && (best == 0 || f.Size < best) {
+			best, target = f.Size, f.Filename
+		}
+	}
+	if target == "" {
+		t.Skip("no unsharded file to probe")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.DownloadURL(id, target), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Range", "bytes=100-1123")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("range request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if len(body) != 1024 {
+		t.Errorf("got %d bytes, want the 1024 requested — ranges are not being honored", len(body))
+	}
+	if !ResponseIsPartial(resp) {
+		t.Errorf("ResponseIsPartial said no: status=%d content-range=%q", resp.StatusCode, resp.Header.Get("Content-Range"))
+	}
+	if resp.StatusCode == http.StatusPartialContent {
+		t.Logf("NOTE: ModelScope now returns a conforming 206; the 200 workaround can be revisited")
+	}
+	t.Logf("%s: status %d, %d bytes, Content-Range %q", target, resp.StatusCode, len(body), resp.Header.Get("Content-Range"))
+}

--- a/internal/modelscope/testhooks.go
+++ b/internal/modelscope/testhooks.go
@@ -1,0 +1,35 @@
+package modelscope
+
+import (
+	"net/http"
+	"strings"
+)
+
+// This file is compiled into the package rather than kept in a _test.go
+// file because the tests that need it live in other packages: an
+// end-to-end check that a token saved in Settings reaches the wire has to
+// observe what this client sends, and the fields that decide that are
+// unexported. Nothing in the shipping code paths calls it.
+
+// SetHTTPClientForTest redirects this client's requests at a stub server,
+// keeping the real URL-building and auth code under test.
+func (c *Client) SetHTTPClientForTest(hc *http.Client, baseURL string) {
+	c.httpClient = hc
+	c.httpClient.Transport = testRewriteHost{
+		host: strings.TrimPrefix(strings.TrimPrefix(baseURL, "http://"), "https://"),
+		rt:   http.DefaultTransport,
+	}
+}
+
+// testRewriteHost sends every request to host instead of modelscope.cn,
+// leaving the path, query and headers the client built untouched.
+type testRewriteHost struct {
+	host string
+	rt   http.RoundTripper
+}
+
+func (r testRewriteHost) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = r.host
+	return r.rt.RoundTrip(req)
+}

--- a/internal/modelsource/files.go
+++ b/internal/modelsource/files.go
@@ -1,0 +1,88 @@
+package modelsource
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+// EstimateVRAM returns estimated VRAM in GB.
+// Uses file size * 1.1 as a rough estimate (overhead for KV cache and buffers).
+func EstimateVRAM(sizeBytes int64) float64 {
+	return float64(sizeBytes) * 1.1 / (1024 * 1024 * 1024)
+}
+
+// shardPattern matches split GGUF filenames like "model-00001-of-00005.gguf"
+var shardPattern = regexp.MustCompile(`^(.+)-(\d{5})-of-(\d{5})\.gguf$`)
+
+// GroupShards merges split GGUF shard files into single entries.
+// e.g., 5 files "model-0000N-of-00005.gguf" become one entry with combined size.
+func GroupShards(files []File) []File {
+	type shardGroup struct {
+		base   string
+		total  int
+		shards []File
+	}
+	groups := map[string]*shardGroup{}
+	var singles []File
+
+	for _, f := range files {
+		m := shardPattern.FindStringSubmatch(f.Filename)
+		if m == nil {
+			singles = append(singles, f)
+			continue
+		}
+		base := m[1]
+		total, _ := strconv.Atoi(m[3])
+		g, ok := groups[base]
+		if !ok {
+			g = &shardGroup{base: base, total: total}
+			groups[base] = g
+		}
+		g.shards = append(g.shards, f)
+	}
+
+	var result []File
+	for _, g := range groups {
+		sort.Slice(g.shards, func(i, j int) bool {
+			return g.shards[i].Filename < g.shards[j].Filename
+		})
+		var totalSize int64
+		var shardNames []string
+		for _, s := range g.shards {
+			totalSize += s.Size
+			shardNames = append(shardNames, s.Filename)
+		}
+		result = append(result, File{
+			Filename:  g.shards[0].Filename,
+			Size:      totalSize,
+			Quant:     g.shards[0].Quant,
+			VRAMEstGB: EstimateVRAM(totalSize),
+			Shards:    shardNames,
+		})
+	}
+
+	// Sort grouped entries by filename for stable ordering
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Filename < result[j].Filename
+	})
+
+	return append(result, singles...)
+}
+
+// ExpandShards returns all shard filenames for a split GGUF, or a single-element
+// slice for non-split files. Exported for use by the downloader.
+func ExpandShards(filename string) []string {
+	m := shardPattern.FindStringSubmatch(filename)
+	if m == nil {
+		return []string{filename}
+	}
+	base := m[1]
+	total, _ := strconv.Atoi(m[3])
+	shards := make([]string, total)
+	for i := range total {
+		shards[i] = fmt.Sprintf("%s-%05d-of-%05d.gguf", base, i+1, total)
+	}
+	return shards
+}

--- a/internal/modelsource/iface_test.go
+++ b/internal/modelsource/iface_test.go
@@ -1,0 +1,17 @@
+package modelsource_test
+
+import (
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/huggingface"
+	"github.com/tmac1973/llama-toolchest/internal/modelscope"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
+)
+
+// Both clients must stay interchangeable: the whole design rests on the
+// API layer being able to pick one by source id without any downstream
+// handler, template or struct knowing which it got.
+func TestBothClientsImplementSource(t *testing.T) {
+	var _ modelsource.Client = huggingface.NewClient("")
+	var _ modelsource.Client = modelscope.NewClient("")
+}

--- a/internal/modelsource/types.go
+++ b/internal/modelsource/types.go
@@ -1,0 +1,34 @@
+// Package modelsource holds the types shared by the model repositories
+// llama-toolchest can search and download from (HuggingFace, ModelScope).
+//
+// They live here rather than in one provider's package so a second
+// provider does not have to import the first just to describe a search
+// result. The provider packages alias these names, so existing references
+// like huggingface.ModelFile keep working and mean exactly this type.
+package modelsource
+
+// SearchResult is one model repository returned by a search.
+type SearchResult struct {
+	ID        string   `json:"id"`
+	Author    string   `json:"author"`
+	Downloads int      `json:"downloads"`
+	Likes     int      `json:"likes"`
+	Tags      []string `json:"tags"`
+	License   string   `json:"license,omitempty"`
+}
+
+// File is a single GGUF file (or a grouped shard set) in a repository.
+type File struct {
+	Filename  string   `json:"filename"`
+	Size      int64    `json:"size"`
+	Quant     string   `json:"quant"`
+	VRAMEstGB float64  `json:"vram_est_gb"`
+	Shards    []string `json:"shards,omitempty"`    // all shard filenames if split; nil for single files
+	IsMMProj  bool     `json:"is_mmproj,omitempty"` // true for vision projector files
+}
+
+// Detail holds one repository's GGUF files.
+type Detail struct {
+	ID    string `json:"id"`
+	Files []File `json:"files"`
+}

--- a/internal/modelsource/types.go
+++ b/internal/modelsource/types.go
@@ -7,6 +7,8 @@
 // like huggingface.ModelFile keep working and mean exactly this type.
 package modelsource
 
+import "context"
+
 // SearchResult is one model repository returned by a search.
 type SearchResult struct {
 	ID        string   `json:"id"`
@@ -31,4 +33,40 @@ type File struct {
 type Detail struct {
 	ID    string `json:"id"`
 	Files []File `json:"files"`
+}
+
+// Source ids for the model repositories llama-toolchest can use. They are
+// persisted on download records and model registry entries, so the string
+// values are part of the on-disk format and must not change.
+const (
+	SourceHuggingFace = "hf"
+	SourceModelScope  = "modelscope"
+)
+
+// KnownSource reports whether id names a source this build understands.
+// The empty string is HuggingFace: every record written before a second
+// source existed came from there.
+func KnownSource(id string) bool {
+	return id == "" || id == SourceHuggingFace || id == SourceModelScope
+}
+
+// NormalizeSource maps an empty or unrecognized source id onto
+// HuggingFace, the default.
+func NormalizeSource(id string) string {
+	if id == SourceModelScope {
+		return SourceModelScope
+	}
+	return SourceHuggingFace
+}
+
+// Client is what a model source must provide for the browse-and-download
+// flow. Both the HuggingFace and ModelScope clients implement it, which
+// is what lets the API layer pick one by source id and leave every
+// downstream handler, template and struct untouched.
+type Client interface {
+	Search(ctx context.Context, query string) ([]SearchResult, error)
+	GetModel(ctx context.Context, modelID string) (*Detail, error)
+	// ModelURL is the human-facing repository page, or empty when the id
+	// is not a linkable owner/name pair.
+	ModelURL(modelID string) string
 }

--- a/internal/presets/fetcher.go
+++ b/internal/presets/fetcher.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tmac1973/llama-toolchest/internal/models"
@@ -38,15 +39,34 @@ const (
 type Fetcher struct {
 	HFBase   string
 	DocsBase string
-	Token    string // HF bearer token, optional (higher rate limits, gated mirrors)
 	CacheDir string // on-disk cache for docs fetches; "" disables caching
 	Client   *http.Client
+
+	// token is the HF bearer token (optional: higher rate limits, gated
+	// mirrors). Guarded because Settings can replace it while a
+	// background preset backfill is mid-fetch.
+	mu    sync.RWMutex
+	token string
+}
+
+// SetToken replaces the HuggingFace token, so a token saved in Settings
+// applies to the next fetch instead of the next restart.
+func (f *Fetcher) SetToken(token string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.token = token
+}
+
+func (f *Fetcher) authToken() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.token
 }
 
 // NewFetcher returns a Fetcher caching docs fetches under cacheDir.
 func NewFetcher(cacheDir, hfToken string) *Fetcher {
 	return &Fetcher{
-		Token:    hfToken,
+		token:    hfToken,
 		CacheDir: cacheDir,
 		Client:   &http.Client{Timeout: 15 * time.Second},
 	}
@@ -153,8 +173,8 @@ func (f *Fetcher) get(ctx context.Context, url string, withAuth bool) ([]byte, e
 			return nil, err
 		}
 		req.Header.Set("User-Agent", userAgent)
-		if withAuth && f.Token != "" {
-			req.Header.Set("Authorization", "Bearer "+f.Token)
+		if tok := f.authToken(); withAuth && tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
 		}
 		resp, err := f.Client.Do(req)
 		if err != nil {

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -73,7 +73,7 @@
         <a href="#builds">Builds</a>
         <a href="#models">Models</a>
         <a href="#model-config">Model config</a>
-        <a href="#search-hf">Search HF</a>
+        <a href="#search-hf">Download Models</a>
         <a href="#benchmarks">Benchmarks</a>
         <a href="#settings">Settings</a>
         <a href="#api">Using the API</a>
@@ -83,7 +83,7 @@
     <h2 id="quickstart">Quickstart</h2>
     <ol>
         <li><strong>Build llama.cpp.</strong> Go to <a href="/builds">Builds</a>, pick a profile that matches your hardware (CUDA, ROCm, Vulkan, CPU), and start a build. Builds are cached and reused.</li>
-        <li><strong>Download a model.</strong> On <a href="/models/browse">Search HF</a>, search for a GGUF repo (e.g. <code>unsloth/Qwen3.5-4B-GGUF</code>) and download a quant (<code>Q4_K_M</code> is a good balance for most).</li>
+        <li><strong>Download a model.</strong> On <a href="/models/browse">Download Models</a>, search for a GGUF repo (e.g. <code>unsloth/Qwen3.5-4B-GGUF</code>) and download a quant (<code>Q4_K_M</code> is a good balance for most).</li>
         <li><strong>Enable it.</strong> On <a href="/models">Models</a>, flip the "On" switch for the model(s) you want the server to serve.</li>
         <li><strong>Tune for VRAM.</strong> Click <em>Configure</em> on a model to adjust what matters most: <em>Context Size</em> (smaller = less KV cache = less VRAM) and <em>KV Cache Quant</em> (<code>q8_0</code> roughly halves KV memory with little quality cost). Watch the <em>VRAM Est.</em> column update so you can see the model fit.</li>
         <li><strong>Start the server.</strong> Go to <a href="/server">Server</a> and click <em>Start</em>. Use the <span class="inline-icon"><svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M4 3l9 5-9 5z"/></svg></span> icon in the Available Models card to force-load a model into VRAM, or let the router load it on the first request.</li>
@@ -224,9 +224,9 @@
         Most config changes require a <strong>server restart</strong> to take effect (the flags are baked into the preset file that llama-server reads at startup). Sampling params apply per-request with no restart.
     </div>
 
-    <h2 id="search-hf">Search HF</h2>
-    <p>Search HuggingFace for GGUF repos, browse files, and download specific quants. Downloads resume on interruption. Large models are shown with their total size so you know what you're committing to. After a download completes, recommended sampling presets are fetched automatically in the background and appear in <em>Configure → Sampling</em>.</p>
-    <p>Gated models require a HuggingFace token — set it under <a href="/settings">Settings</a>.</p>
+    <h2 id="search-hf">Download Models</h2>
+    <p>Search <strong>HuggingFace</strong> or <strong>ModelScope</strong> for GGUF repos, browse files, and download specific quants — pick the host with the radio buttons above the search box. Downloads resume on interruption. Large models are shown with their total size so you know what you're committing to. After a download completes, recommended sampling presets are fetched automatically in the background and appear in <em>Configure → Sampling</em>.</p>
+    <p>ModelScope mirrors most of the popular GGUF repositories and can be the faster of the two depending on where you are. Gated models require a token for the host you are downloading from — set it under <a href="/settings">Settings</a>.</p>
 
     <h3>Vision models &amp; projector files</h3>
     <p>Some vision-capable LLMs come as two files: the main GGUF (text+vision weights) and a separate <strong>mmproj</strong> file (the vision projector — maps image embeddings into the model's text space). On HuggingFace these usually live in the same repo, with names like <code>mmproj-<em>model</em>.gguf</code>.</p>

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -574,7 +574,7 @@
                 <li><a href="/server"{{if eq .Nav "server"}} aria-current="page"{{end}}>Server</a></li>
                 <li><a href="/builds"{{if eq .Nav "builds"}} aria-current="page"{{end}}>Builds</a></li>
                 <li><a href="/models"{{if eq .Nav "models"}} aria-current="page"{{end}}>Models</a></li>
-                <li><a href="/models/browse"{{if eq .Nav "browse"}} aria-current="page"{{end}}>Search HF</a></li>
+                <li><a href="/models/browse"{{if eq .Nav "browse"}} aria-current="page"{{end}}>Download Models</a></li>
                 <li><a href="/benchmarks"{{if eq .Nav "benchmarks"}} aria-current="page"{{end}}>Benchmarks</a></li>
                 <li><a href="/settings"{{if eq .Nav "settings"}} aria-current="page"{{end}}>Settings</a></li>
                 <li><a href="/help"{{if eq .Nav "help"}} aria-current="page"{{end}}>Help</a></li>

--- a/web/templates/models_browse.html
+++ b/web/templates/models_browse.html
@@ -7,11 +7,11 @@
       hx-indicator="#search-spinner">
     <fieldset role="group" style="margin-bottom:0.5rem;">
         <label style="display:inline-flex;align-items:center;gap:0.35rem;margin-right:1rem;font-weight:normal;">
-            <input type="radio" name="source" value="hf" checked>
+            <input type="radio" name="source" value="hf" {{if ne .DefaultSource "modelscope"}}checked{{end}}>
             HuggingFace
         </label>
         <label style="display:inline-flex;align-items:center;gap:0.35rem;font-weight:normal;">
-            <input type="radio" name="source" value="modelscope">
+            <input type="radio" name="source" value="modelscope" {{if eq .DefaultSource "modelscope"}}checked{{end}}>
             ModelScope
         </label>
     </fieldset>

--- a/web/templates/models_browse.html
+++ b/web/templates/models_browse.html
@@ -1,10 +1,20 @@
 {{define "content"}}
-<h1>Search HuggingFace</h1>
+<h1>Download Models</h1>
 
 <form hx-get="/api/hf/search"
       hx-target="#hf-results"
       hx-swap="innerHTML"
       hx-indicator="#search-spinner">
+    <fieldset role="group" style="margin-bottom:0.5rem;">
+        <label style="display:inline-flex;align-items:center;gap:0.35rem;margin-right:1rem;font-weight:normal;">
+            <input type="radio" name="source" value="hf" checked>
+            HuggingFace
+        </label>
+        <label style="display:inline-flex;align-items:center;gap:0.35rem;font-weight:normal;">
+            <input type="radio" name="source" value="modelscope">
+            ModelScope
+        </label>
+    </fieldset>
     <div class="grid">
         <input type="search" name="q" placeholder="Search GGUF models..." autofocus>
         <button type="submit">Search</button>

--- a/web/templates/partials/hf_files.html
+++ b/web/templates/partials/hf_files.html
@@ -44,7 +44,7 @@
                 {{else}}
                     <button type="button"
                             hx-post="/api/hf/download"
-                            hx-vals='{"model_id":"{{$.ID}}","filename":"{{$f.Filename}}","size":"{{$f.Size}}"}'
+                            hx-vals='{"model_id":"{{$.ID}}","filename":"{{$f.Filename}}","size":"{{$f.Size}}","source":"{{$.Source}}"}'
                             hx-target="#dl-{{cssID $.ID}}-{{$i}}"
                             hx-swap="innerHTML">
                         Download

--- a/web/templates/partials/hf_results.html
+++ b/web/templates/partials/hf_results.html
@@ -5,13 +5,13 @@
     <div style="display: flex; justify-content: space-between; align-items: center;">
         <div>
             <strong>{{$m.ID}}</strong>
-            {{if hasHFRepo $m.ID}}<a href="https://huggingface.co/{{$m.ID}}" target="_blank" rel="noopener" title="Open on HuggingFace" style="text-decoration:none;color:var(--pico-muted-color);font-size:0.85em;margin-left:0.15rem;">&#x2197;</a>{{end}}
+            {{with sourceModelURL $.Source $m.ID}}<a href="{{.}}" target="_blank" rel="noopener" title="Open on {{sourceName $.Source}}" style="text-decoration:none;color:var(--pico-muted-color);font-size:0.85em;margin-left:0.15rem;">&#x2197;</a>{{end}}
             {{if $m.License}}<small> — {{$m.License}}</small>{{end}}
             <br>
             <small>{{$m.Downloads}} downloads · {{$m.Likes}} likes</small>
         </div>
         <button type="button"
-                hx-get="/api/hf/model?id={{$m.ID}}"
+                hx-get="/api/hf/model?id={{$m.ID}}&source={{$.Source}}"
                 hx-target="#hf-files-{{$i}}"
                 hx-swap="innerHTML"
                 class="outline"

--- a/web/templates/partials/model_card.html
+++ b/web/templates/partials/model_card.html
@@ -25,7 +25,7 @@
             {{if .PendingDisable}}<span title="Restart server to remove this model" style="cursor: help; color: var(--pico-del-color); margin-right: 0.2rem;">&#x2298;</span>{{end}}
             {{if .NeedsReload}}<span title="Restart server to apply config changes" style="cursor: help; color: var(--pico-primary); margin-right: 0.2rem;">&#x21bb;</span>{{end}}
             {{.ModelID}}
-            {{if hasHFRepo .ModelID}}<a href="https://huggingface.co/{{.ModelID}}" target="_blank" rel="noopener" title="Open on HuggingFace" style="text-decoration:none;color:var(--pico-muted-color);font-size:0.85em;margin-left:0.15rem;">&#x2197;</a>{{end}}
+            {{with sourceModelURL .Source .ModelID}}<a href="{{.}}" target="_blank" rel="noopener" title="Open model page" style="text-decoration:none;color:var(--pico-muted-color);font-size:0.85em;margin-left:0.15rem;">&#x2197;</a>{{end}}
             {{if .HasVision}} <mark style="padding:0 0.3rem;font-size:0.75rem;">vision</mark>{{end}}
             {{if .SupportsTools}} <mark style="padding:0 0.3rem;font-size:0.75rem;">tools</mark>{{end}}
             {{if .GPULabel}} <mark style="padding:0 0.3rem;font-size:0.75rem;background:var(--pico-muted-border-color);color:var(--pico-color);">{{.GPULabel}}</mark>{{end}}

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -257,11 +257,18 @@
 </article>
 
 <article>
-    <header>Model Source Tokens</header>
-    <p>Required only for gated or private repositories. Public models download without a token from either source.</p>
+    <header>Model Sources</header>
+    <p>Which repository the <a href="/models/browse">Download Models</a> page searches by default — you can still switch per search. Tokens are needed only for gated or private repositories; public models download without one from either source.</p>
     <form hx-put="/api/settings"
           hx-target="#hf-token-status"
           hx-swap="innerHTML">
+        <label>
+            Default search source
+            <select name="default_model_source">
+                <option value="hf" {{if ne .DefaultSource "modelscope"}}selected{{end}}>HuggingFace</option>
+                <option value="modelscope" {{if eq .DefaultSource "modelscope"}}selected{{end}}>ModelScope</option>
+            </select>
+        </label>
         <label>
             HuggingFace Token
             <input type="password" name="hf_token"

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -164,7 +164,7 @@
                             if (l && l[0] !== '#') envCount++;
                         });
                     }
-                    var hasSecrets = !!(s.hf_token || s.api_key);
+                    var hasSecrets = !!(s.hf_token || s.ms_token || s.api_key);
                     setSection('sec-label-settings', b[0], !!d.settings,
                         'Settings' + (hasSecrets ? ' ⚠ contains secrets' : ''));
                     setSection('sec-label-env', b[1], !!env, 'Runtime env (' + envCount + ')');
@@ -257,15 +257,20 @@
 </article>
 
 <article>
-    <header>HuggingFace Token</header>
-    <p>Required for gated model downloads.</p>
+    <header>Model Source Tokens</header>
+    <p>Required only for gated or private repositories. Public models download without a token from either source.</p>
     <form hx-put="/api/settings"
           hx-target="#hf-token-status"
           hx-swap="innerHTML">
         <label>
-            HF Token
+            HuggingFace Token
             <input type="password" name="hf_token"
                    placeholder="{{if .HasHFToken}}(token is set){{else}}hf_...{{end}}">
+        </label>
+        <label>
+            ModelScope Token
+            <input type="password" name="ms_token"
+                   placeholder="{{if .HasMSToken}}(token is set){{else}}ms_...{{end}}">
         </label>
         <button type="submit">Save</button>
     </form>


### PR DESCRIPTION
Adds ModelScope (modelscope.cn) as a second model source. The only new control is a radio pair above the search box, as specified — every other view (file list, quant picker, disk-space guard, progress, downloads panel) is untouched.

Two commits: the client on its own, then the wiring.

## How the UI stays unchanged

Both clients satisfy one `modelsource.Client` interface and return the same types, so the API layer picks one by source id and nothing downstream knows which it got. The shared types moved to a new `internal/modelsource` package and `internal/huggingface` **aliases** them, so `huggingface.ModelFile` still compiles everywhere and *is* the same type — the refactor touched no call sites.

## A correctness fix that applies to both sources

The downloader decided whether a response carried the whole file or just the requested tail by testing `resp.StatusCode == 206`. ModelScope answers a ranged request with **200 plus a `Content-Range` header**. Against it, a resume would take the 200 branch, reset the resume offset to zero, open the partial with `O_TRUNC`, and write the tail over it — a truncated model reported as complete.

A `Content-Range` header now means partial whatever the status. That is also correct for HuggingFace, where the two signals agree, so this is a strict improvement rather than a special case.

I only found this by testing: my earlier endpoint probe *looked* like it returned 206 and I reported it as such. Re-reading the raw output showed 200 with a `Content-Range`.

## Source travels with the download

From search result to bytes on disk: the Files button passes it, the download button posts it, the downloader resolves URL and token through a per-source `Provider`, and the registry records it on the model. That last part is what makes the **links work** — the "open model page" arrows now point at the host a model actually came from, in both search results and model cards. `hasHFRepo`, which hardcoded one host, is gone.

An empty source means HuggingFace everywhere, so records written before this change and models found by a disk scan keep working and keep linking correctly.

## Verification

Live, through the running app:

| check | result |
|---|---|
| Search ModelScope via the API | 50 GGUF repos, top `unsloth/Qwen3-30B-A3B-GGUF` (1,119,515 downloads) |
| File listing, `unsloth/Qwen3-8B-GGUF` | 25 files with sizes and parsed quants, in one request (HF needs two) |
| **Download, cancel at 5.5 MB, resume** | **byte-for-byte identical to upstream**, pre-cancel prefix unchanged |
| Registry record | `source='modelscope'` |

That resume is the exact path the status-code bug would have corrupted, on a real 205 MiB file.

Unit tests cover the search request shape (pinning `Criterion` over `SingleCriterion`, and `SortBy: DownloadsCount`), non-GGUF results being dropped, total filter failure raising rather than returning an empty list, shard grouping with subdirectories preserved, URL construction, source defaulting, and the templates carrying the source into links, file requests and downloads. Live tests are opt-in via `MODELSCOPE_LIVE_TEST=1`.

## Notes

- ModelScope's REST surface is not a published contract — the search call is what modelscope.cn's own web UI issues. It fails by returning plausible data rather than errors, so `Search` re-checks each result's `Libraries` and raises a diagnosable error if the server-side filter stops applying.
- The download URL is the direct `/api/v1/.../repo` form. The browser-facing `resolve` link returns a conforming 206 but redirects to a CDN that timed out on one attempt in three from outside China, and hands back an expiring signed URL.
- New optional `ms_token` config key, for gated repos only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go9An1JPRDAuj8nVYwpXLZ