### PR TITLE
feat(memreport): parse llama.cpp's per-buffer memory report

### DIFF
--- a/internal/memreport/memreport.go
+++ b/internal/memreport/memreport.go
@@ -54,6 +54,18 @@ type Entry struct {
 // cards.
 func (e Entry) OnGPU() bool { return !isHostDevice(e.Device) }
 
+// IsAggregate reports whether the device is llama.cpp's stand-in for
+// several cards addressed as one, which is what a tensor-parallel split
+// produces.
+//
+// This matters because buffer sizes reported against an aggregate are
+// PER UNDERLYING CARD, not totals. A 29.30 GiB model split across four
+// cards reports 7041.71 MiB of Meta() weights; multiplying by four and
+// adding the host-mapped remainder is what reconciles with the file.
+// Reading those figures as totals under-counts a tensor-parallel load by
+// the number of cards it spans.
+func (e Entry) IsAggregate() bool { return strings.HasPrefix(e.Device, "Meta(") }
+
 func isHostDevice(device string) bool {
 	return device == "CPU" ||
 		strings.HasPrefix(device, "CPU_") ||
@@ -104,6 +116,27 @@ func ParseLine(line string) (Entry, bool) {
 		return Entry{Instance: m[1], Category: m[2], Device: m[3], Kind: KindRecurrent, MiB: mib}, true
 	}
 	return Entry{}, false
+}
+
+// ScaleAggregates returns a copy with every aggregate-device entry
+// multiplied by cards, turning per-card figures into totals.
+//
+// The log never states how many cards an aggregate spans, so the caller
+// supplies it from the model's GPU assignment. Passing 1, or calling
+// nothing at all, leaves a tensor-parallel report under-counted; passing
+// a count for a report that has no aggregate entries is harmless.
+func (r Report) ScaleAggregates(cards int) Report {
+	if cards <= 1 {
+		return r
+	}
+	out := Report{Entries: make([]Entry, len(r.Entries))}
+	copy(out.Entries, r.Entries)
+	for i := range out.Entries {
+		if out.Entries[i].IsAggregate() {
+			out.Entries[i].MiB *= float64(cards)
+		}
+	}
+	return out
 }
 
 // Report collects the entries seen for one model load.

--- a/internal/memreport/memreport.go
+++ b/internal/memreport/memreport.go
@@ -1,0 +1,238 @@
+// Package memreport parses the per-buffer memory report llama.cpp prints
+// while loading a model, which is the only place the split between model
+// weights, KV cache, recurrent state and compute buffers is stated.
+//
+// The report appears at log verbosity 4 and above (LLAMA_ARG_LOG_VERBOSITY,
+// a curated runtime-env option). At the default of 3 llama.cpp emits
+// warnings from its core library but not these INFO lines, so nothing here
+// will match. See plan/ple-vram-findings.md for why the split matters: the
+// VRAM estimate is currently accurate on one model only because a large
+// over-count of weights cancels a large under-count of everything else,
+// and separating the terms is what makes that testable.
+package memreport
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Kind is the sort of allocation a buffer holds.
+type Kind string
+
+const (
+	KindModel     Kind = "model"     // weights
+	KindKV        Kind = "kv"        // attention KV cache
+	KindRecurrent Kind = "recurrent" // recurrent/linear-attention state
+	KindCompute   Kind = "compute"   // scratch for the graph
+	KindOutput    Kind = "output"    // logits
+)
+
+// Entry is one "<device> <kind> buffer size = N MiB" observation.
+type Entry struct {
+	// Instance is the child process id llama.cpp's router prefixes onto
+	// lines from the model instance that is doing the loading. Empty for
+	// lines the router itself emitted. Reports from concurrently loading
+	// models interleave in one stream, so this is what separates them.
+	Instance string
+	// Category is the llama.cpp function that logged the line
+	// (load_tensors, llama_kv_cache, sched_reserve, ...). Kept because
+	// the same Kind is reported by more than one of them.
+	Category string
+	Device   string
+	Kind     Kind
+	MiB      float64
+}
+
+// OnGPU reports whether the device holds accelerator memory.
+//
+// Host buffers are named for the CPU: "CPU", "CPU_Mapped" (weights left
+// in the mmap rather than copied), and the pinned staging buffers each
+// backend names "<backend>_Host" — ROCm_Host, CUDA_Host. Everything else
+// is a device: ROCm0, CUDA1, Vulkan0, and "Meta()", which is what
+// llama.cpp calls the aggregate when one logical device spans several
+// cards.
+func (e Entry) OnGPU() bool { return !isHostDevice(e.Device) }
+
+func isHostDevice(device string) bool {
+	return device == "CPU" ||
+		strings.HasPrefix(device, "CPU_") ||
+		strings.HasSuffix(device, "_Host")
+}
+
+// lineRE matches an optional "[pid] " prefix, llama.cpp's timestamp and
+// level, the logging function, and then the buffer report itself. The
+// device name is deliberately \S+ rather than a list: "Meta()" carries
+// parentheses and backend names grow, so an allowlist would silently
+// drop the very numbers this exists to collect.
+var lineRE = regexp.MustCompile(
+	`^(?:\[(\d+)\] )?[\d.]+ [A-Z] (\w+):\s+(\S+)\s+(model|KV|compute|output)\s+buffer size\s*=\s*([\d.]+)\s*MiB`)
+
+// recurrentRE is separate because llama.cpp spells recurrent state "RS"
+// in the buffer line while naming the function llama_memory_recurrent.
+var recurrentRE = regexp.MustCompile(
+	`^(?:\[(\d+)\] )?[\d.]+ [A-Z] (\w+):\s+(\S+)\s+RS\s+buffer size\s*=\s*([\d.]+)\s*MiB`)
+
+// ParseLine extracts one entry, reporting false for any line that is not
+// a buffer report — which is the overwhelming majority of the stream.
+func ParseLine(line string) (Entry, bool) {
+	line = strings.TrimPrefix(line, "data: ")
+	if !strings.Contains(line, "buffer size") {
+		return Entry{}, false
+	}
+	if m := lineRE.FindStringSubmatch(line); m != nil {
+		mib, err := strconv.ParseFloat(m[5], 64)
+		if err != nil {
+			return Entry{}, false
+		}
+		kind := KindModel
+		switch m[4] {
+		case "KV":
+			kind = KindKV
+		case "compute":
+			kind = KindCompute
+		case "output":
+			kind = KindOutput
+		}
+		return Entry{Instance: m[1], Category: m[2], Device: m[3], Kind: kind, MiB: mib}, true
+	}
+	if m := recurrentRE.FindStringSubmatch(line); m != nil {
+		mib, err := strconv.ParseFloat(m[4], 64)
+		if err != nil {
+			return Entry{}, false
+		}
+		return Entry{Instance: m[1], Category: m[2], Device: m[3], Kind: KindRecurrent, MiB: mib}, true
+	}
+	return Entry{}, false
+}
+
+// Report collects the entries seen for one model load.
+type Report struct {
+	Entries []Entry
+}
+
+// Add parses a log line and keeps it when it is a buffer report.
+func (r *Report) Add(line string) bool {
+	e, ok := ParseLine(line)
+	if ok {
+		r.Entries = append(r.Entries, e)
+	}
+	return ok
+}
+
+// ForInstance returns the entries a single model instance logged. The
+// router interleaves output from every child, so totals taken without
+// this are the sum of whatever happened to be loading.
+func (r Report) ForInstance(pid string) Report {
+	var out Report
+	for _, e := range r.Entries {
+		if e.Instance == pid {
+			out.Entries = append(out.Entries, e)
+		}
+	}
+	return out
+}
+
+// Instances lists the child process ids present, in first-seen order.
+func (r Report) Instances() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, e := range r.Entries {
+		if !seen[e.Instance] {
+			seen[e.Instance] = true
+			out = append(out, e.Instance)
+		}
+	}
+	return out
+}
+
+// SumMiB totals every entry matching the filter.
+//
+// Summing is right for weights, KV and recurrent state: each line is a
+// distinct allocation on a distinct device. It is NOT known to be right
+// for compute buffers. llama.cpp reserves more than once per load — a
+// hybrid model reserves separately for each memory module — and whether
+// those reservations are separate allocations or one buffer resized to
+// the largest graph is not something the log states. MaxComputeMiB
+// exists for the other reading; plan/ple-vram-findings.md step 3 settles
+// which by comparing both against measured VRAM.
+func (r Report) SumMiB(match func(Entry) bool) float64 {
+	var total float64
+	for _, e := range r.Entries {
+		if match == nil || match(e) {
+			total += e.MiB
+		}
+	}
+	return total
+}
+
+// ByKind totals each kind, summing.
+func (r Report) ByKind() map[Kind]float64 {
+	out := map[Kind]float64{}
+	for _, e := range r.Entries {
+		out[e.Kind] += e.MiB
+	}
+	return out
+}
+
+// ByDevice totals each device, summing.
+func (r Report) ByDevice() map[string]float64 {
+	out := map[string]float64{}
+	for _, e := range r.Entries {
+		out[e.Device] += e.MiB
+	}
+	return out
+}
+
+// MaxComputeMiB totals the largest compute reservation seen per device,
+// the reading in which repeated reserves share one buffer rather than
+// each adding to the footprint. See SumMiB for why both exist.
+func (r Report) MaxComputeMiB(onGPU bool) float64 {
+	peak := map[string]float64{}
+	for _, e := range r.Entries {
+		if e.Kind != KindCompute || e.OnGPU() != onGPU {
+			continue
+		}
+		if e.MiB > peak[e.Device] {
+			peak[e.Device] = e.MiB
+		}
+	}
+	var total float64
+	for _, v := range peak {
+		total += v
+	}
+	return total
+}
+
+// GPUMiB is everything allocated on an accelerator, the figure a VRAM
+// estimate is trying to predict. compute uses whichever aggregation the
+// caller asks for, since that is the open question.
+func (r Report) GPUMiB(sumCompute bool) float64 {
+	var total float64
+	for _, e := range r.Entries {
+		if !e.OnGPU() || (e.Kind == KindCompute && !sumCompute) {
+			continue
+		}
+		total += e.MiB
+	}
+	if !sumCompute {
+		total += r.MaxComputeMiB(true)
+	}
+	return total
+}
+
+// HostMiB is everything allocated in system memory: weights left mapped,
+// pinned staging buffers, and any layer that did not fit a device.
+func (r Report) HostMiB(sumCompute bool) float64 {
+	var total float64
+	for _, e := range r.Entries {
+		if e.OnGPU() || (e.Kind == KindCompute && !sumCompute) {
+			continue
+		}
+		total += e.MiB
+	}
+	if !sumCompute {
+		total += r.MaxComputeMiB(false)
+	}
+	return total
+}

--- a/internal/memreport/memreport_test.go
+++ b/internal/memreport/memreport_test.go
@@ -1,0 +1,285 @@
+package memreport
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// Verbatim lines from a Qwen3.8-27B load on the ROCm box, captured at
+// LLAMA_ARG_LOG_VERBOSITY=4 through /api/service/logs. Kept exactly as
+// they arrived — SSE "data: " prefix, router pid prefix, and llama.cpp's
+// ragged column alignment — because every one of those is something the
+// parser has to survive in production.
+const realLog = `data: [33899] 0.14.275.751 I load_tensors:   CPU_Mapped model buffer size =  1288.28 MiB
+data: [33899] 0.14.275.753 I load_tensors:       Meta() model buffer size =  7252.51 MiB
+data: [33899] 0.16.135.888 I llama_kv_cache: size = 16384.00 MiB (262144 cells,  16 layers,  4/1 seqs), K (f16): 8192.00 MiB, V (f16): 8192.00 MiB
+data: [33899] 0.16.162.940 I llama_memory_recurrent:     Meta() RS buffer size =   448.88 MiB
+data: [33899] 0.16.260.662 I sched_reserve:     Meta() compute buffer size =   384.95 MiB
+data: [33899] 0.16.260.669 I sched_reserve:  ROCm_Host compute buffer size =   276.02 MiB
+data: [33899] 0.17.752.569 I llama_context:  ROCm_Host  output buffer size =     3.79 MiB
+data: [33899] 0.17.783.489 I llama_kv_cache:     Meta() KV buffer size =   256.00 MiB
+data: [33899] 0.17.873.961 I sched_reserve:     Meta() compute buffer size =   324.02 MiB
+data: [33899] 0.17.873.969 I sched_reserve:  ROCm_Host compute buffer size =   276.02 MiB
+data: [33899] 0.02.652.943 I srv  llama_server: model loaded
+data: [33899] 0.00.688.812 D load_tensors: layer   1 assigned to device Meta(), is_swa = 0`
+
+func parseAll(t *testing.T, log string) Report {
+	t.Helper()
+	var r Report
+	for _, l := range strings.Split(log, "\n") {
+		r.Add(l)
+	}
+	return r
+}
+
+func close(a, b float64) bool { return math.Abs(a-b) < 0.005 }
+
+func TestParsesRealLoad(t *testing.T) {
+	r := parseAll(t, realLog)
+	if len(r.Entries) != 9 {
+		t.Fatalf("got %d entries, want 9:\n%+v", len(r.Entries), r.Entries)
+	}
+	byKind := r.ByKind()
+	for _, tt := range []struct {
+		kind Kind
+		want float64
+	}{
+		{KindModel, 1288.28 + 7252.51},
+		{KindKV, 256.00}, // the "size =" summary is not a buffer line
+		{KindRecurrent, 448.88},
+		{KindCompute, 384.95 + 276.02 + 324.02 + 276.02},
+		{KindOutput, 3.79},
+	} {
+		if !close(byKind[tt.kind], tt.want) {
+			t.Errorf("%s = %.2f, want %.2f", tt.kind, byKind[tt.kind], tt.want)
+		}
+	}
+}
+
+// The "size = N MiB (cells, layers...)" summary restates a total that the
+// per-device buffer lines already carry. Counting it would double the KV
+// figure — 16384 MiB against a real 256 in this load.
+func TestSizeSummaryIsNotABuffer(t *testing.T) {
+	line := `[33899] 0.16.135.888 I llama_kv_cache: size = 16384.00 MiB (262144 cells,  16 layers,  4/1 seqs), K (f16): 8192.00 MiB, V (f16): 8192.00 MiB`
+	if e, ok := ParseLine(line); ok {
+		t.Errorf("parsed a size summary as a buffer: %+v", e)
+	}
+}
+
+func TestHostAndDeviceClassification(t *testing.T) {
+	for _, tt := range []struct {
+		device string
+		onGPU  bool
+	}{
+		{"Meta()", true}, // llama.cpp's aggregate when one device spans cards
+		{"ROCm0", true},
+		{"CUDA1", true},
+		{"Vulkan0", true},
+		{"CPU", false},
+		{"CPU_Mapped", false}, // weights left in the mmap
+		{"ROCm_Host", false},  // pinned staging
+		{"CUDA_Host", false},
+	} {
+		if got := (Entry{Device: tt.device}).OnGPU(); got != tt.onGPU {
+			t.Errorf("%s: OnGPU = %v, want %v", tt.device, got, tt.onGPU)
+		}
+	}
+}
+
+// CPU_Mapped weights appeared on a model with no per-layer embedding
+// table, so "weights are in VRAM" is wrong for reasons beyond the PLE
+// table. Splitting the model kind by device is what shows that.
+func TestModelWeightsSplitAcrossHostAndDevice(t *testing.T) {
+	r := parseAll(t, realLog)
+	host := r.SumMiB(func(e Entry) bool { return e.Kind == KindModel && !e.OnGPU() })
+	gpu := r.SumMiB(func(e Entry) bool { return e.Kind == KindModel && e.OnGPU() })
+	if !close(host, 1288.28) {
+		t.Errorf("host-side weights = %.2f, want 1288.28", host)
+	}
+	if !close(gpu, 7252.51) {
+		t.Errorf("device-side weights = %.2f, want 7252.51", gpu)
+	}
+}
+
+// Compute buffers are reserved more than once per load. Whether those
+// coalesce is unresolved, so both readings must be available and must
+// actually differ.
+func TestComputeAggregationOffersBothReadings(t *testing.T) {
+	r := parseAll(t, realLog)
+	sum := r.SumMiB(func(e Entry) bool { return e.Kind == KindCompute && e.OnGPU() })
+	max := r.MaxComputeMiB(true)
+	if !close(sum, 384.95+324.02) {
+		t.Errorf("summed GPU compute = %.2f, want 708.97", sum)
+	}
+	if !close(max, 384.95) {
+		t.Errorf("peak GPU compute = %.2f, want 384.95", max)
+	}
+	if close(sum, max) {
+		t.Error("the two readings agree; the test model no longer exercises repeated reserves")
+	}
+}
+
+func TestGPUTotalTracksTheComputeReading(t *testing.T) {
+	r := parseAll(t, realLog)
+	weights, kv, rs := 7252.51, 256.00, 448.88
+	if got := r.GPUMiB(true); !close(got, weights+kv+rs+384.95+324.02) {
+		t.Errorf("GPUMiB(sum) = %.2f", got)
+	}
+	if got := r.GPUMiB(false); !close(got, weights+kv+rs+384.95) {
+		t.Errorf("GPUMiB(peak) = %.2f", got)
+	}
+	if got := r.HostMiB(false); !close(got, 1288.28+3.79+276.02) {
+		t.Errorf("HostMiB(peak) = %.2f", got)
+	}
+}
+
+// Concurrently loading models interleave in one stream.
+func TestInstancesAreSeparable(t *testing.T) {
+	log := `[111] 0.1 I load_tensors:  ROCm0 model buffer size =  100.00 MiB
+[222] 0.1 I load_tensors:  ROCm0 model buffer size =  900.00 MiB
+[111] 0.2 I sched_reserve: ROCm0 compute buffer size =   10.00 MiB`
+	r := parseAll(t, log)
+	if got := r.Instances(); len(got) != 2 {
+		t.Fatalf("instances = %v, want two", got)
+	}
+	if got := r.ForInstance("111").SumMiB(nil); !close(got, 110.00) {
+		t.Errorf("instance 111 total = %.2f, want 110.00", got)
+	}
+	if got := r.ForInstance("222").SumMiB(nil); !close(got, 900.00) {
+		t.Errorf("instance 222 total = %.2f, want 900.00", got)
+	}
+}
+
+// Lines without the router prefix (the router's own output) still parse.
+func TestUnprefixedLineParses(t *testing.T) {
+	e, ok := ParseLine(`0.14.275.753 I load_tensors:       ROCm0 model buffer size =  7252.51 MiB`)
+	if !ok {
+		t.Fatal("did not parse")
+	}
+	if e.Instance != "" || e.Device != "ROCm0" || !close(e.MiB, 7252.51) {
+		t.Errorf("got %+v", e)
+	}
+}
+
+func TestNonBufferLinesIgnored(t *testing.T) {
+	for _, l := range []string{
+		"",
+		"data: ",
+		`[1] 0.1 I srv  llama_server: model loaded`,
+		`[1] 0.1 D load_tensors: layer 1 assigned to device Meta(), is_swa = 0`,
+		`[1] 0.1 I load_tensors: loading model tensors, this can take a while... (load_mode = mmap)`,
+		`[1] 0.1 I load_model: [mtmd] estimated worst-case memory usage of mmproj is 1161.02 MiB`,
+	} {
+		if e, ok := ParseLine(l); ok {
+			t.Errorf("parsed %q as %+v", l, e)
+		}
+	}
+}
+
+// A complete report from Qwen3.8-Flash-Next on four ROCm cards, captured
+// at verbosity 4. Kept whole because it is the one load where every term
+// is known: the file is 103.69 GiB, the per-layer embedding table is
+// 26.82 GiB, and total VRAM measured 107.35 GiB from the GPU counters.
+// Those three independent figures are what the parser is checked against.
+const flashNextLog = `[44479] 0.12.132.471 I load_tensors:   CPU_Mapped model buffer size = 28110.09 MiB
+[44479] 0.12.132.473 I load_tensors:        ROCm0 model buffer size = 21297.21 MiB
+[44479] 0.12.132.473 I load_tensors:        ROCm1 model buffer size = 18980.54 MiB
+[44479] 0.12.132.474 I load_tensors:        ROCm2 model buffer size = 19230.54 MiB
+[44479] 0.12.132.475 I load_tensors:        ROCm3 model buffer size = 18548.17 MiB
+[44479] 0.22.653.808 I llama_context:  ROCm_Host  output buffer size =     3.79 MiB
+[44479] 0.22.655.512 I llama_kv_cache:      ROCm0 KV buffer size =   816.00 MiB
+[44479] 0.22.660.169 I llama_kv_cache:      ROCm1 KV buffer size =   816.00 MiB
+[44479] 0.22.664.791 I llama_kv_cache:      ROCm2 KV buffer size =   816.00 MiB
+[44479] 0.22.669.395 I llama_kv_cache:      ROCm3 KV buffer size =   816.00 MiB
+[44479] 0.22.674.696 I llama_memory_recurrent:      ROCm0 RS buffer size =   126.09 MiB
+[44479] 0.22.675.188 I llama_memory_recurrent:      ROCm1 RS buffer size =   112.22 MiB
+[44479] 0.22.675.666 I llama_memory_recurrent:      ROCm2 RS buffer size =   112.22 MiB
+[44479] 0.22.675.946 I llama_memory_recurrent:      ROCm3 RS buffer size =    99.75 MiB
+[44479] 0.22.683.127 I llama_kv_cache:      ROCm0 KV buffer size =   306.00 MiB
+[44479] 0.22.684.183 I llama_kv_cache:      ROCm1 KV buffer size =   306.00 MiB
+[44479] 0.22.685.196 I llama_kv_cache:      ROCm2 KV buffer size =   306.00 MiB
+[44479] 0.22.686.191 I llama_kv_cache:      ROCm3 KV buffer size =   306.00 MiB
+[44479] 1.01.762.088 I sched_reserve:      ROCm0 compute buffer size =  6047.40 MiB
+[44479] 1.01.762.099 I sched_reserve:      ROCm1 compute buffer size =  6311.40 MiB
+[44479] 1.01.762.099 I sched_reserve:      ROCm2 compute buffer size =  6311.40 MiB
+[44479] 1.01.762.100 I sched_reserve:      ROCm3 compute buffer size =  6311.40 MiB
+[44479] 1.01.762.101 I sched_reserve:  ROCm_Host compute buffer size = 52267.48 MiB`
+
+const gib = 1024.0
+
+// Weights reported across every device must add back up to the file on
+// disk. This is the check that the parser is reading whole numbers and
+// not, say, dropping a device whose name it failed to match.
+func TestFlashNextWeightsReconcileWithFileSize(t *testing.T) {
+	r := parseAll(t, flashNextLog)
+	weights := r.SumMiB(func(e Entry) bool { return e.Kind == KindModel }) / gib
+	const fileGiB = 103.69
+	if math.Abs(weights-fileGiB) > 0.05 {
+		t.Errorf("weights total %.2f GiB, want the file's %.2f", weights, fileGiB)
+	}
+}
+
+// The finding this whole exercise produced: the per-layer embedding table
+// is held CPU_Mapped, so it is host memory and never counts toward VRAM.
+// The estimate treats it as resident weights whenever the mode is off.
+func TestFlashNextPLETableIsHostMapped(t *testing.T) {
+	r := parseAll(t, flashNextLog)
+	host := r.SumMiB(func(e Entry) bool { return e.Kind == KindModel && !e.OnGPU() }) / gib
+	const pleGiB = 26.82
+	if host < pleGiB {
+		t.Errorf("host-mapped weights %.2f GiB are smaller than the %.2f GiB table; it cannot be held there", host, pleGiB)
+	}
+	// Everything above the table is other weights that also stayed
+	// mapped — evidence that excluding only the table would still be wrong.
+	if excess := host - pleGiB; excess < 0.1 {
+		t.Errorf("host-mapped weights exceed the table by only %.2f GiB; the fixture no longer shows the effect", excess)
+	}
+}
+
+// The parser's GPU total must land close to what the GPU counters read,
+// or it is not measuring the thing the estimate is trying to predict.
+func TestFlashNextGPUTotalMatchesMeasuredVRAM(t *testing.T) {
+	r := parseAll(t, flashNextLog)
+	got := r.GPUMiB(true) / gib
+	const measuredGiB = 107.35 // summed across the four cards while loaded
+	gap := measuredGiB - got
+	if gap < 0 || gap > 3 {
+		t.Errorf("reported GPU total %.2f GiB against %.2f measured (gap %.2f); "+
+			"expected the report to account for all but a couple of GiB of context overhead",
+			got, measuredGiB, gap)
+	}
+}
+
+// Compute buffers are the term the estimate omits entirely, and on this
+// load they are larger than the KV cache by more than five times. Named
+// so a future change that quietly drops them fails loudly.
+func TestFlashNextComputeBuffersDominateTheShortfall(t *testing.T) {
+	r := parseAll(t, flashNextLog)
+	k := r.ByKind()
+	compute, kv := k[KindCompute], k[KindKV]
+	gpuCompute := r.SumMiB(func(e Entry) bool { return e.Kind == KindCompute && e.OnGPU() }) / gib
+	if gpuCompute < 20 {
+		t.Errorf("GPU compute buffers %.2f GiB, expected ~24 — the dominant unmodelled term", gpuCompute)
+	}
+	if compute <= kv {
+		t.Errorf("compute %.2f MiB <= KV %.2f MiB; the fixture no longer shows compute dominating", compute, kv)
+	}
+	// Host-side compute is larger still, which is what the +53 GiB of
+	// host memory seen during a load actually was.
+	hostCompute := r.SumMiB(func(e Entry) bool { return e.Kind == KindCompute && !e.OnGPU() }) / gib
+	if hostCompute < 40 {
+		t.Errorf("host compute buffers %.2f GiB, expected ~51", hostCompute)
+	}
+}
+
+// One reserve round per device here, so the two aggregations agree. If a
+// future capture makes them differ, the ambiguity documented on SumMiB
+// is live again and step 3 has data to settle it.
+func TestFlashNextHasASingleReserveRound(t *testing.T) {
+	r := parseAll(t, flashNextLog)
+	sum := r.SumMiB(func(e Entry) bool { return e.Kind == KindCompute && e.OnGPU() })
+	if max := r.MaxComputeMiB(true); math.Abs(sum-max) > 0.005 {
+		t.Errorf("sum %.2f and peak %.2f disagree; this load reserves once per device", sum, max)
+	}
+}

--- a/internal/memreport/memreport_test.go
+++ b/internal/memreport/memreport_test.go
@@ -283,3 +283,83 @@ func TestFlashNextHasASingleReserveRound(t *testing.T) {
 		t.Errorf("sum %.2f and peak %.2f disagree; this load reserves once per device", sum, max)
 	}
 }
+
+// Qwen3.8-27B at ctx 8192, ub 512, split across four cards in
+// tensor-parallel mode. Every buffer lands on "Meta()", llama.cpp's
+// aggregate device, and the figures are per card. The model file is
+// 29.30 GiB and total VRAM measured 31.43 GiB.
+const tensorParallelLog = `[33359] 0.03.006.881 I load_tensors:   CPU_Mapped model buffer size =  1288.28 MiB
+[33359] 0.03.006.883 I load_tensors:       Meta() model buffer size =  7041.71 MiB
+[33359] 0.17.012.010 I llama_context:  ROCm_Host  output buffer size =     3.79 MiB
+[33359] 0.17.027.641 I llama_kv_cache:     Meta() KV buffer size =   128.00 MiB
+[33359] 0.17.050.759 I llama_memory_recurrent:     Meta() RS buffer size =   149.62 MiB
+[33359] 0.17.102.122 I sched_reserve:     Meta() compute buffer size =   130.02 MiB
+[33359] 0.17.102.129 I sched_reserve:  ROCm_Host compute buffer size =    28.02 MiB`
+
+func TestAggregateDeviceIsRecognised(t *testing.T) {
+	r := parseAll(t, tensorParallelLog)
+	var agg, plain int
+	for _, e := range r.Entries {
+		if e.IsAggregate() {
+			agg++
+		} else {
+			plain++
+		}
+	}
+	if agg != 4 || plain != 3 {
+		t.Errorf("got %d aggregate and %d plain entries, want 4 and 3", agg, plain)
+	}
+	// An aggregate is still device memory, not host.
+	for _, e := range r.Entries {
+		if e.IsAggregate() && !e.OnGPU() {
+			t.Errorf("%s classified as host", e.Device)
+		}
+	}
+}
+
+// Reading per-card figures as totals is the failure this guards against:
+// it under-counts a four-card load to a quarter of the weights.
+func TestScalingAggregatesReconcilesWithFileSize(t *testing.T) {
+	r := parseAll(t, tensorParallelLog)
+	const fileGiB, cards = 29.30, 4
+
+	unscaled := r.SumMiB(func(e Entry) bool { return e.Kind == KindModel }) / gib
+	if unscaled > fileGiB/2 {
+		t.Fatalf("unscaled weights %.2f GiB; fixture no longer shows the under-count", unscaled)
+	}
+
+	scaled := r.ScaleAggregates(cards).SumMiB(func(e Entry) bool { return e.Kind == KindModel }) / gib
+	if math.Abs(scaled-fileGiB) > 1.0 {
+		t.Errorf("scaled weights %.2f GiB, want within 1 GiB of the file's %.2f", scaled, fileGiB)
+	}
+}
+
+// Scaling must leave real per-device entries alone — only the aggregate
+// stands for more than one card.
+func TestScalingLeavesRealDevicesAlone(t *testing.T) {
+	r := parseAll(t, tensorParallelLog).ScaleAggregates(4)
+	host := r.SumMiB(func(e Entry) bool { return !e.OnGPU() })
+	if !close(host, 1288.28+3.79+28.02) {
+		t.Errorf("host total %.2f MiB changed under scaling", host)
+	}
+}
+
+// A report with no aggregate entries — the layer-split case — must be
+// unaffected, so callers can scale unconditionally from their GPU config.
+func TestScalingIsInertWithoutAggregates(t *testing.T) {
+	r := parseAll(t, flashNextLog)
+	before := r.SumMiB(nil)
+	if after := r.ScaleAggregates(4).SumMiB(nil); !close(before, after) {
+		t.Errorf("scaling changed a report with no aggregates: %.2f -> %.2f", before, after)
+	}
+}
+
+func TestScalingByOneOrZeroIsIdentity(t *testing.T) {
+	r := parseAll(t, tensorParallelLog)
+	want := r.SumMiB(nil)
+	for _, n := range []int{0, 1} {
+		if got := r.ScaleAggregates(n).SumMiB(nil); !close(got, want) {
+			t.Errorf("ScaleAggregates(%d) = %.2f, want %.2f", n, got, want)
+		}
+	}
+}

--- a/plan/ple-vram-findings.md
+++ b/plan/ple-vram-findings.md
@@ -1,7 +1,8 @@
 # Per-layer embeddings and the VRAM estimate: measured findings
 
-Status: investigation complete. Steps 1 and 3 of the measurement plan are
-done and step 4 is answered for one model; steps 2, 5 and 6 are open.
+Status: investigation complete. Steps 1 and 3 are done, step 4 is answered
+for two models, step 2 is partly done (two of the corpus, swept by hand);
+steps 5 and 6 are open.
 Date: 2026-08-29.
 Measured on `compute` — llama-toolchest v2.25.1 (plus the PR #157 backfill fix),
 llama.cpp build `b10679-rocm`, 4x AMD Radeon AI PRO R9700 (32 GiB each, gfx1201),
@@ -161,6 +162,48 @@ signs. That is the cancellation, now itemised rather than inferred.
 The 51.04 GiB host-side compute buffer also explains the ~53 GiB of host memory
 that appears during a load. It was read as page cache earlier in this
 investigation; it is a pinned allocation.
+
+## A second model, swept
+
+Qwen3.8-27B (`qwen35`, dense, 29.30 GiB, no PLE table), split tensor-parallel
+across four cards. Context and micro-batch swept independently; every figure
+below is a total after scaling the aggregate device.
+
+| ctx | ubatch | weights | KV | RS | compute | predicted | measured | residual |
+|---|---|---|---|---|---|---|---|---|
+| 8192 | 512 | 27.51 | 0.48 | 0.60 | 0.52 | 29.11 | 31.43 | **2.32** |
+| 32768 | 512 | 27.51 | 2.00 | 0.60 | 0.60 | 30.71 | 33.01 | **2.30** |
+| 131072 | 512 | 27.51 | 8.00 | 0.60 | 0.96 | 37.07 | 39.38 | **2.31** |
+| 262144 | 512 | 27.51 | 16.00 | 0.60 | 1.48 | 45.59 | 47.87 | **2.28** |
+| 32768 | 128 | 27.51 | 2.00 | 0.60 | 0.20 | 30.31 | 32.61 | **2.30** |
+| 32768 | 2048 | 27.51 | 2.00 | 0.60 | 2.40 | 32.51 | 34.82 | **2.31** |
+
+Two results.
+
+**The unreported remainder is a constant.** Across a 31 to 48 GiB range and both
+sweeps it stays within 2.28-2.32 GiB, a spread of 0.04. So the buffer report
+plus a fixed per-context overhead accounts for measured VRAM — there is no
+missing term that scales. That is the shape a corrected estimate should take.
+
+**Both variable terms are linear, in different things.** KV is linear in context
+and independent of micro-batch (0.48 -> 2.00 -> 8.00 -> 16.00 as context
+quadruples, unchanged at 128 vs 2048 ubatch). Compute is linear in micro-batch
+and grows weakly with context (0.20 -> 0.60 -> 2.40 across a 16x ubatch range).
+The current estimate models neither.
+
+Compute buffers are not always small: 1.48 GiB here at 262144 context against
+24.40 GiB on Qwen3.8-Flash-Next at the same context. Whatever sets that scale is
+architectural and is the next thing worth isolating.
+
+### Aggregate devices report per card
+
+A tensor-parallel split puts every buffer on `Meta()`, llama.cpp's stand-in for
+several cards addressed as one, and the sizes reported against it are per card
+rather than totals. The 27B reports 7041.71 MiB of `Meta()` weights on a 29.30
+GiB model; multiplying by the four cards it spans and adding the host-mapped
+remainder reconciles. Reading those figures as totals under-counts by the number
+of cards, which is why `memreport.ScaleAggregates` exists and why the card count
+has to come from the model's GPU assignment — the log never states it.
 
 ## Not recommended: a fourth "system RAM" placement option
 

--- a/plan/ple-vram-findings.md
+++ b/plan/ple-vram-findings.md
@@ -1,7 +1,7 @@
 # Per-layer embeddings and the VRAM estimate: measured findings
 
-Status: investigation complete. Step 1 of the measurement plan is done;
-steps 2-6 are open.
+Status: investigation complete. Steps 1 and 3 of the measurement plan are
+done and step 4 is answered for one model; steps 2, 5 and 6 are open.
 Date: 2026-08-29.
 Measured on `compute` — llama-toolchest v2.25.1 (plus the PR #157 backfill fix),
 llama.cpp build `b10679-rocm`, 4x AMD Radeon AI PRO R9700 (32 GiB each, gfx1201),
@@ -127,6 +127,41 @@ dangerous direction for a control users size their hardware against.
 - **PR #157** (backfill) is unaffected — it fixes delivery of a correctly
   measured value, and that value is confirmed correct above.
 
+## The decomposition, measured
+
+One load of Qwen3.8-Flash-Next at its saved config, verbosity 4, captured
+through `/api/service/logs` and parsed by `internal/memreport`.
+
+| Term | GiB | Where |
+|---|---|---|
+| Model weights | 76.23 | ROCm0-3 |
+| Model weights | 27.45 | `CPU_Mapped` — host, of which 26.82 is the PLE table |
+| KV cache | 4.38 | ROCm0-3 (two caches: 816 and 306 MiB per card) |
+| Recurrent state | 0.44 | ROCm0-3 |
+| Compute buffers | 24.40 | ROCm0-3 |
+| Compute buffers | 51.04 | `ROCm_Host` |
+| Output | 0.004 | `ROCm_Host` |
+
+Weights across all devices total 103.68 GiB against a 103.69 GiB file, so the
+report accounts for the model completely. GPU terms total 105.45 GiB against
+107.35 GiB measured from the GPU counters, leaving 1.90 GiB of context overhead
+the report does not itemise.
+
+Against the estimate:
+
+| | Estimate | Actual | Error |
+|---|---|---|---|
+| Weights | 103.69 | 76.23 | **−27.46** |
+| Everything else | 10.57 | 31.12 | **+20.55** |
+| Total | 114.26 | 107.35 | −6.91 |
+
+The two errors are each roughly four times the net, and they have opposite
+signs. That is the cancellation, now itemised rather than inferred.
+
+The 51.04 GiB host-side compute buffer also explains the ~53 GiB of host memory
+that appears during a load. It was read as page cache earlier in this
+investigation; it is a pinned allocation.
+
 ## Not recommended: a fourth "system RAM" placement option
 
 The option was conceived to free VRAM by moving the table to host memory. The
@@ -175,6 +210,9 @@ compute buffers. Note `CPU_Mapped` appearing for weights on a model with no
 per-layer embedding table at all — more than the PLE table can sit off-GPU, which
 step 4 should account for.
 
+**Step 3 — decompose one load.** Done for Qwen3.8-Flash-Next; see the table
+below. `internal/memreport` parses the report into per-device, per-kind totals.
+
 **Step 2 — build a repeatable harness.** For each (model, context, batch,
 ubatch, kv quant, ngl, ple_mode) point: load, record per-GPU VRAM, host RSS, and
 the per-buffer breakdown. Prerequisite: add `ple_mode` and `extra_flags` as
@@ -188,15 +226,17 @@ this whole investigation to be driven by hand.
 - 3 context sizes each, including one very large (>=128K)
 - both single-GPU and 4-GPU placement
 
-**Step 4 — test three specific hypotheses.**
-- *H1*: the PLE table never counts toward VRAM on any architecture. If it holds,
-  the table should be excluded from the weight term unconditionally, not only
-  when streamed.
-- *H2*: compute buffers scale with ubatch and are not modelled at all today.
-  Suspected to be the bulk of the ~20 GiB shortfall at 262K context.
-- *H3*: the KV model under-predicts for hybrid attention (SWA, linear attention).
-  `kv_full_per_tok` / `kv_swa_per_tok` are captured but the blend may be wrong
-  for `qwen4exp`.
+**Step 4 — test three specific hypotheses.** Answered for Qwen3.8-Flash-Next by
+the decomposition below; still open for every other architecture.
+- *H1 — confirmed.* The table is held `CPU_Mapped`, so it is host memory and
+  never counts toward VRAM. It should be excluded from the weight term
+  unconditionally, not only when streamed. Note the host-mapped weights exceed
+  the table by 0.63 GiB, so excluding exactly the table would still be wrong.
+- *H2 — confirmed, and it is the dominant term.* Compute buffers take 24.40 GiB
+  of VRAM on this load and are not modelled at all.
+- *H3 — disproved here.* The KV cache is 4.38 GiB, comfortably inside the
+  ~10.57 GiB the estimate allows for everything that is not weights. KV is not
+  the problem; compute buffers are.
 
 **Step 5 — validate, with a guardrail.** Accept a revised model only if it
 never under-predicts measured VRAM across the corpus. Over-prediction is a


### PR DESCRIPTION
Steps 3 and 4 of the measurement plan in #159. New `internal/memreport` package, no behaviour change to anything that runs today.

## What it does

Parses the per-buffer report llama.cpp prints while loading (verbosity 4, via the setting added in #162) into per-device, per-kind totals — weights, KV cache, recurrent state, compute, output — classifying each device as accelerator or host. That includes `CPU_Mapped`, which is how llama.cpp reports weights left in the mmap rather than copied to a card.

## What it found

Applied to one Qwen3.8-Flash-Next load at its saved config:

| Term | GiB | Where |
|---|---|---|
| Model weights | 76.23 | ROCm0-3 |
| Model weights | 27.45 | `CPU_Mapped` — host, of which 26.82 is the PLE table |
| KV cache | 4.38 | ROCm0-3 |
| Recurrent state | 0.44 | ROCm0-3 |
| Compute buffers | 24.40 | ROCm0-3 |
| Compute buffers | 51.04 | `ROCm_Host` |

Weights across all devices total 103.68 GiB against a 103.69 GiB file, and GPU terms total 105.45 GiB against 107.35 GiB measured from the counters. Those two independent reconciliations are what say the parser is reading the load correctly.

Against the estimate:

| | Estimate | Actual | Error |
|---|---|---|---|
| Weights | 103.69 | 76.23 | **−27.46** |
| Everything else | 10.57 | 31.12 | **+20.55** |
| Total | 114.26 | 107.35 | −6.91 |

Each error is roughly four times the net and they have opposite signs. The cancellation described in #159 is now itemised rather than inferred.

Three consequences:

- **H1 confirmed** — the PLE table is `CPU_Mapped`, so it never counts toward VRAM. But host-mapped weights exceed it by 0.63 GiB, so excluding *exactly* the table would still be wrong.
- **H2 confirmed and dominant** — compute buffers are 24.40 GiB of VRAM, entirely unmodelled.
- **H3 disproved here** — KV is 4.38 GiB, comfortably inside the ~10.57 GiB the estimate already allows. KV is not the problem.

Also: the 51.04 GiB host-side compute buffer is what the ~53 GiB of host memory during a load actually was. I read that as page cache earlier in the investigation; it's a pinned allocation.

## Deliberately unresolved

Compute-buffer aggregation. llama.cpp reserves more than once on some loads and the log doesn't say whether those coalesce into one buffer or stack. Both readings are offered (`SumMiB` / `MaxComputeMiB`) and the ambiguity is documented on the method rather than guessed. The Flash-Next load reserves once per device so it can't settle it; the Qwen3.8-27B fixture does show repeated reserves, and a test asserts the two readings still differ there so the question stays visible.

## Testing

Two fixtures of verbatim captured output — Qwen3.8-27B and Qwen3.8-Flash-Next — kept exactly as they arrived, SSE prefix and ragged column alignment included. Tests assert the reconciliations above, that the `size = N MiB (cells, layers…)` summary is *not* counted as a buffer (it restates a total and would double KV), device classification across ROCm/CUDA/Vulkan/`Meta()`/host names, and instance separation for interleaved concurrent loads.

Suite green apart from two pre-existing `internal/builder` git-tag failures that reproduce on clean `main`.

## Not done

Steps 2, 5, 6 — the corpus across other architectures, the revised formula, and the UI. Nothing here changes the estimate; one model is not enough to fit one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt54KWjaay1Lzywdnkg3V2