### PR TITLE
feat(settings): curate the llama.cpp log verbosity, and expose the PLE table size

### DIFF
--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -101,6 +101,11 @@ func withPublicNames(list []*models.Model) []map[string]any {
 			"context_length":     m.ContextLength,
 			"supports_tools":     m.SupportsTools,
 			"has_builtin_vision": m.HasBuiltinVision,
+			// The per-layer embedding table drives both the config
+			// selector's visibility and the VRAM estimate, so a client
+			// reading this list cannot explain either number without it.
+			"ple_bytes":   m.PLEBytes,
+			"ple_checked": m.PLEChecked,
 		}
 		out = append(out, entry)
 	}

--- a/internal/api/models_ple_fields_test.go
+++ b/internal/api/models_ple_fields_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/models"
+)
+
+// The models list is an explicit allow-list, so a field is invisible
+// until it is named there. Both PLE fields drive things a client can
+// see — the config selector's visibility and the VRAM estimate — and
+// their absence once made a populated registry look empty.
+func TestModelListExposesPLEFields(t *testing.T) {
+	out := withPublicNames([]*models.Model{{
+		ID: "m", PLEBytes: 1937768448, PLEChecked: true,
+	}})
+	if len(out) != 1 {
+		t.Fatalf("got %d entries", len(out))
+	}
+	if got := out[0]["ple_bytes"]; got != int64(1937768448) {
+		t.Errorf("ple_bytes = %v (%T), want 1937768448", got, got)
+	}
+	if got := out[0]["ple_checked"]; got != true {
+		t.Errorf("ple_checked = %v, want true", got)
+	}
+}
+
+// A model with no table must report zero rather than omitting the key,
+// so "no table" and "not in this payload" stay distinguishable.
+func TestModelListReportsAbsentPLETable(t *testing.T) {
+	out := withPublicNames([]*models.Model{{ID: "m"}})
+	if _, ok := out[0]["ple_bytes"]; !ok {
+		t.Error("ple_bytes missing for a model without a table; callers cannot tell it from an old payload")
+	}
+	if out[0]["ple_checked"] != false {
+		t.Errorf("ple_checked = %v, want false", out[0]["ple_checked"])
+	}
+}

--- a/internal/config/log_verbosity_test.go
+++ b/internal/config/log_verbosity_test.go
@@ -1,0 +1,51 @@
+package config
+
+import "testing"
+
+// The buffer-size report that the VRAM-estimate work depends on
+// (plan/ple-vram-findings.md) only appears at verbosity 4 or above, and
+// the router passes its environment to every model instance it starts.
+// Curating the variable is what makes that reachable without hand-editing
+// the free-form block.
+func TestLogVerbosityIsCurated(t *testing.T) {
+	var opt *RuntimeEnvOption
+	for i, o := range RuntimeEnvOptions() {
+		if o.Name == "LLAMA_ARG_LOG_VERBOSITY" {
+			opt = &RuntimeEnvOptions()[i]
+		}
+	}
+	if opt == nil {
+		t.Fatal("LLAMA_ARG_LOG_VERBOSITY is not a curated option")
+	}
+	// Backend-independent: this is llama.cpp's own logging, not a GPU knob.
+	if len(opt.Backends) != 0 {
+		t.Errorf("Backends = %v, want empty (applies to every build)", opt.Backends)
+	}
+	want := map[string]bool{"": true, "3": true, "4": true, "5": true}
+	for _, v := range opt.Values {
+		if !want[v] {
+			t.Errorf("unexpected value %q", v)
+		}
+		delete(want, v)
+	}
+	for v := range want {
+		t.Errorf("missing value %q — 4 is the level that reports buffer sizes", v)
+	}
+}
+
+// A curated value must survive validation, or the setting cannot be saved.
+func TestLogVerbosityValidates(t *testing.T) {
+	set := EnvSet{Curated: map[string]string{"LLAMA_ARG_LOG_VERBOSITY": "4"}}
+	if err := set.Validate(); err != nil {
+		t.Errorf("verbosity 4 rejected: %v", err)
+	}
+	var found bool
+	for _, p := range set.Pairs() {
+		if p == "LLAMA_ARG_LOG_VERBOSITY=4" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("verbosity never reached the environment passed to the router")
+	}
+}

--- a/internal/config/runtime_env.go
+++ b/internal/config/runtime_env.go
@@ -38,6 +38,18 @@ type RuntimeEnvOption struct {
 func RuntimeEnvOptions() []RuntimeEnvOption {
 	return []RuntimeEnvOption{
 		{
+			Name:  "LLAMA_ARG_LOG_VERBOSITY",
+			Label: "Model loading detail",
+			Help: "How much llama.cpp reports while loading a model. The router passes its own " +
+				"environment to every model instance it starts, so this reaches them too. " +
+				"3 is llama.cpp's default. 4 adds the per-buffer memory report — model weights, " +
+				"KV cache, recurrent state and compute buffers, each with the device holding it — " +
+				"which is the only place those figures are stated and the way to check a VRAM " +
+				"estimate against what was really allocated. 5 adds per-layer and per-tensor debug " +
+				"output and is very noisy: roughly 12,000 log lines per model load against 900 at 4.",
+			Values: []string{"", "3", "4", "5"},
+		},
+		{
 			Name:  "GGML_CUDA_CUBLAS_COMPUTE_TYPE",
 			Label: "cuBLAS/hipBLAS compute type",
 			Help: "Accumulator precision for GEMMs that fall through to cuBLAS/hipBLAS. " +

--- a/plan/ple-vram-findings.md
+++ b/plan/ple-vram-findings.md
@@ -1,6 +1,7 @@
 # Per-layer embeddings and the VRAM estimate: measured findings
 
-Status: investigation complete, no code changes proposed yet.
+Status: investigation complete. Step 1 of the measurement plan is done;
+steps 2-6 are open.
 Date: 2026-08-29.
 Measured on `compute` — llama-toolchest v2.25.1 (plus the PR #157 backfill fix),
 llama.cpp build `b10679-rocm`, 4x AMD Radeon AI PRO R9700 (32 GiB each, gfx1201),
@@ -138,11 +139,41 @@ if wanted at all, as what it is rather than as a placement control.
 The estimator cannot be corrected from per-GPU totals alone — they conflate
 weights, KV and compute buffers. The work needs a decomposition first.
 
-**Step 1 — get llama.cpp's own buffer report.** The router forwards only
-`srv`/`slot`/`load`/`cmn` categories, so `load_tensors: ... buffer size` lines
-never reach `/api/service/logs`. Either widen what the router captures, or run
-`llama-server` directly in the container for measurement runs. Without this every
-subsequent step is inference from totals.
+**Step 1 — get llama.cpp's own buffer report. Done.** The cause was not
+filtering in toolchest, which broadcasts every line the router emits
+(`process/manager.go:153`). It was log verbosity: llama.cpp's default of 3 passes
+warnings from the core library but drops its INFO lines, so `W load:` arrived and
+`I load:` did not. The router passes its environment to every model instance it
+starts, so raising `LLAMA_ARG_LOG_VERBOSITY` reaches the children that do the
+loading. It is now a curated Settings option.
+
+Verbosity 4 is the level to use. Measured on one Qwen3.8-27B load:
+
+| Verbosity | Lines per load | Buffer report |
+|---|---|---|
+| 3 (default) | 168 | no |
+| 4 | 916 | yes |
+| 5 | 11,874 | yes, plus per-layer and per-tensor debug |
+
+At 4 the report reads (device names as llama.cpp prints them):
+
+```
+load_tensors:         CPU_Mapped model buffer size =  1288.28 MiB
+load_tensors:             Meta() model buffer size =  7252.51 MiB
+llama_kv_cache:           Meta() KV buffer size    =  4096.00 MiB
+llama_kv_cache:  size = 16384.00 MiB (262144 cells, 16 layers, 4/1 seqs),
+                 K (f16): 8192.00 MiB, V (f16): 8192.00 MiB
+llama_memory_recurrent:   Meta() RS buffer size    =   448.88 MiB
+sched_reserve:            Meta() compute buffer size =  384.95 MiB
+sched_reserve:         ROCm_Host compute buffer size =  276.02 MiB
+llama_context:         ROCm_Host output buffer size  =    3.79 MiB
+```
+
+That is the decomposition the estimator needs: weights split by device and by
+whether they are mmap-backed, KV with its K/V breakdown, recurrent state, and
+compute buffers. Note `CPU_Mapped` appearing for weights on a model with no
+per-layer embedding table at all — more than the PLE table can sit off-GPU, which
+step 4 should account for.
 
 **Step 2 — build a repeatable harness.** For each (model, context, batch,
 ubatch, kv quant, ngl, ple_mode) point: load, record per-GPU VRAM, host RSS, and


### PR DESCRIPTION
Two small unblockers for the VRAM-estimate work in `plan/ple-vram-findings.md` (#159). Step 1 of that plan is now done; the doc is updated to record how.

## Why the buffer report was missing

Not filtering in toolchest — `process/manager.go:153` broadcasts every line the router emits, unconditionally. It was **log verbosity**.

llama.cpp's default of 3 passes warnings from the core library but drops its INFO lines. The signature was visible in a captured load: `W load:` lines arrived, `I load:` lines did not, while `I srv` / `I cmn` / `I slot` came through fine. The router passes its environment to every model instance it starts, so raising `LLAMA_ARG_LOG_VERBOSITY` reaches the children that actually do the loading.

## Which level

Measured on one Qwen3.8-27B load:

| Verbosity | Lines per load | Buffer report |
|---|---|---|
| 3 (default) | 168 | no |
| **4** | **916** | **yes** |
| 5 | 11,874 | yes, plus per-layer/per-tensor debug |

At 4 you get the decomposition the estimator needs — weights split by device and by whether they're mmap-backed, KV with its K/V breakdown, recurrent state, and compute buffers:

```
load_tensors:       CPU_Mapped model buffer size =  1288.28 MiB
load_tensors:           Meta() model buffer size =  7252.51 MiB
llama_kv_cache:         Meta() KV buffer size    =  4096.00 MiB
llama_memory_recurrent: Meta() RS buffer size    =   448.88 MiB
sched_reserve:          Meta() compute buffer size =  384.95 MiB
```

Level 5 is a trap for this purpose: 3,128 of its extra lines are graph-compute debug, and every buffer-size line is already INFO.

Worth noting for step 4: `CPU_Mapped` shows up for **weights** on a model with no per-layer embedding table at all. More than the PLE table can sit off-GPU, which the estimator will have to account for.

## The second change

The models list is an explicit allow-list (`withPublicNames`), so `ple_bytes` and `ple_checked` were invisible to any client reading `/api/models` — including while they decide whether the config selector renders and how the VRAM estimate is computed. Their absence is also what made a populated registry look empty and sent my earlier diagnosis down the wrong path; the endpoint still reports 0 of 29 today on a box where both fields are set.

Zero is reported rather than omitted, so "no table" stays distinguishable from "old payload".

## Testing

New tests cover both: the curated option's values and that it survives `EnvSet.Validate` into the environment handed to the router; and that both PLE fields appear in the list payload, including the absent-table case. Full suite green apart from two pre-existing `internal/builder` git-tag failures that reproduce on clean `main`.

Verified end to end against the live instance — set to 4, reloaded, confirmed the buffer lines arrive, restored the setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt54KWjaay1Lzywdnkg3V2