### PR TITLE
feat(benchmarks): sweep per-layer embedding mode and extra flags

### DIFF
--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -401,6 +401,8 @@ func (e *jobEnv) modelInfoBundle(m *models.Model) (benchmark.ModelInfo, error) {
 			DraftPMin:      cfg.DraftPMin,
 			NgramSizeN:     cfg.NgramSizeN,
 			NgramSizeM:     cfg.NgramSizeM,
+			PLEMode:        cfg.PLEMode,
+			ExtraFlags:     cfg.ExtraFlags,
 		},
 	}, nil
 }
@@ -672,6 +674,8 @@ func applySnapshotToConfig(base models.ModelConfig, snap benchmark.ConfigSnapsho
 	out.NgramSizeM = snap.NgramSizeM
 	out.FlashAttention = snap.FlashAttention
 	out.DirectIO = snap.DirectIO
+	out.PLEMode = snap.PLEMode
+	out.ExtraFlags = snap.ExtraFlags
 	return out
 }
 

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -116,6 +116,13 @@ type ConfigSnapshot struct {
 	DraftPMin      string `json:"draft_p_min,omitempty"`
 	NgramSizeN     int    `json:"ngram_size_n,omitempty"`
 	NgramSizeM     int    `json:"ngram_size_m,omitempty"`
+
+	// PLEMode and ExtraFlags reach llama-server through the preset INI
+	// (tensor-read-lazy, and the raw flag text appended verbatim). Both
+	// are load-time settings that never reach the capability evaluation
+	// — see the excluded list on evaluate.MapConfigFlags.
+	PLEMode    string `json:"ple_mode,omitempty"`
+	ExtraFlags string `json:"extra_flags,omitempty"`
 }
 
 // GPUSnapshot captures GPU hardware at benchmark time.

--- a/internal/benchmark/collapse_test.go
+++ b/internal/benchmark/collapse_test.go
@@ -228,6 +228,9 @@ func TestSweepFieldAffectsEvalClassification(t *testing.T) {
 		"context_size": false, "spec_type": false,
 		"temperature": false, "top_p": false, "min_p": false,
 		"repeat_penalty": false, "top_k": false,
+		// Both are load-time settings the evaluation never sees; see
+		// the excluded list on evaluate.MapConfigFlags.
+		"ple_mode": false, "extra_flags": false,
 	}
 	for name, want := range wantTrue {
 		if affects[name] != want {

--- a/internal/benchmark/job.go
+++ b/internal/benchmark/job.go
@@ -84,6 +84,8 @@ type ConfigOverrides struct {
 	FlashAttention *bool    `json:"flash_attention,omitempty"`
 	KVCacheQuant   *string  `json:"kv_cache_quant,omitempty"`
 	DirectIO       *bool    `json:"direct_io,omitempty"`
+	PLEMode        *string  `json:"ple_mode,omitempty"`
+	ExtraFlags     *string  `json:"extra_flags,omitempty"`
 	GPUAssign      *string  `json:"gpu_assign,omitempty"`
 	TensorSplit    *string  `json:"tensor_split,omitempty"`
 	SpecType       *string  `json:"spec_type,omitempty"`

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -859,6 +859,12 @@ func applyOverrides(base ConfigSnapshot, overrides *ConfigOverrides) ConfigSnaps
 	if overrides.NgramSizeM != nil {
 		out.NgramSizeM = *overrides.NgramSizeM
 	}
+	if overrides.PLEMode != nil {
+		out.PLEMode = *overrides.PLEMode
+	}
+	if overrides.ExtraFlags != nil {
+		out.ExtraFlags = *overrides.ExtraFlags
+	}
 	return out
 }
 

--- a/internal/benchmark/sweep.go
+++ b/internal/benchmark/sweep.go
@@ -368,6 +368,48 @@ var sweepFields = map[string]SweepField{
 		func(o *ConfigOverrides, v *bool) { o.FlashAttention = v }),
 	"direct_io": boolField("direct_io", "Direct I/O", "Bypasses the page cache when loading weights.",
 		func(o *ConfigOverrides, v *bool) { o.DirectIO = v }),
+	// "auto" is llama.cpp's own default and is stored as the empty
+	// string so the preset omits the flag entirely. It needs the
+	// explicit spelling because a blank sweep value means "use the
+	// model's saved setting", which is a different thing — the same
+	// reason spec_type spells out "none".
+	"ple_mode": {
+		Name: "ple_mode", Label: "Per-Layer Embeddings", Kind: SweepKindStr,
+		Help:    "How the per-layer embedding table is held. Auto follows llama.cpp and reads it on demand above 4 GiB. Only meaningful for models that carry such a table.",
+		Example: "auto,on,off", RestartsRouter: true, Separator: ",",
+		Choices: []SweepChoice{
+			{Value: "auto", Label: "Auto (stream if over 4 GiB)"},
+			{Value: "on", Label: "Stream from model file"},
+			{Value: "off", Label: "Keep resident"},
+		},
+		set: func(o *ConfigOverrides, raw string) error {
+			v := strings.TrimSpace(raw)
+			switch v {
+			case "auto":
+				v = ""
+			case "on", "off":
+			default:
+				return fmt.Errorf("%q is not a per-layer embedding mode (use auto, on or off)", raw)
+			}
+			o.PLEMode = &v
+			return nil
+		},
+	},
+	// Separator "|" rather than "," because flag values contain commas
+	// of their own — an --override-tensor pattern list is the motivating
+	// case, and splitting it on commas would shred one flag into several
+	// bogus sweep points.
+	"extra_flags": {
+		Name: "extra_flags", Label: "Extra Flags", Kind: SweepKindStr,
+		Help:           "Raw llama-server flags, appended verbatim to the preset. Separate sweep points with | since flag values contain spaces and commas.",
+		Example:        "--load-mode none|--load-mode mmap",
+		RestartsRouter: true, Separator: "|", FreeText: true,
+		set: func(o *ConfigOverrides, raw string) error {
+			v := strings.TrimSpace(raw)
+			o.ExtraFlags = &v
+			return nil
+		},
+	},
 	"kv_cache_quant": strField("kv_cache_quant", "KV Cache Quant", "KV cache type, e.g. f16, q8_0, q4_0. Trades memory for accuracy.", "f16,q8_0",
 		func(o *ConfigOverrides, v *string) { o.KVCacheQuant = v }),
 	// gpu_assign and tensor_split reach the evaluation only through the

--- a/internal/benchmark/sweep_ple_test.go
+++ b/internal/benchmark/sweep_ple_test.go
@@ -1,0 +1,48 @@
+package benchmark
+
+import "testing"
+
+// The two axes added for the VRAM-estimate investigation (plan/ple-vram-findings.md).
+// Both are load-time settings, so the only thing that makes them useful is
+// reaching the preset INI — a sweep that parsed but never changed the
+// launched config would report several labels for one measurement.
+func TestPLEModeSweepReachesSnapshot(t *testing.T) {
+	for _, tt := range []struct{ raw, want string }{
+		{"auto", ""}, // llama.cpp's default: emit no flag at all
+		{"on", "on"},
+		{"off", "off"},
+	} {
+		var o ConfigOverrides
+		if err := sweepFields["ple_mode"].set(&o, tt.raw); err != nil {
+			t.Fatalf("%s: %v", tt.raw, err)
+		}
+		if got := applyOverrides(ConfigSnapshot{}, &o).PLEMode; got != tt.want {
+			t.Errorf("ple_mode %q reached the snapshot as %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestPLEModeSweepRejectsNonsense(t *testing.T) {
+	var o ConfigOverrides
+	if err := sweepFields["ple_mode"].set(&o, "resident"); err == nil {
+		t.Error("accepted a mode llama.cpp does not have; a typo would silently run the model's saved setting under a wrong label")
+	}
+}
+
+// Flag values contain commas of their own, so the axis splits on "|".
+// Splitting on "," would shred one --override-tensor pattern list into
+// several bogus sweep points.
+func TestExtraFlagsSweepKeepsCommasIntact(t *testing.T) {
+	f := sweepFields["extra_flags"]
+	if f.Separator != "|" {
+		t.Fatalf("separator = %q, want |", f.Separator)
+	}
+	const raw = "--override-tensor per_layer_token_embd=CPU,blk.1=CPU --load-mode none"
+	var o ConfigOverrides
+	if err := f.set(&o, raw); err != nil {
+		t.Fatal(err)
+	}
+	if got := applyOverrides(ConfigSnapshot{}, &o).ExtraFlags; got != raw {
+		t.Errorf("extra_flags reached the snapshot as %q, want it verbatim", got)
+	}
+}

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -177,6 +177,11 @@ type SnapshotSubset struct {
 //     NgramSizeN, NgramSizeM: speculative decoding — scoring is a fixed
 //     greedy next-token pass over a fixed corpus, there is nothing for
 //     a drafter to accelerate.
+//   - PLEMode, ExtraFlags: load-time settings. --tensor-read-lazy
+//     governs host residency during load and ExtraFlags is arbitrary
+//     user text; neither changes a deterministic greedy scoring pass,
+//     and mapping raw flag text into the evaluation command line would
+//     let a sweep silently rewrite the invocation being scored.
 //   - parallel slots, sampling, mmproj, context-shift (ModelConfig
 //     fields the snapshot never carries): irrelevant to or incompatible
 //     with single-stream deterministic scoring.


### PR DESCRIPTION
Adds `ple_mode` and `extra_flags` as benchmark sweep axes. Prerequisite for step 2 of the measurement plan in #159.

## Why

Neither was sweepable, so the two settings that decide where a model's per-layer embedding table lives could not be compared from a job. The investigation behind #159 had to be driven by hand against a live server — setting model config over HTTP, restarting the router, timing completions — purely because the job system could not express the axis.

## What

Wired through all six sites the existing completeness tests demand: `ConfigOverrides`, `ConfigSnapshot`, `applyOverrides`, the snapshot seeding in `ResolveModel`, `applySnapshotToConfig`, and the sweep catalogue.

Two details worth review:

**`ple_mode` spells its default "auto"** rather than leaving it blank. The empty string is the stored value that makes the preset omit `--tensor-read-lazy` entirely, but a blank sweep value already means "use the model's saved setting" — a different thing. `spec_type` spells out `none` for the same reason. The setter rejects anything that isn't `auto`/`on`/`off`, so a typo can't quietly run the saved setting under a wrong label.

**`extra_flags` splits on `|`**, not `,`. An `--override-tensor` pattern list contains commas of its own, and the comma separator would shred one flag into several bogus sweep points. `tensor_split` already sets this precedent.

## AffectsEval

Both are `false`, and both are added to the excluded list documented on `evaluate.MapConfigFlags` — that comment asserts every `ConfigSnapshot` field is either mapped or named, so adding fields without touching it would have made it false.

They're load-time settings that cannot move a deterministic greedy scoring pass. Mapping raw flag text into the evaluation command line would also let a sweep silently rewrite the invocation being scored, which is the mislabeled-result failure this package guards against everywhere else.

`TestSweepFieldAffectsEvalClassification` caught the omission on the first run, which is the tripwire working — its `wantFalse` map is updated with a comment pointing at the reason.

## Testing

- New `sweep_ple_test.go` covers the parse-to-snapshot handoff for both axes: `auto` reaching the snapshot as `""`, a rejected bad mode, and an `--override-tensor` value with commas surviving verbatim.
- Full suite green apart from two pre-existing `internal/builder` git-tag failures that reproduce identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt54KWjaay1Lzywdnkg3V2