### PR TITLE
fix(models): make the Flash Attention toggle actually turn it off

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -976,6 +976,10 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if err := cfg.ValidateFlashAttention(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if err := s.registry.SetConfig(id, cfg); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/models/flash_attn_test.go
+++ b/internal/models/flash_attn_test.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func renderFA(cfg *ModelConfig) string {
+	m := &Model{ID: "m", Filename: "m.gguf", FilePath: "/models/m.gguf"}
+	return GeneratePresetINI("/models", []*Model{m}, map[string]*ModelConfig{"m": cfg}, "rocm")
+}
+
+// Writing nothing for "off" left llama.cpp on its own default, which is
+// auto — flash attention enabled wherever the backend supports it. So the
+// toggle did nothing in the off direction while every surface in the app
+// reported it as off.
+//
+// Confirmed on hardware: a model saved with flash attention off produced
+// byte-identical compute buffers (378.02 MiB per card) and identical total
+// VRAM (48.09 GiB) to the same model with it on. Passing the flag
+// explicitly changed the load outcome, proving the value does reach
+// llama.cpp once it is actually written.
+func TestFlashAttentionEmittedInBothDirections(t *testing.T) {
+	for _, tt := range []struct {
+		on   bool
+		want string
+	}{
+		{true, "flash-attn = on"},
+		{false, "flash-attn = off"},
+	} {
+		ini := renderFA(&ModelConfig{Enabled: true, ContextSize: 4096, FlashAttention: tt.on})
+		if !strings.Contains(ini, tt.want) {
+			t.Errorf("flash attention %v did not emit %q:\n%s", tt.on, tt.want, ini)
+		}
+	}
+}
+
+// The off case is the regression: assert the opposite value is absent, so
+// a future edit cannot satisfy the test above by emitting both.
+func TestFlashAttentionOffDoesNotEmitOn(t *testing.T) {
+	ini := renderFA(&ModelConfig{Enabled: true, ContextSize: 4096, FlashAttention: false})
+	if strings.Contains(ini, "flash-attn = on") {
+		t.Errorf("off config emitted the on value:\n%s", ini)
+	}
+}
+
+// llama.cpp fails a tensor-split load without flash attention, after
+// reading the weights and with nothing tying the error to the toggle.
+// Rejecting the save is the only place a user can act on it.
+func TestTensorSplitRequiresFlashAttention(t *testing.T) {
+	bad := &ModelConfig{FlashAttention: false, SplitMode: "tensor"}
+	if err := bad.ValidateFlashAttention(); err == nil {
+		t.Error("accepted a combination llama.cpp refuses to load")
+	} else if !strings.Contains(err.Error(), "layer split") {
+		t.Errorf("error does not say what to do instead: %v", err)
+	}
+	for _, ok := range []*ModelConfig{
+		{FlashAttention: true, SplitMode: "tensor"},
+		{FlashAttention: false, SplitMode: "layer"},
+		{FlashAttention: false, SplitMode: ""},
+	} {
+		if err := ok.ValidateFlashAttention(); err != nil {
+			t.Errorf("rejected a valid pair (fa=%v split=%q): %v", ok.FlashAttention, ok.SplitMode, err)
+		}
+	}
+}

--- a/internal/models/preset.go
+++ b/internal/models/preset.go
@@ -140,8 +140,15 @@ func writeConfigParams(b *strings.Builder, cfg *ModelConfig, isEmbedding bool, b
 		b.WriteString("embeddings = true\n")
 	}
 	if !isEmbedding {
+		// Emitted in both directions. Writing nothing for "off" left
+		// llama.cpp on its own default, which is auto — flash attention
+		// enabled wherever the backend supports it. The toggle therefore
+		// did nothing when turned off, while the config, the model info
+		// panel and the capability evaluation all reported it as off.
 		if cfg.FlashAttention {
 			b.WriteString("flash-attn = on\n")
+		} else {
+			b.WriteString("flash-attn = off\n")
 		}
 		if cfg.Jinja {
 			b.WriteString("jinja = true\n")

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -244,6 +244,22 @@ func (c *ModelConfig) ValidateBatchSizes() error {
 	return nil
 }
 
+// ValidateFlashAttention rejects the one combination llama.cpp refuses to
+// load: tensor-split placement without flash attention. It fails there
+// with "SPLIT_MODE_TENSOR requires flash_attn to be enabled", after the
+// weights have been read and with nothing in the UI to connect it back to
+// the toggle that caused it.
+//
+// This became reachable only once the flag was emitted for "off" at all;
+// before that the setting was silently discarded, so the pair could be
+// saved and the model would load with flash attention on regardless.
+func (c *ModelConfig) ValidateFlashAttention() error {
+	if !c.FlashAttention && c.SplitMode == "tensor" {
+		return fmt.Errorf("flash attention cannot be turned off while the GPU assignment splits by tensor — llama.cpp refuses to load that combination; choose a layer split, or leave flash attention on")
+	}
+	return nil
+}
+
 // SamplingOverrides returns a map of non-nil sampling parameters suitable
 // for merging into an OpenAI-compatible request body.
 func (c *ModelConfig) SamplingOverrides() map[string]any {


### PR DESCRIPTION
## The bug

`preset.go` wrote `flash-attn = on` when the toggle was on and **nothing at all** when it was off. Writing nothing leaves llama.cpp on its own default — `auto`, which enables flash attention wherever the backend supports it.

So the toggle did nothing in the off direction, while the saved config, the model info panel and the capability evaluation all reported it as off.

## How it surfaced

While measuring compute buffers for the VRAM estimate work (#159). I disabled flash attention on Qwen3.8-27B expecting the compute buffers to grow, and got **byte-identical** results:

| | compute buffer | total VRAM |
|---|---|---|
| flash attention on | 378.02 MiB/card | 48.09 GiB |
| flash attention off | 378.02 MiB/card | 48.09 GiB |

Passing `--flash-attn off` through Extra Flags instead changed the load outcome immediately, which is what proved the value only reaches llama.cpp once it is actually written.

## A second consequence

`evaluate.MapConfigFlags` already emitted `--flash-attn on|off` explicitly. So a model **scored** with flash attention off was **served** with it on — the evaluation and the serving config disagreed about the thing under test. That is the mislabeled-result failure the benchmark package guards against everywhere else.

## The guard

Emitting the flag in both directions makes one combination reachable that llama.cpp refuses:

```
E llama_init_from_model: SPLIT_MODE_TENSOR requires flash_attn to be enabled
E srv  llama_server: exiting due to model loading error
```

It fails there after reading the weights, with nothing in the UI tying it to the toggle that caused it. Previously unreachable, because the setting was being discarded. The pair is now rejected on save next to the batch-size check, with a message naming the setting to change — same pattern as #135.

Worth noting for review: anyone currently running a tensor split with the toggle showing "off" has been getting flash attention on. After this they will be asked to make that explicit. That is the point, but it is a visible change for those configs.

## Testing

Emission in both directions, plus an assertion that the off case does not emit the on value so a future edit cannot satisfy the first test by writing both. Validation covers the rejected pair and the three valid ones. Suite green apart from two pre-existing `internal/builder` git-tag failures that reproduce on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt54KWjaay1Lzywdnkg3V2