### PR TITLE
fix(models): find the embedding table in a split model's later shards

### DIFF
--- a/internal/models/gguf.go
+++ b/internal/models/gguf.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -68,6 +71,11 @@ type GGUFMeta struct {
 	// file-size estimate does, overstates the requirement by more than the
 	// rest of the model put together.
 	PLEBytes int64 `json:"ple_bytes,omitempty"`
+	// PLEChecked mirrors ReasoningChecked and the rest: it records that
+	// the tensor table was inspected, so a record written before split
+	// models were scanned correctly can be told apart from one whose file
+	// genuinely has no table.
+	PLEChecked bool `json:"ple_checked,omitempty"`
 
 	// BaseModelRepo is the upstream "org/repo" this quant derives from, per
 	// general.base_model.0.repo_url. Used to locate the base model's
@@ -100,6 +108,7 @@ func (meta *GGUFMeta) ApplyTo(m *Model) {
 	m.SlidingWindow = meta.SlidingWindow
 	m.SamplingChecked = meta.SamplingChecked
 	m.PLEBytes = meta.PLEBytes
+	m.PLEChecked = meta.PLEChecked
 	if meta.BaseModelRepo != "" {
 		m.BaseModelRepo = meta.BaseModelRepo
 	}
@@ -149,7 +158,16 @@ func ParseGGUFMeta(path string) (*GGUFMeta, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return ParseGGUFMetaFrom(f)
+	meta, err := ParseGGUFMetaFrom(f)
+	if err != nil {
+		return nil, err
+	}
+	// A split model keeps its tensor table in a later shard; see
+	// scanShardsForPLE.
+	if meta.PLEBytes == 0 {
+		meta.PLEBytes = scanShardsForPLE(path)
+	}
+	return meta, nil
 }
 
 // ParseGGUFMetaFrom reads the same metadata from an arbitrary seekable
@@ -394,6 +412,7 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 	// general.sampling.* keys were looked for, present or not.
 	meta.ReasoningChecked = true
 	meta.SamplingChecked = true
+	meta.PLEChecked = true
 	if meta.Reasoning.Toggle == "" {
 		meta.Reasoning.Toggle = ReasoningToggleNone
 	}
@@ -764,4 +783,62 @@ func scanPLETensorBytes(f io.ReadSeeker, tensorCount uint64, alignment int64) in
 		return 0
 	}
 	return next - pleOffset
+}
+
+// ggufShardPattern matches a split GGUF filename like
+// "model-00001-of-00005.gguf". The naming is llama.cpp's, shared by every
+// publisher that splits with its tooling.
+var ggufShardPattern = regexp.MustCompile(`^(.+)-(\d{5})-of-(\d{5})\.gguf$`)
+
+// ExpandShards returns every shard filename of a split GGUF, or a
+// single-element slice for an unsplit one.
+func ExpandShards(filename string) []string {
+	m := ggufShardPattern.FindStringSubmatch(filename)
+	if m == nil {
+		return []string{filename}
+	}
+	base := m[1]
+	total, _ := strconv.Atoi(m[3])
+	shards := make([]string, total)
+	for i := range total {
+		shards[i] = fmt.Sprintf("%s-%05d-of-%05d.gguf", base, i+1, total)
+	}
+	return shards
+}
+
+// scanShardsForPLE looks for the per-layer embedding table in the sibling
+// shards of a split GGUF.
+//
+// A split model's first shard — the one the registry records and the one
+// callers hand to ParseGGUFMeta — holds all the metadata and, in the
+// splits publishers actually ship, no tensors at all. So the architecture
+// parses correctly from it while the tensor table, and with it the
+// embedding table's size, sits in a later shard. Without this the
+// per-layer embedding control never appears for exactly the models that
+// have one, since a table big enough to matter belongs to a model big
+// enough to be split.
+//
+// Returns 0 for an unsplit file, for siblings that aren't on disk (a
+// partial download), or when no shard carries the table.
+func scanShardsForPLE(path string) int64 {
+	dir, name := filepath.Split(path)
+	shards := ExpandShards(name)
+	if len(shards) < 2 {
+		return 0
+	}
+	for _, sh := range shards {
+		if sh == name {
+			continue // already parsed by the caller
+		}
+		f, err := os.Open(filepath.Join(dir, sh))
+		if err != nil {
+			continue
+		}
+		meta, err := ParseGGUFMetaFrom(f)
+		f.Close()
+		if err == nil && meta.PLEBytes > 0 {
+			return meta.PLEBytes
+		}
+	}
+	return 0
 }

--- a/internal/models/gguf_ple_test.go
+++ b/internal/models/gguf_ple_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -164,5 +165,148 @@ func TestPLETensorScanToleratesTruncation(t *testing.T) {
 	}
 	if meta.PLEBytes != 0 {
 		t.Errorf("PLEBytes = %d, want 0 on a truncated tensor block", meta.PLEBytes)
+	}
+}
+
+// writeSplitGGUF writes a shard set into dir: shard 1 carries the
+// metadata and no tensors at all, later shards carry tensors and no
+// metadata. That is the shape publishers actually ship, and the shape
+// that made the per-layer embedding control never appear.
+func writeSplitGGUF(t *testing.T, dir, base string, total int, pleShard int, pleSize int64) string {
+	t.Helper()
+	for i := 1; i <= total; i++ {
+		var buf bytes.Buffer
+		writeStr := func(s string) {
+			binary.Write(&buf, binary.LittleEndian, uint64(len(s)))
+			buf.WriteString(s)
+		}
+		var tensors []pleTensor
+		kv := 0
+		if i == 1 {
+			kv = 1 // metadata shard: architecture only, zero tensors
+		} else if i == pleShard {
+			tensors = []pleTensor{
+				{"token_embd.weight", 0},
+				{pleTensorName, 4096},
+				{"output.weight", uint64(4096 + pleSize)},
+			}
+		} else {
+			tensors = []pleTensor{{fmt.Sprintf("blk.%d.attn_q.weight", i), 0}}
+		}
+
+		buf.WriteString("GGUF")
+		binary.Write(&buf, binary.LittleEndian, uint32(3))
+		binary.Write(&buf, binary.LittleEndian, uint64(len(tensors)))
+		binary.Write(&buf, binary.LittleEndian, uint64(kv))
+		if kv > 0 {
+			writeStr("general.architecture")
+			binary.Write(&buf, binary.LittleEndian, ggufTypeString)
+			writeStr("qwen4exp")
+		}
+		for _, tn := range tensors {
+			writeStr(tn.name)
+			binary.Write(&buf, binary.LittleEndian, uint32(1))
+			binary.Write(&buf, binary.LittleEndian, uint64(8))
+			binary.Write(&buf, binary.LittleEndian, uint32(0))
+			binary.Write(&buf, binary.LittleEndian, tn.offset)
+		}
+		for buf.Len()%32 != 0 {
+			buf.WriteByte(0)
+		}
+		// Enough trailing data for the last tensor in the shard to have a
+		// length; the PLE table's size comes from the gap to the tensor
+		// after it, so this only has to be non-empty.
+		buf.Write(make([]byte, 8192))
+
+		name := fmt.Sprintf("%s-%05d-of-%05d.gguf", base, i, total)
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// The table's size is the gap between its offset and the next
+		// tensor's, so the shard has to actually be that long or the
+		// arithmetic clamps to the file end. Extend it sparsely: the
+		// bytes are never read, and the file costs nothing on disk.
+		if i == pleShard && pleSize > 0 {
+			if err := os.Truncate(path, 4096+pleSize+8192); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s-%05d-of-%05d.gguf", base, 1, total))
+}
+
+// Parsing shard 1 of a split model must still find the table, which lives
+// in a later shard. This is the case that shipped broken: architecture
+// parsed, table missed, control hidden.
+func TestPLEFoundInLaterShard(t *testing.T) {
+	dir := t.TempDir()
+	const pleSize = int64(6) << 30
+	first := writeSplitGGUF(t, dir, "Qwen3.8-Flash-Next-UD-Q4_K_XL", 4, 2, pleSize)
+
+	meta, err := ParseGGUFMeta(first)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if meta.Architecture != "qwen4exp" {
+		t.Errorf("Architecture = %q; the metadata shard should still be read", meta.Architecture)
+	}
+	if meta.PLEBytes != pleSize {
+		t.Errorf("PLEBytes = %d, want %d from the shard that carries the table", meta.PLEBytes, pleSize)
+	}
+	if !meta.PLEChecked {
+		t.Error("PLEChecked should be set once the shards have been inspected")
+	}
+}
+
+// The table can be in any shard, not just the second.
+func TestPLEFoundInAnyShard(t *testing.T) {
+	const pleSize = int64(5) << 30
+	for _, shard := range []int{2, 3, 4} {
+		dir := t.TempDir()
+		first := writeSplitGGUF(t, dir, "m-UD-Q4_K_XL", 4, shard, pleSize)
+		meta, err := ParseGGUFMeta(first)
+		if err != nil {
+			t.Fatalf("shard %d: %v", shard, err)
+		}
+		if meta.PLEBytes != pleSize {
+			t.Errorf("table in shard %d: PLEBytes = %d, want %d", shard, meta.PLEBytes, pleSize)
+		}
+	}
+}
+
+// A split model without such a table reports zero, and says it looked.
+func TestSplitModelWithoutPLE(t *testing.T) {
+	dir := t.TempDir()
+	first := writeSplitGGUF(t, dir, "plain-Q4_K_M", 3, 0, 0) // no shard carries one
+	meta, err := ParseGGUFMeta(first)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if meta.PLEBytes != 0 {
+		t.Errorf("PLEBytes = %d, want 0", meta.PLEBytes)
+	}
+	if !meta.PLEChecked {
+		t.Error("PLEChecked should be set even when nothing was found")
+	}
+}
+
+// A partial download leaves siblings missing; that must not fail the
+// parse, since the metadata read from shard 1 is still good.
+func TestSplitModelWithMissingShards(t *testing.T) {
+	dir := t.TempDir()
+	first := writeSplitGGUF(t, dir, "partial-UD-Q4_K_XL", 4, 2, 6<<30)
+	if err := os.Remove(filepath.Join(dir, "partial-UD-Q4_K_XL-00002-of-00004.gguf")); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := ParseGGUFMeta(first)
+	if err != nil {
+		t.Fatalf("parse should survive a missing shard: %v", err)
+	}
+	if meta.Architecture != "qwen4exp" {
+		t.Errorf("Architecture = %q, want the metadata to survive", meta.Architecture)
+	}
+	if meta.PLEBytes != 0 {
+		t.Errorf("PLEBytes = %d, want 0 when the shard holding it is absent", meta.PLEBytes)
 	}
 }

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -79,6 +79,11 @@ type Model struct {
 	// else, which is what makes it double as the "does this model have a
 	// PLE table" test. See GGUFMeta.PLEBytes.
 	PLEBytes int64 `json:"ple_bytes,omitempty"`
+	// PLEChecked records that the tensor table was inspected. Records
+	// written before split models were scanned correctly have it false
+	// and get re-parsed once, which is how an already-downloaded model
+	// picks up its table size without being downloaded again.
+	PLEChecked bool `json:"ple_checked,omitempty"`
 
 	// Architecture parameters parsed from GGUF header.
 	Arch          string `json:"arch,omitempty"`
@@ -606,8 +611,11 @@ func (r *Registry) BackfillGGUFMeta() {
 		// not on VocabSize == 0, so a file that simply has no such key is
 		// asked once rather than at every startup.
 		needsVocab := m.NLayers > 0 && !m.VocabChecked
+		// Records parsed before a split model's later shards were
+		// scanned — re-parse once to find the per-layer embedding table.
+		needsPLE := m.NLayers > 0 && !m.PLEChecked
 
-		if !needsFull && !needsVision && !needsKV && !needsReasoning && !needsSampling && !needsVocab {
+		if !needsFull && !needsVision && !needsKV && !needsReasoning && !needsSampling && !needsVocab && !needsPLE {
 			continue
 		}
 		meta, err := ParseGGUFMeta(m.FilePath)

--- a/internal/modelsource/files.go
+++ b/internal/modelsource/files.go
@@ -1,10 +1,11 @@
 package modelsource
 
 import (
-	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
+
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 // EstimateVRAM returns estimated VRAM in GB.
@@ -74,18 +75,7 @@ func GroupShards(files []File) []File {
 	return append(result, singles...)
 }
 
-// ExpandShards returns all shard filenames for a split GGUF, or a single-element
-// slice for non-split files. Exported for use by the downloader.
-func ExpandShards(filename string) []string {
-	m := shardPattern.FindStringSubmatch(filename)
-	if m == nil {
-		return []string{filename}
-	}
-	base := m[1]
-	total, _ := strconv.Atoi(m[3])
-	shards := make([]string, total)
-	for i := range total {
-		shards[i] = fmt.Sprintf("%s-%05d-of-%05d.gguf", base, i+1, total)
-	}
-	return shards
-}
+// ExpandShards returns all shard filenames for a split GGUF, or a
+// single-element slice for non-split files. The naming rule lives in
+// models, which needs it to find a split model's tensor table.
+func ExpandShards(filename string) []string { return models.ExpandShards(filename) }


### PR DESCRIPTION
The per-layer embedding control never appeared for the models that have one. Reported from a real instance with Qwen3.8-Flash-Next downloaded:

```
model_id   : unsloth/Qwen3.8-Flash-Next-GGUF
filename   : UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf
arch       : qwen4exp          ← parsed fine
ple_bytes  : (absent)          ← zero, so the control is hidden
```

## Why

The architecture parsed because it is metadata, and metadata lives in the first shard. **The tensor table does not.** In the splits publishers actually ship, shard one carries every KV pair and *zero tensors*; the table sits in a later shard.

So the scan added in #149 looked in the one shard that could never hold what it was looking for. It worked for unsplit models — gemma-4-E4B, which is what I tested it against — and silently failed for every split one. Which is every model where the table is big enough to matter, since a table over 4 GiB belongs to a model publishers split.

Compounding it: I had already measured that zero-tensor first shard while building the browse-page probe, which walks all the shards and gets this right. I didn't connect it back to the on-disk path.

## The fix

`ParseGGUFMeta` walks the sibling shards when the file it was handed has no table. The shard-naming rule moves down into `models` so the parser can use it, with `modelsource` forwarding — same direction as the earlier type moves.

Existing records need a re-parse, so **`PLEChecked`** joins `ReasoningChecked`/`SamplingChecked`/`VocabChecked`: it distinguishes "inspected, no table" from "never looked", and the startup backfill re-reads records that predate this. An already-downloaded model picks up its table size on the next restart, without re-downloading.

## Verified against the real thing

I fetched the four shard headers of `Qwen3.8-Flash-Next-UD-Q4_K_XL` and restored them to their true lengths as sparse files, then parsed them exactly as the app does:

```
arch=qwen4exp  PLEBytes=28800138240 (26.82 GiB)  checked=true
VRAM: resident=104.7 GiB  →  streamed=77.9 GiB
```

That 26.82 GiB matches what the browse-page probe measures over HTTP for the same repo, and what a *different* quant reports — Unsloth keeps the table at a fixed quantization across variants, so the agreement is meaningful rather than coincidental.

## Tests

The table in each shard position, a split model with no table at all, and a partial download whose missing shard must not fail a parse that already read good metadata. Fixtures are sparse files: the table's size comes from the gap to the next tensor, so a shard has to genuinely be that long or the arithmetic clamps to the file end — which is what made my first attempt at these tests pass a wrong number.

## Note on impact

Runtime behaviour was never wrong. llama.cpp defaults to `--tensor-read-lazy auto`, which streams any table over 4 GiB, so affected models were already reading it from disk. What was broken is the missing control and an inflated VRAM figure on the Models page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go9An1JPRDAuj8nVYwpXLZ