### PR TITLE
feat(browse): exclude streamed embedding tables from the VRAM estimate

### DIFF
--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -11,11 +12,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/tmac1973/llama-toolchest/internal/huggingface"
 	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
 )
 
 // hfFileView decorates a HuggingFace ModelFile with local-state flags used
@@ -89,6 +92,13 @@ func (s *Server) handleHFModel(w http.ResponseWriter, r *http.Request) {
 		FreeBytes:      s.downloader.FreeBytes(),
 		SafetyMargin:   huggingface.DiskSafetyMarginBytes,
 	}
+	// Measure how much of each candidate is streamed rather than loaded,
+	// so the VRAM column reflects what actually reaches the card. Only
+	// the large files are probed and each is a small ranged read, but
+	// they are done together so the listing is not serialized behind
+	// them.
+	s.probeStreamedBytes(r.Context(), source, detail)
+
 	for _, f := range detail.Files {
 		fv := hfFileView{ModelFile: f}
 		if _, ok := s.registry.HasFile(detail.ID, f.Filename); ok {
@@ -475,4 +485,86 @@ func (s *Server) onDownloadComplete(source, downloadID, modelID, filename string
 	// in the background — the GGUF-embedded default was already attached via
 	// meta.ApplyTo above.
 	go s.enrichModelPresets(m.ID)
+}
+
+// probeStreamedBytes fills in StreamedBytes for the files in detail,
+// adjusting their VRAM estimate to exclude a per-layer embedding table
+// that llama.cpp will stream from disk.
+//
+// The correction is worth the trouble: on Qwen3.8-Flash-Next the table is
+// about 40% of the download, so the uncorrected estimate calls a model
+// too large for a card it comfortably fits on. Results are cached per
+// (source, repo, file) because the answer is a property of the published
+// file and does not change.
+func (s *Server) probeStreamedBytes(ctx context.Context, source string, detail *modelsource.Detail) {
+	client := s.sourceClient(source)
+	token := s.sourceToken(source)
+
+	// Bound the whole batch: a listing must not hang on a slow host.
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := range detail.Files {
+		f := &detail.Files[i]
+		if cached, ok := s.cachedProbe(source, detail.ID, f.Filename); ok {
+			applyProbe(f, cached)
+			continue
+		}
+		names, sizes := f.Shards, f.ShardSizes
+		if len(names) == 0 {
+			names, sizes = []string{f.Filename}, []int64{f.Size}
+		}
+		if len(sizes) != len(names) {
+			continue
+		}
+		shards := make([]modelsource.ShardURL, 0, len(names))
+		for j, n := range names {
+			shards = append(shards, modelsource.ShardURL{URL: client.DownloadURL(detail.ID, n), Size: sizes[j]})
+		}
+
+		wg.Add(1)
+		go func(f *modelsource.File, shards []modelsource.ShardURL) {
+			defer wg.Done()
+			res := modelsource.ProbePLE(ctx, nil, token, shards, f.Size)
+			if res.Probed {
+				s.storeProbe(source, detail.ID, f.Filename, res)
+			}
+			applyProbe(f, res)
+		}(f, shards)
+	}
+	wg.Wait()
+}
+
+// applyProbe records a probe result on a file and rewrites its VRAM
+// estimate to cover only the part that becomes resident.
+func applyProbe(f *modelsource.File, res modelsource.ProbeResult) {
+	if !res.Probed {
+		return
+	}
+	f.StreamProbed = true
+	f.StreamedBytes = res.StreamedBytes
+	if res.StreamedBytes > 0 && res.StreamedBytes < f.Size {
+		f.VRAMEstGB = modelsource.EstimateVRAM(f.Size - res.StreamedBytes)
+	}
+}
+
+func probeKey(source, modelID, filename string) string {
+	return source + "\x00" + modelID + "\x00" + filename
+}
+
+func (s *Server) cachedProbe(source, modelID, filename string) (modelsource.ProbeResult, bool) {
+	s.probeMu.RLock()
+	defer s.probeMu.RUnlock()
+	r, ok := s.probeCache[probeKey(source, modelID, filename)]
+	return r, ok
+}
+
+func (s *Server) storeProbe(source, modelID, filename string, res modelsource.ProbeResult) {
+	s.probeMu.Lock()
+	defer s.probeMu.Unlock()
+	if s.probeCache == nil {
+		s.probeCache = make(map[string]modelsource.ProbeResult)
+	}
+	s.probeCache[probeKey(source, modelID, filename)] = res
 }

--- a/internal/api/modelsource_test.go
+++ b/internal/api/modelsource_test.go
@@ -197,3 +197,81 @@ func TestDefaultModelSourceFallback(t *testing.T) {
 		t.Errorf("zero Server: %q, want hf", got)
 	}
 }
+
+// A streamed table must be excluded from the VRAM estimate and shown as
+// such, or the fit verdict stays wrong in exactly the case the probe
+// exists to fix.
+func TestFileListShowsStreamedPortion(t *testing.T) {
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	const gib = int64(1) << 30
+	view := hfModelView{
+		ID:     "unsloth/Qwen3.8-Flash-Next-GGUF",
+		Source: modelsource.SourceModelScope,
+		Files: []hfFileView{{
+			ModelFile: modelsource.File{
+				Filename: "q.gguf", Size: 68 * gib, Quant: "UD_IQ1_S",
+				StreamedBytes: 27 * gib, StreamProbed: true,
+				VRAMEstGB: modelsource.EstimateVRAM(41 * gib),
+			},
+			FitsOnDisk: true,
+		}},
+		AvailableBytes: 1 << 46,
+	}
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, "hf_files", view); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "streamed from disk") {
+		t.Errorf("streamed portion not surfaced; output=\n%s", out)
+	}
+	// The full download is still what lands on disk, so Size must not be
+	// quietly reduced to the resident part.
+	if !strings.Contains(out, "68.0 GiB") {
+		t.Error("Size column should still show the whole download")
+	}
+	if !strings.Contains(out, "45.1 GiB") {
+		t.Errorf("VRAM estimate should cover only the resident part; output=\n%s", out)
+	}
+}
+
+// applyProbe is what turns a measurement into a corrected estimate, and
+// its edge cases decide whether a bad probe can make things worse.
+func TestApplyProbe(t *testing.T) {
+	const gib = int64(1) << 30
+	base := modelsource.File{Size: 68 * gib, VRAMEstGB: modelsource.EstimateVRAM(68 * gib)}
+
+	// A probe that did not run leaves the estimate exactly as it was.
+	f := base
+	applyProbe(&f, modelsource.ProbeResult{})
+	if f.VRAMEstGB != base.VRAMEstGB || f.StreamProbed {
+		t.Errorf("unprobed file was modified: %+v", f)
+	}
+
+	// A completed probe finding no table records the fact but changes
+	// nothing, so the listing does not re-probe it.
+	f = base
+	applyProbe(&f, modelsource.ProbeResult{Probed: true})
+	if !f.StreamProbed || f.VRAMEstGB != base.VRAMEstGB {
+		t.Errorf("no-table probe should record and not adjust: %+v", f)
+	}
+
+	// A real table is subtracted.
+	f = base
+	applyProbe(&f, modelsource.ProbeResult{Probed: true, StreamedBytes: 27 * gib})
+	if want := modelsource.EstimateVRAM(41 * gib); f.VRAMEstGB != want {
+		t.Errorf("VRAMEstGB = %.2f, want %.2f", f.VRAMEstGB, want)
+	}
+
+	// A nonsensical measurement larger than the file must not produce a
+	// negative estimate.
+	f = base
+	applyProbe(&f, modelsource.ProbeResult{Probed: true, StreamedBytes: 999 * gib})
+	if f.VRAMEstGB != base.VRAMEstGB {
+		t.Errorf("oversized measurement changed the estimate to %.2f", f.VRAMEstGB)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,14 +31,20 @@ import (
 )
 
 type Server struct {
-	cfg         *config.Config
-	configPath  string // path the cfg was loaded from; saveConfig writes back here
-	version     string // injected by main via SetVersion; "" = dev build
-	pages       map[string]*template.Template
-	router      chi.Router
-	builder     *builder.Builder
-	hfClient    *huggingface.Client
-	msClient    *modelscope.Client
+	cfg        *config.Config
+	configPath string // path the cfg was loaded from; saveConfig writes back here
+	version    string // injected by main via SetVersion; "" = dev build
+	pages      map[string]*template.Template
+	router     chi.Router
+	builder    *builder.Builder
+	hfClient   *huggingface.Client
+	msClient   *modelscope.Client
+
+	// probeCache memoizes remote GGUF header probes, keyed by source,
+	// repo and file. A published file's layout does not change, so the
+	// answer is good for the life of the process.
+	probeMu     sync.RWMutex
+	probeCache  map[string]modelsource.ProbeResult
 	downloader  *huggingface.Downloader
 	registry    *models.Registry
 	presets     *presets.Fetcher
@@ -876,6 +882,18 @@ func (s *Server) defaultModelSource() string {
 		return modelsource.SourceHuggingFace
 	}
 	return modelsource.NormalizeSource(s.cfg.DefaultModelSource)
+}
+
+// sourceToken returns the credential for a source, for callers that make
+// their own requests rather than going through a client.
+func (s *Server) sourceToken(source string) string {
+	if s.cfg == nil {
+		return ""
+	}
+	if modelsource.NormalizeSource(source) == modelsource.SourceModelScope {
+		return s.cfg.MSToken
+	}
+	return s.cfg.HFToken
 }
 
 // sourceClient returns the client for a source id, defaulting to

--- a/internal/huggingface/client.go
+++ b/internal/huggingface/client.go
@@ -176,6 +176,13 @@ func (c *Client) populateFileSizes(ctx context.Context, modelID string, detail *
 	}
 }
 
+// DownloadURL returns the URL for one file in a repository. The same
+// form the downloader uses, exposed so other callers (the header probe)
+// do not have to rebuild it.
+func (c *Client) DownloadURL(modelID, filename string) string {
+	return "https://huggingface.co/" + modelID + "/resolve/main/" + filename
+}
+
 // ModelURL returns the human-facing page for a repository, for the link
 // next to a search result.
 func (c *Client) ModelURL(modelID string) string {

--- a/internal/huggingface/downloader.go
+++ b/internal/huggingface/downloader.go
@@ -140,7 +140,7 @@ func (d *Downloader) provider(source string) Provider {
 }
 
 func hfDownloadURL(modelID, filename string) string {
-	return fmt.Sprintf("https://huggingface.co/%s/resolve/main/%s", modelID, filename)
+	return (&Client{}).DownloadURL(modelID, filename)
 }
 
 // SetOnComplete registers a callback invoked when a download finishes.

--- a/internal/models/gguf.go
+++ b/internal/models/gguf.go
@@ -149,6 +149,15 @@ func ParseGGUFMeta(path string) (*GGUFMeta, error) {
 		return nil, err
 	}
 	defer f.Close()
+	return ParseGGUFMetaFrom(f)
+}
+
+// ParseGGUFMetaFrom reads the same metadata from an arbitrary seekable
+// source. Split out from ParseGGUFMeta so a GGUF that isn't on disk yet
+// can be inspected over ranged HTTP reads — see modelsource.ProbePLE,
+// which uses it to answer "how much of this download never reaches VRAM"
+// before anyone commits to the download.
+func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 
 	// Magic: "GGUF"
 	var magic [4]byte

--- a/internal/models/vram.go
+++ b/internal/models/vram.go
@@ -120,11 +120,14 @@ func VRAMEstimateForConfig(m *Model, cfg *ModelConfig) float64 {
 	return weightsGB + m.KVCacheGB(ctx, cfg.KVCacheQuant) + AuxFilesVRAMGB(cfg) + vramOverheadGB
 }
 
-// pleAutoMinBytes mirrors auto_lazy_min_size in llama.cpp's model loader:
+// PLEAutoMinBytes mirrors auto_lazy_min_size in llama.cpp's model loader:
 // under the default auto mode, only tables above this size are read on
 // demand. Smaller ones stay resident, because the per-row read latency
 // costs more than the memory is worth on a small model.
-const pleAutoMinBytes = 4 * 1024 * 1024 * 1024
+const PLEAutoMinBytes = 4 * 1024 * 1024 * 1024
+
+// pleAutoMinBytes is the unexported spelling this file already used.
+const pleAutoMinBytes = PLEAutoMinBytes
 
 // lazyPLEBytes returns the number of bytes of the model file that
 // llama.cpp will read on demand rather than load, which is the part a VRAM

--- a/internal/modelsource/files.go
+++ b/internal/modelsource/files.go
@@ -50,16 +50,19 @@ func GroupShards(files []File) []File {
 		})
 		var totalSize int64
 		var shardNames []string
+		var shardSizes []int64
 		for _, s := range g.shards {
 			totalSize += s.Size
 			shardNames = append(shardNames, s.Filename)
+			shardSizes = append(shardSizes, s.Size)
 		}
 		result = append(result, File{
-			Filename:  g.shards[0].Filename,
-			Size:      totalSize,
-			Quant:     g.shards[0].Quant,
-			VRAMEstGB: EstimateVRAM(totalSize),
-			Shards:    shardNames,
+			Filename:   g.shards[0].Filename,
+			Size:       totalSize,
+			Quant:      g.shards[0].Quant,
+			VRAMEstGB:  EstimateVRAM(totalSize),
+			Shards:     shardNames,
+			ShardSizes: shardSizes,
 		})
 	}
 

--- a/internal/modelsource/ple_probe.go
+++ b/internal/modelsource/ple_probe.go
@@ -1,0 +1,170 @@
+package modelsource
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/tmac1973/llama-toolchest/internal/models"
+)
+
+const (
+	// probeChunk is how much of a header to fetch per request. Sized for
+	// the case that matters: a split GGUF's tensor-carrying shards have
+	// no metadata block, so their tensor table ends around 40 KB in and a
+	// single request covers it.
+	probeChunk = 64 * 1024
+
+	// maxProbeChunk bounds how large the sliding window grows while
+	// walking toward a tensor table that is a long way in.
+	maxProbeChunk = 4 * 1024 * 1024
+
+	// probeBudget caps what one file may cost, so a pathological file
+	// cannot turn a listing into a download.
+	//
+	// In a split model every shard is cheap: the metadata shard declares
+	// no tensors and is dropped on its 24-byte header, and the others
+	// have no metadata to walk. An unsplit GGUF is the opposite — its
+	// tensor table sits behind the tokenizer, which for a large model
+	// runs to tens of megabytes, and paying that for every file in a
+	// listing made an ordinary repository take nine seconds to expand.
+	//
+	// The budget is generous enough to reach a table behind a large
+	// tokenizer; the sliding window grows as it goes so that walk costs a
+	// handful of requests rather than hundreds. A file that still does
+	// not yield within the budget falls back to the uncorrected estimate,
+	// which is the status quo rather than a new problem.
+	probeBudget = 16 * 1024 * 1024
+
+	// probeMinBytes is the download size below which probing cannot
+	// change the verdict. llama.cpp only streams tables over 4 GiB, and a
+	// table is a minority of the file, so anything under this threshold
+	// either has no table or has one that stays resident. Skipping these
+	// keeps the probe off the path of every ordinary model.
+	probeMinBytes = 8 * 1024 * 1024 * 1024
+)
+
+// ProbeResult is what a remote header probe learned about one file.
+type ProbeResult struct {
+	// StreamedBytes is the part of the download that llama.cpp reads from
+	// disk on demand and never makes resident. Zero when the file has no
+	// such table, or has one small enough to stay resident.
+	StreamedBytes int64
+	// Probed records that the header was actually read. False means the
+	// probe was skipped or failed, and StreamedBytes says nothing.
+	Probed bool
+}
+
+// ShardURL resolves one shard of a file to a download URL and its size.
+type ShardURL struct {
+	URL  string
+	Size int64
+}
+
+// ProbePLE reads the GGUF headers of a file's shards to find the
+// per-layer embedding table, and reports how much of the download will be
+// streamed rather than loaded.
+//
+// Shards are probed in order and the first table found wins: the tensor
+// lives in exactly one shard, and stopping there means the common case
+// costs a single small ranged read.
+//
+// Every failure path returns Probed false rather than an error the caller
+// must handle. The probe is an improvement on an estimate, not a
+// precondition for anything, so a host that rate-limits or a network that
+// drops should leave the UI showing its uncorrected number rather than an
+// error.
+func ProbePLE(ctx context.Context, client *http.Client, token string, shards []ShardURL, totalBytes int64) ProbeResult {
+	if totalBytes < probeMinBytes || len(shards) == 0 {
+		return ProbeResult{}
+	}
+	// Only split files are probed, and the reason is cost. A split
+	// model's shards are nearly free to inspect: the metadata shard
+	// declares no tensors and is dropped on its 24-byte header, and the
+	// rest carry no metadata, so their tensor table sits in the first few
+	// kilobytes — one request, about 4 KB. An unsplit GGUF puts its
+	// tensor table behind the tokenizer, which for a large model means
+	// roughly 12 MB and six requests per file; across a repository's
+	// worth of quants that turned expanding a listing into a nine-second
+	// wait for every ordinary model, to correct the rare one.
+	//
+	// The trade is sound because the two sets barely overlap: a table big
+	// enough to be streamed at all is over 4 GiB, and a model carrying
+	// one is large enough that publishers split it. Where it does not
+	// hold, the estimate stays as it was — conservative, and corrected
+	// exactly once the file is on disk.
+	if len(shards) < 2 {
+		return ProbeResult{}
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	for _, sh := range shards {
+		if sh.Size <= 0 || sh.URL == "" {
+			continue
+		}
+		r := newRangeReader(ctx, client, sh.URL, token, sh.Size, probeChunk, probeBudget)
+
+		// Skip a shard that declares no tensors before parsing it. This
+		// is not a micro-optimization: a split model puts all of its
+		// metadata in the first shard, and for a large model that is a
+		// tokenizer megabytes long that the parser would walk in full to
+		// reach a tensor table that isn't there. On Qwen3.8-Flash-Next
+		// skipping it takes the probe from 33 seconds to under one.
+		if n, err := tensorCount(r); err == nil && n == 0 {
+			continue
+		}
+		if _, err := r.Seek(0, io.SeekStart); err != nil {
+			continue
+		}
+		meta, err := models.ParseGGUFMetaFrom(r)
+		if err != nil {
+			// A shard that isn't parseable on its own — or a probe that
+			// ran out of budget — tells us nothing about the others, so
+			// keep going rather than giving up on the file.
+			continue
+		}
+		if meta.PLEBytes > 0 {
+			return ProbeResult{StreamedBytes: streamedBytes(meta.PLEBytes), Probed: true}
+		}
+	}
+	// Every shard parsed and none held a table: that is a real answer,
+	// not a failure. Saying so lets the caller skip re-probing.
+	return ProbeResult{StreamedBytes: 0, Probed: true}
+}
+
+// streamedBytes applies llama.cpp's own rule for what gets streamed under
+// the default --tensor-read-lazy auto: tables over 4 GiB, and only those.
+// Deliberately the same threshold the post-download estimate uses, so the
+// number shown before downloading and the number shown after agree.
+func streamedBytes(pleBytes int64) int64 {
+	if pleBytes > models.PLEAutoMinBytes {
+		return pleBytes
+	}
+	return 0
+}
+
+// tensorCount reads a GGUF file's tensor count from its 24-byte header,
+// leaving the reader positioned after it.
+func tensorCount(r io.ReadSeeker) (uint64, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	var hdr struct {
+		Magic   [4]byte
+		Version uint32
+		Tensors uint64
+		KV      uint64
+	}
+	if err := binary.Read(r, binary.LittleEndian, &hdr); err != nil {
+		return 0, err
+	}
+	if string(hdr.Magic[:]) != "GGUF" {
+		return 0, errors.New("not a GGUF file")
+	}
+	return hdr.Tensors, nil
+}

--- a/internal/modelsource/ple_probe_live_test.go
+++ b/internal/modelsource/ple_probe_live_test.go
@@ -1,0 +1,55 @@
+package modelsource
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+// The probe's whole justification is that the header of a large split
+// GGUF is cheap to reach. This checks that against the real thing rather
+// than a fixture, so a change in how models are split shows up here.
+// Opt-in: MODELSCOPE_LIVE_TEST=1.
+func TestLiveProbeQwen38FlashNext(t *testing.T) {
+	if os.Getenv("MODELSCOPE_LIVE_TEST") != "1" {
+		t.Skip("set MODELSCOPE_LIVE_TEST=1 to run against live model hosts")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// HuggingFace rather than ModelScope: the same repository, and the
+	// probe is source-agnostic, but ModelScope rate-limits an address
+	// that has been probing it repeatedly, which is exactly what
+	// developing this feature involves.
+	const base = "https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/resolve/main/UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-"
+	shards := []ShardURL{
+		{URL: base + "00001-of-00003.gguf", Size: 10946624},
+		{URL: base + "00002-of-00003.gguf", Size: 49990818368},
+		{URL: base + "00003-of-00003.gguf", Size: 22544696352},
+	}
+	var total int64
+	for _, s := range shards {
+		total += s.Size
+	}
+
+	start := time.Now()
+	got := ProbePLE(ctx, &http.Client{Timeout: 60 * time.Second}, "", shards, total)
+	elapsed := time.Since(start)
+
+	if !got.Probed {
+		t.Fatal("probe did not complete")
+	}
+	if got.StreamedBytes == 0 {
+		t.Fatal("no per-layer embedding table found in Qwen3.8-Flash-Next, which has one")
+	}
+	streamedGiB := float64(got.StreamedBytes) / (1 << 30)
+	totalGiB := float64(total) / (1 << 30)
+	if streamedGiB < 20 || streamedGiB > 35 {
+		t.Errorf("streamed = %.2f GiB, expected roughly 27 (about 40%% of the download)", streamedGiB)
+	}
+	t.Logf("total %.1f GiB, streamed %.2f GiB (%.0f%%), uncorrected estimate %.1f GiB, corrected %.1f GiB, probe took %s",
+		totalGiB, streamedGiB, streamedGiB/totalGiB*100,
+		totalGiB*1.1, (totalGiB-streamedGiB)*1.1, elapsed.Round(time.Millisecond))
+}

--- a/internal/modelsource/ple_probe_test.go
+++ b/internal/modelsource/ple_probe_test.go
@@ -1,0 +1,216 @@
+package modelsource
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// buildGGUF writes a minimal GGUF: one string KV of the requested padding
+// size (standing in for a tokenizer), then the named tensors, then
+// dataBytes of tensor data.
+func buildGGUF(t *testing.T, kvPadding int, tensors []struct {
+	name   string
+	offset uint64
+}, dataBytes int) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	ws := func(s string) {
+		binary.Write(&b, binary.LittleEndian, uint64(len(s)))
+		b.WriteString(s)
+	}
+	b.WriteString("GGUF")
+	binary.Write(&b, binary.LittleEndian, uint32(3))
+	binary.Write(&b, binary.LittleEndian, uint64(len(tensors)))
+	kv := 1
+	if kvPadding > 0 {
+		kv = 2
+	}
+	binary.Write(&b, binary.LittleEndian, uint64(kv))
+
+	ws("general.architecture")
+	binary.Write(&b, binary.LittleEndian, uint32(8)) // string
+	ws("testarch")
+	if kvPadding > 0 {
+		// A real tokenizer is an array of many short strings, not one
+		// long one. The distinction decides the cost of reaching the
+		// tensor table: a single string is one seek, while an array's
+		// per-element length prefixes have to be read through.
+		ws("tokenizer.ggml.tokens")
+		binary.Write(&b, binary.LittleEndian, uint32(9)) // array
+		binary.Write(&b, binary.LittleEndian, uint32(8)) // of strings
+		const tokenLen = 8
+		count := kvPadding / (tokenLen + 8)
+		binary.Write(&b, binary.LittleEndian, uint64(count))
+		for i := 0; i < count; i++ {
+			ws(strings.Repeat("t", tokenLen))
+		}
+	}
+	for _, tn := range tensors {
+		ws(tn.name)
+		binary.Write(&b, binary.LittleEndian, uint32(1))
+		binary.Write(&b, binary.LittleEndian, uint64(8))
+		binary.Write(&b, binary.LittleEndian, uint32(0))
+		binary.Write(&b, binary.LittleEndian, tn.offset)
+	}
+	for b.Len()%32 != 0 {
+		b.WriteByte(0)
+	}
+	b.Write(make([]byte, dataBytes))
+	return b.Bytes()
+}
+
+type tensorSpec = struct {
+	name   string
+	offset uint64
+}
+
+// serveRanges hosts fixed bodies at /0, /1, ... and counts bytes served,
+// so a test can assert on what a probe actually cost.
+func serveRanges(t *testing.T, bodies [][]byte) (*httptest.Server, *int64) {
+	t.Helper()
+	var served int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := strings.TrimPrefix(r.URL.Path, "/")
+		var i int
+		if _, err := fmtSscan(idx, &i); err != nil || i >= len(bodies) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body := bodies[i]
+		rng := r.Header.Get("Range")
+		var start, end int
+		if n, _ := fmtSscanRange(rng, &start, &end); n == 2 {
+			if end >= len(body) {
+				end = len(body) - 1
+			}
+			if start > end {
+				w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			chunk := body[start : end+1]
+			atomic.AddInt64(&served, int64(len(chunk)))
+			w.Header().Set("Content-Range", "bytes")
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write(chunk)
+			return
+		}
+		atomic.AddInt64(&served, int64(len(body)))
+		w.Write(body)
+	}))
+	return srv, &served
+}
+
+func fmtSscan(s string, i *int) (int, error)         { return fmt.Sscanf(s, "%d", i) }
+func fmtSscanRange(s string, a, b *int) (int, error) { return fmt.Sscanf(s, "bytes=%d-%d", a, b) }
+
+// A split model's metadata shard carries no tensors. Probing it would
+// mean walking a tokenizer megabytes long to find nothing, so it must be
+// skipped on the strength of its header alone.
+func TestProbeSkipsTensorlessShard(t *testing.T) {
+	// Several chunks worth of metadata, so "did it walk the whole
+	// shard?" is actually measurable.
+	meta := buildGGUF(t, 5*1024*1024, nil, 0)
+	data := buildGGUF(t, 0, []tensorSpec{
+		{"token_embd.weight", 0},
+		{pleTensorNameForTest, 1 << 20},
+		{"output.weight", 1<<20 + 6<<30},
+	}, 1024)
+
+	srv, served := serveRanges(t, [][]byte{meta, data})
+	defer srv.Close()
+
+	// The stub serves only the header bytes; Size is the shard's real
+	// length, which is where the last tensor's size comes from and is
+	// exactly what a file listing gives us in production.
+	shards := []ShardURL{
+		{URL: srv.URL + "/0", Size: int64(len(meta))},
+		{URL: srv.URL + "/1", Size: 8 << 30},
+	}
+	got := ProbePLE(context.Background(), srv.Client(), "", shards, probeMinBytes+1)
+	if !got.Probed {
+		t.Fatal("probe did not complete")
+	}
+	if got.StreamedBytes != 6<<30 {
+		t.Errorf("streamed = %d, want %d", got.StreamedBytes, int64(6)<<30)
+	}
+	// Walking the 5 MB metadata shard would show up here. One chunk to
+	// read its header and recognize it as tensorless is the whole cost.
+	if *served > 2*probeChunk {
+		t.Errorf("probe fetched %d bytes, more than the %d it takes to read a header and move on",
+			*served, 2*probeChunk)
+	}
+}
+
+// Below the size threshold the answer cannot change, so nothing should be
+// fetched at all.
+func TestProbeSkippedBelowThreshold(t *testing.T) {
+	srv, served := serveRanges(t, [][]byte{buildGGUF(t, 0, nil, 0)})
+	defer srv.Close()
+	got := ProbePLE(context.Background(), srv.Client(), "",
+		[]ShardURL{{URL: srv.URL + "/0", Size: 10}}, probeMinBytes-1)
+	if got.Probed || got.StreamedBytes != 0 {
+		t.Errorf("small model was probed: %+v", got)
+	}
+	if *served != 0 {
+		t.Errorf("fetched %d bytes for a model under the threshold", *served)
+	}
+}
+
+// A table under llama.cpp's 4 GiB lazy threshold stays resident, so it
+// must not be subtracted — the estimate is already right for it.
+func TestProbeIgnoresSmallTable(t *testing.T) {
+	data := buildGGUF(t, 0, []tensorSpec{
+		{pleTensorNameForTest, 0},
+		{"output.weight", 1 << 30}, // 1 GiB table
+	}, 1024)
+	srv, _ := serveRanges(t, [][]byte{data})
+	defer srv.Close()
+	got := ProbePLE(context.Background(), srv.Client(), "", []ShardURL{
+		{URL: srv.URL + "/1", Size: 1 << 20}, // stand-in metadata shard
+		{URL: srv.URL + "/0", Size: 3 << 30},
+	}, probeMinBytes+1)
+	if !got.Probed {
+		t.Fatal("probe did not complete")
+	}
+	if got.StreamedBytes != 0 {
+		t.Errorf("streamed = %d, want 0 for a table under the lazy threshold", got.StreamedBytes)
+	}
+}
+
+// A model with no such table is a real answer, not a failure: Probed must
+// be true so the caller can cache it and not ask again.
+func TestProbeReportsNoTableAsAnswer(t *testing.T) {
+	data := buildGGUF(t, 0, []tensorSpec{{"token_embd.weight", 0}, {"output.weight", 1 << 20}}, 1024)
+	srv, _ := serveRanges(t, [][]byte{data})
+	defer srv.Close()
+	got := ProbePLE(context.Background(), srv.Client(), "", []ShardURL{
+		{URL: srv.URL + "/1", Size: 1 << 20},
+		{URL: srv.URL + "/0", Size: 8 << 30},
+	}, probeMinBytes+1)
+	if !got.Probed || got.StreamedBytes != 0 {
+		t.Errorf("got %+v, want a completed probe reporting no table", got)
+	}
+}
+
+// The probe improves an estimate; it must never turn a host problem into
+// a user-visible failure.
+func TestProbeDegradesQuietly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	got := ProbePLE(context.Background(), srv.Client(), "",
+		[]ShardURL{{URL: srv.URL + "/0", Size: 1 << 30}}, probeMinBytes+1)
+	if got.StreamedBytes != 0 {
+		t.Errorf("streamed = %d, want 0 when the host refuses", got.StreamedBytes)
+	}
+}
+
+const pleTensorNameForTest = "per_layer_token_embd.weight"

--- a/internal/modelsource/remote.go
+++ b/internal/modelsource/remote.go
@@ -1,0 +1,141 @@
+package modelsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ErrProbeBudget is returned when reading a remote header would cost more
+// than the caller allowed. It is not a failure of the file — just a
+// refusal to keep spending — so callers fall back to their uncorrected
+// estimate rather than reporting the model as broken.
+var ErrProbeBudget = errors.New("remote header probe exceeded its byte budget")
+
+// rangeReader is an io.ReadSeeker over an HTTP resource, fetching only
+// the spans that are actually read. It exists so the GGUF header parser
+// can run against a file still sitting on a model host: the parser seeks
+// and reads its way through a header, and paying for a whole multi-GiB
+// download to answer a question about its first few kilobytes would be
+// absurd.
+//
+// Reads are served from a single sliding window rather than a general
+// cache, because the parser walks forward. A backwards seek inside the
+// window is free; one outside it refetches.
+type rangeReader struct {
+	ctx      context.Context
+	client   *http.Client
+	url      string
+	token    string
+	size     int64 // total resource length, known from the file listing
+	chunk    int64 // bytes to request next; grows as reading continues
+	maxChunk int64
+	budget   int64 // total bytes this reader may fetch
+	fetched  int64
+
+	pos      int64
+	buf      []byte
+	bufStart int64
+}
+
+func newRangeReader(ctx context.Context, client *http.Client, url, token string, size, chunk, budget int64) *rangeReader {
+	return &rangeReader{
+		ctx: ctx, client: client, url: url, token: token,
+		size: size, chunk: chunk, maxChunk: maxProbeChunk, budget: budget,
+		bufStart: -1,
+	}
+}
+
+func (r *rangeReader) Read(p []byte) (int, error) {
+	if r.pos >= r.size {
+		return 0, io.EOF
+	}
+	if r.bufStart < 0 || r.pos < r.bufStart || r.pos >= r.bufStart+int64(len(r.buf)) {
+		if err := r.fetchAt(r.pos); err != nil {
+			return 0, err
+		}
+	}
+	off := int(r.pos - r.bufStart)
+	n := copy(p, r.buf[off:])
+	r.pos += int64(n)
+	return n, nil
+}
+
+func (r *rangeReader) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = r.pos + offset
+	case io.SeekEnd:
+		// The length comes from the host's file listing, which is why a
+		// probe needs the size passed in rather than discovering it.
+		abs = r.size + offset
+	default:
+		return 0, fmt.Errorf("invalid whence %d", whence)
+	}
+	if abs < 0 {
+		return 0, errors.New("negative seek position")
+	}
+	r.pos = abs
+	return abs, nil
+}
+
+// fetchAt loads the chunk containing off into the buffer.
+func (r *rangeReader) fetchAt(off int64) error {
+	end := off + r.chunk - 1
+	if end >= r.size {
+		end = r.size - 1
+	}
+	want := end - off + 1
+	if r.fetched+want > r.budget {
+		return ErrProbeBudget
+	}
+
+	req, err := http.NewRequestWithContext(r.ctx, http.MethodGet, r.url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", off, end))
+	if r.token != "" {
+		req.Header.Set("Authorization", "Bearer "+r.token)
+	}
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("range request returned %d", resp.StatusCode)
+	}
+	// A host that ignores Range answers 200 with the whole file. Reading
+	// it would blow the budget on a file measured in gigabytes, so cap
+	// the read and let the parser work with what arrives.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, want))
+	if err != nil {
+		return err
+	}
+	if len(body) == 0 {
+		return io.ErrUnexpectedEOF
+	}
+	r.buf = body
+	r.bufStart = off
+	r.fetched += int64(len(body))
+
+	// Grow the window as reading continues. The two access patterns want
+	// opposite things: finding a tensor table in a split shard needs one
+	// small request, while walking a tokenizer to reach the table in an
+	// unsplit file is dominated by round trips. Starting small and
+	// growing serves both — the cheap case never pays for a large fetch,
+	// and the expensive one stops being a long chain of small ones.
+	if r.chunk < r.maxChunk {
+		r.chunk *= 4
+		if r.chunk > r.maxChunk {
+			r.chunk = r.maxChunk
+		}
+	}
+	return nil
+}

--- a/internal/modelsource/remote_test.go
+++ b/internal/modelsource/remote_test.go
@@ -1,0 +1,176 @@
+package modelsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// countingHost serves a body over ranges while recording how many
+// requests and bytes it took. Request count is what decides probe
+// latency against a real host, so it is what these tests assert on.
+type countingHost struct {
+	requests atomic.Int64
+	bytes    atomic.Int64
+	srv      *httptest.Server
+}
+
+func newCountingHost(t *testing.T, body []byte) *countingHost {
+	t.Helper()
+	h := &countingHost{}
+	h.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.requests.Add(1)
+		var start, end int
+		if n, _ := fmt.Sscanf(r.Header.Get("Range"), "bytes=%d-%d", &start, &end); n == 2 {
+			if end >= len(body) {
+				end = len(body) - 1
+			}
+			if start > end || start >= len(body) {
+				w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			chunk := body[start : end+1]
+			h.bytes.Add(int64(len(chunk)))
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write(chunk)
+			return
+		}
+		h.bytes.Add(int64(len(body)))
+		w.Write(body)
+	}))
+	t.Cleanup(h.srv.Close)
+	return h
+}
+
+// The cheap case: a split model's tensor-carrying shard has no metadata,
+// so its table sits in the first few kilobytes. One request should do it.
+func TestProbeCostSplitShard(t *testing.T) {
+	body := buildGGUF(t, 0, []tensorSpec{
+		{"token_embd.weight", 0},
+		{pleTensorNameForTest, 1 << 20},
+		{"output.weight", 1<<20 + 6<<30},
+	}, 4096)
+	h := newCountingHost(t, body)
+
+	got := ProbePLE(context.Background(), h.srv.Client(), "", []ShardURL{
+		{URL: h.srv.URL, Size: 8 << 30},
+		{URL: h.srv.URL, Size: 8 << 30},
+	}, probeMinBytes+1)
+	if got.StreamedBytes != 6<<30 {
+		t.Fatalf("streamed = %d, want %d", got.StreamedBytes, int64(6)<<30)
+	}
+	if n := h.requests.Load(); n > 2 {
+		t.Errorf("took %d requests; a split shard's table should be reachable in one", n)
+	}
+	t.Logf("split shard: %d request(s), %d bytes", h.requests.Load(), h.bytes.Load())
+}
+
+// The expensive case: an unsplit GGUF puts its tokenizer ahead of the
+// tensor table. The window has to grow, or this becomes a long chain of
+// tiny requests — which is exactly what made a listing take 20 seconds.
+func TestProbeCostUnsplitWithLargeTokenizer(t *testing.T) {
+	const tokenizer = 12 * 1024 * 1024
+	body := buildGGUF(t, tokenizer, []tensorSpec{
+		{"token_embd.weight", 0},
+		{pleTensorNameForTest, 1 << 20},
+		{"output.weight", 1<<20 + 6<<30},
+	}, 4096)
+	h := newCountingHost(t, body)
+
+	got := ProbePLE(context.Background(), h.srv.Client(), "", []ShardURL{
+		{URL: h.srv.URL, Size: 8 << 30},
+		{URL: h.srv.URL, Size: 8 << 30},
+	}, probeMinBytes+1)
+	if got.StreamedBytes != 6<<30 {
+		t.Fatalf("streamed = %d, want the table found behind the tokenizer", got.StreamedBytes)
+	}
+	// Fixed 64 KB windows would need ~190 requests for 12 MB. Growth
+	// should bring that down by more than an order of magnitude.
+	if n := h.requests.Load(); n > 15 {
+		t.Errorf("took %d requests to walk %d MB; the window is not growing",
+			n, tokenizer/(1024*1024))
+	}
+	t.Logf("unsplit + %d MB tokenizer: %d requests, %.1f MB fetched",
+		tokenizer/(1024*1024), h.requests.Load(), float64(h.bytes.Load())/(1024*1024))
+}
+
+// Whatever a file looks like, a probe must never fetch more than its
+// budget: a listing that quietly turned into a multi-gigabyte download
+// would be far worse than an uncorrected estimate.
+func TestProbeNeverExceedsBudget(t *testing.T) {
+	body := buildGGUF(t, probeBudget*2, []tensorSpec{{pleTensorNameForTest, 0}}, 4096)
+	h := newCountingHost(t, body)
+
+	ProbePLE(context.Background(), h.srv.Client(), "", []ShardURL{
+		{URL: h.srv.URL, Size: 8 << 30},
+	}, probeMinBytes+1)
+
+	// One in-flight window may straddle the limit, hence the allowance.
+	if b := h.bytes.Load(); b > probeBudget+maxProbeChunk {
+		t.Errorf("fetched %d bytes, over the %d budget", b, probeBudget)
+	}
+	t.Logf("%d requests, %.1f MB fetched (budget %.0f MB)",
+		h.requests.Load(), float64(h.bytes.Load())/(1024*1024), float64(probeBudget)/(1024*1024))
+}
+
+// The budget is enforced by the reader itself, so a caller cannot walk
+// past it by continuing to read.
+func TestRangeReaderStopsAtBudget(t *testing.T) {
+	body := make([]byte, 4*1024*1024)
+	h := newCountingHost(t, body)
+	const budget = 256 * 1024
+	r := newRangeReader(context.Background(), h.srv.Client(), h.srv.URL, "",
+		int64(len(body)), 64*1024, budget)
+
+	buf := make([]byte, 32*1024)
+	var err error
+	for i := 0; i < 1000 && err == nil; i++ {
+		_, err = r.Read(buf)
+	}
+	if !errors.Is(err, ErrProbeBudget) {
+		t.Fatalf("read stopped with %v, want ErrProbeBudget", err)
+	}
+	if b := h.bytes.Load(); b > budget+maxProbeChunk {
+		t.Errorf("fetched %d bytes against a %d budget", b, budget)
+	}
+}
+
+func TestRangeReaderSeek(t *testing.T) {
+	body := []byte(strings.Repeat("abcdefgh", 1024))
+	h := newCountingHost(t, body)
+	r := newRangeReader(context.Background(), h.srv.Client(), h.srv.URL, "", int64(len(body)), 1024, 1<<20)
+
+	// SeekEnd uses the declared size, which is where a shard's last
+	// tensor gets its length from.
+	if got, err := r.Seek(0, 2); err != nil || got != int64(len(body)) {
+		t.Fatalf("SeekEnd = %d, %v; want %d", got, err, len(body))
+	}
+	if _, err := r.Seek(8, 0); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 8)
+	if _, err := r.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "abcdefgh" {
+		t.Errorf("read %q after seek", buf)
+	}
+	// Re-reading inside the window already fetched must not refetch —
+	// the parser does exactly this when it re-reads a header after
+	// checking the tensor count.
+	before := h.requests.Load()
+	if _, err := r.Seek(8, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if h.requests.Load() != before {
+		t.Error("re-read inside the window issued another request")
+	}
+}

--- a/internal/modelsource/types.go
+++ b/internal/modelsource/types.go
@@ -25,8 +25,18 @@ type File struct {
 	Size      int64    `json:"size"`
 	Quant     string   `json:"quant"`
 	VRAMEstGB float64  `json:"vram_est_gb"`
-	Shards    []string `json:"shards,omitempty"`    // all shard filenames if split; nil for single files
-	IsMMProj  bool     `json:"is_mmproj,omitempty"` // true for vision projector files
+	Shards    []string `json:"shards,omitempty"` // all shard filenames if split; nil for single files
+	// ShardSizes parallels Shards. Grouping sums the shards into Size,
+	// but the individual lengths are what a header probe needs, so keep
+	// them rather than paying a HEAD per shard to ask again.
+	ShardSizes []int64 `json:"shard_sizes,omitempty"`
+	// StreamedBytes is the part of this download that llama.cpp reads
+	// from disk on demand and never makes resident (the per-layer
+	// embedding table). Zero when there is none, or when it was not
+	// measured — see StreamProbed.
+	StreamedBytes int64 `json:"streamed_bytes,omitempty"`
+	StreamProbed  bool  `json:"stream_probed,omitempty"`
+	IsMMProj      bool  `json:"is_mmproj,omitempty"` // true for vision projector files
 }
 
 // Detail holds one repository's GGUF files.
@@ -69,4 +79,6 @@ type Client interface {
 	// ModelURL is the human-facing repository page, or empty when the id
 	// is not a linkable owner/name pair.
 	ModelURL(modelID string) string
+	// DownloadURL locates one file within a repository.
+	DownloadURL(modelID, filename string) string
 }

--- a/web/templates/partials/hf_files.html
+++ b/web/templates/partials/hf_files.html
@@ -18,7 +18,10 @@
             <td><small>{{$f.Filename}}{{if $f.Shards}} ({{len $f.Shards}} parts){{end}}{{if $f.IsMMProj}} <mark style="padding:0 0.3rem;">vision</mark>{{end}}</small></td>
             <td><kbd>{{$f.Quant}}</kbd></td>
             <td>{{printf "%.1f" (divGB $f.Size)}} GiB</td>
-            <td>{{printf "%.1f" $f.VRAMEstGB}} GiB</td>
+            <td>
+                {{printf "%.1f" $f.VRAMEstGB}} GiB
+                {{if gt $f.StreamedBytes 0}}<br><small title="This architecture keeps its per-layer embedding table on disk and reads rows on demand, so that part never occupies VRAM. Assumes the default Per-Layer Embeddings setting; choosing &quot;Keep resident in memory&quot; after download would add it back.">+{{printf "%.1f" (divGB $f.StreamedBytes)}} GiB streamed from disk</small>{{end}}
+            </td>
             <td>
                 {{$fit := vramFit $f.VRAMEstGB}}
                 {{if eq $fit "too_large"}}


### PR DESCRIPTION
The Download Models page sized every file as `file_size * 1.1`. For an architecture that keeps its per-layer embedding table on disk and reads rows on demand, that counts memory the model never occupies.

On **Qwen3.8-Flash-Next UD-IQ1_S**:

| | |
|---|---|
| download (3 shards) | 67.6 GiB |
| ~~shown as VRAM Est.~~ | ~~74.3 GiB → **Too Large**~~ |
| table streamed from disk | 26.8 GiB |
| **actual** | **44.8 GiB** |

A 29 GiB overstatement — the difference between "impossible" and "fits on a 48 GB card". Every quant in the repo was affected.

## Measuring it

The answer is in the GGUF tensor table, which at browse time is on the host rather than on disk. So the header parser (already there from #149) now runs over an **HTTP range reader** that fetches only the spans it touches. The window starts at 64 KB and grows as reading continues, because the two access patterns want opposite things: finding a table in a split shard is one small request, while walking a tokenizer to reach one is dominated by round trips.

## Scope is drawn where the cost is

- **Only downloads over 8 GiB.** Below that a table cannot exceed the 4 GiB llama.cpp streams above, so the answer cannot change.
- **Only split files.** A split model's shards are nearly free: the metadata shard declares no tensors and is dropped on its 24-byte header, and the rest carry no metadata, so their tensor table sits ~4 KB in — one request. An unsplit GGUF hides its table behind the tokenizer: **12 MB and six requests per file**, which turned expanding an ordinary repository into a nine-second wait to correct the rare one. The two sets barely overlap, since a model with a table that large is one publishers split.
- **A 16 MB budget per file**, enforced in the reader, so a listing can never quietly become a download.

Every failure path returns "not probed" rather than an error. This improves an estimate; a rate-limited host should leave the old number showing, not break the page. Results are cached per source, repo and file.

## Consistency and honesty

The 4 GiB threshold and the arithmetic are **shared with the post-download estimator**, so the number shown before downloading and the one shown after agree — they would otherwise disagree, which is its own bug. The table's size is surfaced next to the estimate rather than silently subtracted:

```
67.6 GiB | 44.8 GiB
           +26.8 GiB streamed from disk
```

with a tooltip noting it assumes the default Per-Layer Embeddings setting (choosing "Keep resident" after download adds it back). The **Size** column still shows the whole download, and the *disk* fit check is unchanged — the full file still has to land somewhere.

## Verification

Live against the real repository:

```
total 67.6 GiB, streamed 26.82 GiB (40%), uncorrected 74.3 GiB,
corrected 44.8 GiB, probe took 639ms
```

That 26.82 GiB matches an independent read of the same headers, and a second quant probed separately reports the same figure — Unsloth keeps the table at a fixed quantization across their variants, so the agreement is real rather than a caching artifact.

Through the running app:

| | |
|---|---|
| Qwen3.8-Flash-Next (split, has a table) | **1126 ms**, 11 of 13 files corrected |
| ordinary unsplit repository | **106 ms**, untouched |

Local tests assert the request counts those timings depend on: 1 request for a split shard, 6 for a 12 MB tokenizer walk (fixed windows would need ~190), 0 below the size threshold, and a hard bytes bound at the budget. Full suite green, and race-clean apart from the pre-existing `internal/benchmark` race that also fails on main.

## Note

Unsplit files are not probed, so an unsplit model with a table over 4 GiB would keep the old conservative estimate. I have not found one — gemma-4-E4B is unsplit but its table is 1.8 GiB, under the streaming threshold, so its estimate is already correct. If one turns up, reading `general.architecture` from the first window before committing to the tokenizer walk would make the unsplit case cheap too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go9An1JPRDAuj8nVYwpXLZ