### PR TITLE
fix(models): apply the per-layer embedding scan to already-downloaded models

### DIFF
--- a/internal/models/ple_backfill_test.go
+++ b/internal/models/ple_backfill_test.go
@@ -1,0 +1,69 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A model registered before the split-shard scan existed has architecture
+// metadata but no PLE table recorded. BackfillGGUFMeta must re-parse it and
+// store both the table size and the "we looked" flag, or the Per-Layer
+// Embeddings selector never appears for any already-downloaded model.
+func TestBackfillPopulatesPLE(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "config")
+	modelsDir := filepath.Join(dir, "models")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(modelsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	const pleSize = int64(6) << 30
+	first := writeSplitGGUF(t, modelsDir, "Qwen3.8-Flash-Next-UD-Q4_K_XL", 4, 2, pleSize)
+
+	// The registry as it looks on a box that downloaded this model before
+	// the scan shipped: layers known, PLE fields absent.
+	stale := fmt.Sprintf(`{"models":{"q":{"id":"q","filename":%q,"file_path":%q,"n_layers":48}}}`,
+		filepath.Base(first), first)
+	if err := os.WriteFile(filepath.Join(cfgDir, "models.json"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry(dir, modelsDir)
+	r.BackfillGGUFMeta()
+
+	m, err := r.Get("q")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.PLEBytes != pleSize {
+		t.Errorf("PLEBytes = %d, want %d — the selector stays hidden without it", m.PLEBytes, pleSize)
+	}
+	if !m.PLEChecked {
+		t.Error("PLEChecked = false — every startup will re-scan this model's shards forever")
+	}
+
+	// And it must actually persist, not just live in memory.
+	raw, err := os.ReadFile(filepath.Join(cfgDir, "models.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved struct {
+		Models map[string]struct {
+			PLEBytes   int64 `json:"ple_bytes"`
+			PLEChecked bool  `json:"ple_checked"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(raw, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.Models["q"].PLEBytes != pleSize || !saved.Models["q"].PLEChecked {
+		t.Errorf("persisted ple_bytes=%d ple_checked=%v, want %d/true",
+			saved.Models["q"].PLEBytes, saved.Models["q"].PLEChecked, pleSize)
+	}
+}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -677,6 +677,18 @@ func (r *Registry) BackfillGGUFMeta() {
 					slog.Info("backfilled vocab size", "model", m.ID, "vocab", meta.VocabSize)
 				}
 			}
+			if needsPLE {
+				// Record that the tensor table was inspected whatever
+				// the answer, so a model that simply has no table is
+				// not re-scanned at every startup — for a split model
+				// that scan opens every shard.
+				m.PLEChecked = true
+				changed = true
+				if meta.PLEBytes > 0 {
+					m.PLEBytes = meta.PLEBytes
+					slog.Info("backfilled per-layer embedding table", "model", m.ID, "ple_bytes", meta.PLEBytes)
+				}
+			}
 		}
 	}
 	if changed {


### PR DESCRIPTION
## What's wrong

The **Per-Layer Embeddings** selector never appears for any model. Not just for `qwen4exp` — for anything.

On a live instance running v2.25.1 (so it already has #155), **0 of 29 models** have a table recorded. That includes the gemma-4 E2B/E4B models, which certainly carry one. The selector in `model_config.html` is gated on `.HasPLE`, which is `model.PLEBytes > 0`; that is always zero, so the control is never rendered and `--tensor-read-lazy` cannot be set from the UI.

## Why

The scan is correct. The delivery was missing.

`BackfillGGUFMeta` is the only path that reaches a model already in the registry. It computed `needsPLE` and re-parsed the GGUF on the strength of it — and then the branch that applies results had blocks for vision, KV scaling, reasoning, sampling and vocab, but none for PLE. The freshly parsed `meta.PLEBytes` was discarded.

Only a brand-new download, which goes through `ApplyTo`, ever recorded a table. So the split-shard scan added in #155 was unreachable for exactly the models it was written for: anything downloaded before it shipped.

`PLEChecked` was dropped the same way, which has a second effect — `needsPLE` stays true, so every model gets its GGUF re-parsed at every startup, forever. For a split model that reopens every shard; `ple_probe.go` notes that costing 33 seconds on one model.

## Why it survived three PRs

Every existing test exercises `ParseGGUFMeta` directly. Nothing covered the parser-to-registry handoff, so the scan could be right and thoroughly tested while its result went nowhere. The new test covers that handoff and checks the value persists — it fails on `main`, passes here.

## Testing

- `TestBackfillPopulatesPLE` fails before this change, passes after.
- Existing PLE tests all still pass.
- Full suite green apart from two pre-existing `internal/builder` git-tag failures that reproduce identically on a clean `main`.

## Note for deploying

This takes effect on restart, when backfill runs. Watch for `backfilled per-layer embedding table` in the log.

I could not verify that the `Qwen3.8-Flash-Next` GGUF actually carries a table over the 4 GiB threshold — I had no read access to the file, and its current VRAM estimate (114.26 GB against a 111 GB download) suggests nothing is being excluded yet. If that log line does not appear for it after restart, then the tensor is named something other than `per_layer_token_embd.weight` under `qwen4exp`, and the matcher in `gguf.go` needs a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt54KWjaay1Lzywdnkg3V2