### PR TITLE
fix(models): stop counting recurrent layers in a hybrid's KV cache

### DIFF
--- a/internal/models/gguf.go
+++ b/internal/models/gguf.go
@@ -221,6 +221,11 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 		valLenSWA     int   // attention.value_length_swa
 		slidingWindow int   // attention.sliding_window size
 		swaPattern    []bool
+		// Hybrid models interleave recurrent (linear-attention) layers,
+		// which hold no KV cache at all. Either key identifies them; the
+		// explicit array wins when both are present, matching llama.cpp.
+		fullAttnInterval int    // full_attention_interval
+		recurrentLayers  []bool // attention.recurrent_layers
 	)
 
 	for i := uint64(0); i < kvCount; i++ {
@@ -380,6 +385,18 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 				slidingWindow = v
 				continue
 			}
+		case arch != "" && key == arch+".full_attention_interval":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				fullAttnInterval = v
+				continue
+			}
+		case arch != "" && key == arch+".attention.recurrent_layers":
+			if valueType == ggufTypeArray {
+				for _, x := range readGGUFArrayInts(f) {
+					recurrentLayers = append(recurrentLayers, x != 0)
+				}
+				continue
+			}
 		case arch != "" && key == arch+".attention.sliding_window_pattern":
 			// Per-layer bool array (gemma-3/4): true = local/sliding-window
 			// layer. Other layouts (scalar interval) are left unmodeled, which
@@ -396,7 +413,8 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 		skipGGUFValue(f, valueType)
 	}
 
-	computeKVScaling(meta, headCountKV, kvHeadCounts, keyLen, valLen, keyLenSWA, valLenSWA, slidingWindow, swaPattern)
+	computeKVScaling(meta, headCountKV, kvHeadCounts, keyLen, valLen, keyLenSWA, valLenSWA, slidingWindow, swaPattern,
+		fullAttnInterval, recurrentLayers)
 
 	// The KV loop consumed every key and either read or seek-skipped every
 	// value, so the reader is now sitting on the tensor-info block. A file
@@ -420,11 +438,29 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 	return meta, nil
 }
 
+// isRecurrentLayer reports whether layer il holds recurrent state rather
+// than a KV cache, following llama.cpp's own rule: an explicit
+// attention.recurrent_layers array when the GGUF carries one, otherwise
+// every layer except each full_attention_interval-th.
+//
+// Both are absent on a non-hybrid model, where every layer attends and
+// this returns false throughout — so nothing changes for those.
+func isRecurrentLayer(il, fullAttnInterval int, recurrentLayers []bool) bool {
+	if il < len(recurrentLayers) {
+		return recurrentLayers[il]
+	}
+	if fullAttnInterval > 0 {
+		return (il+1)%fullAttnInterval != 0
+	}
+	return false
+}
+
 // computeKVScaling reduces the raw per-layer attention parameters into the
 // compact KV-cache scaling factors stored on GGUFMeta. Falls back to uniform
 // full attention with head_dim = n_embd/n_head when the richer keys are absent,
 // which reproduces the legacy estimate exactly for non-gemma architectures.
-func computeKVScaling(meta *GGUFMeta, headCountKV int, kvHeadCounts []int, keyLen, valLen, keyLenSWA, valLenSWA, slidingWindow int, swaPattern []bool) {
+func computeKVScaling(meta *GGUFMeta, headCountKV int, kvHeadCounts []int, keyLen, valLen, keyLenSWA, valLenSWA, slidingWindow int, swaPattern []bool,
+	fullAttnInterval int, recurrentLayers []bool) {
 	if meta.NLayers == 0 {
 		return
 	}
@@ -459,6 +495,13 @@ func computeKVScaling(meta *GGUFMeta, headCountKV int, kvHeadCounts []int, keyLe
 
 	full, swa, maxKV := 0, 0, meta.NKVHead
 	for i := 0; i < meta.NLayers; i++ {
+		// A recurrent layer carries linear-attention state instead of a KV
+		// cache, so it contributes nothing here. Counting them made the
+		// estimate for a hybrid too large by the full-attention interval —
+		// four times over on both Qwen hybrids measured.
+		if isRecurrentLayer(i, fullAttnInterval, recurrentLayers) {
+			continue
+		}
 		kv := defaultKV
 		if i < len(kvHeadCounts) {
 			kv = kvHeadCounts[i]

--- a/internal/models/gguf.go
+++ b/internal/models/gguf.go
@@ -76,6 +76,11 @@ type GGUFMeta struct {
 	// models were scanned correctly can be told apart from one whose file
 	// genuinely has no table.
 	PLEChecked bool `json:"ple_checked,omitempty"`
+	// KVRecurrentChecked records that the KV factors were computed by a
+	// parser that knows recurrent layers hold no cache. Records written
+	// before that have plausible non-zero factors which are simply too
+	// large, so "is it zero" cannot tell them apart — only this can.
+	KVRecurrentChecked bool `json:"kv_recurrent_checked,omitempty"`
 
 	// BaseModelRepo is the upstream "org/repo" this quant derives from, per
 	// general.base_model.0.repo_url. Used to locate the base model's
@@ -109,6 +114,7 @@ func (meta *GGUFMeta) ApplyTo(m *Model) {
 	m.SamplingChecked = meta.SamplingChecked
 	m.PLEBytes = meta.PLEBytes
 	m.PLEChecked = meta.PLEChecked
+	m.KVRecurrentChecked = meta.KVRecurrentChecked
 	if meta.BaseModelRepo != "" {
 		m.BaseModelRepo = meta.BaseModelRepo
 	}
@@ -431,6 +437,7 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 	meta.ReasoningChecked = true
 	meta.SamplingChecked = true
 	meta.PLEChecked = true
+	meta.KVRecurrentChecked = true
 	if meta.Reasoning.Toggle == "" {
 		meta.Reasoning.Toggle = ReasoningToggleNone
 	}

--- a/internal/models/hybrid_kv_test.go
+++ b/internal/models/hybrid_kv_test.go
@@ -1,0 +1,85 @@
+package models
+
+import (
+	"math"
+	"testing"
+)
+
+// A hybrid model interleaves recurrent (linear-attention) layers, which
+// hold no KV cache. Counting them made the estimate too large by the
+// full-attention interval — four times over on both Qwen hybrids measured.
+//
+// Both cases below are pinned to hardware. The predicted cache is compared
+// against what llama.cpp actually allocated, read from its own buffer
+// report at verbosity 4 (see plan/ple-vram-findings.md).
+func TestHybridKVExcludesRecurrentLayers(t *testing.T) {
+	tests := []struct {
+		name        string
+		layers      int
+		kvHeads     int
+		headDim     int
+		interval    int
+		ctx         int
+		quant       string
+		measuredGiB float64 // summed across the cards llama.cpp reported
+	}{
+		// Qwen3.8-27B: 65 layers, interval 4, key/value_length 256, f16 cache.
+		// llama.cpp allocated 4.00 GiB per card across 4 cards.
+		{"qwen35 27B", 65, 4, 256, 4, 262144, "", 16.00},
+		// Qwen3.8-Flash-Next: 48 layers, interval 4, q8_0 cache.
+		// 816 MiB per card across 4 cards = 3.19 GiB.
+		{"qwen4exp Flash-Next", 48, 2, 256, 4, 262144, "q8_0", 3.19},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := &GGUFMeta{NLayers: tt.layers, NEmbd: tt.kvHeads * tt.headDim, NHead: tt.kvHeads}
+			computeKVScaling(meta, tt.kvHeads, nil, tt.headDim, tt.headDim, 0, 0, 0, nil, tt.interval, nil)
+
+			m := &Model{NLayers: tt.layers, NEmbd: meta.NEmbd, NKVHead: meta.NKVHead,
+				KVFullPerTok: meta.KVFullPerTok, KVSWAPerTok: meta.KVSWAPerTok}
+			got := m.KVCacheGB(tt.ctx, tt.quant)
+			if math.Abs(got-tt.measuredGiB) > 0.35 {
+				t.Errorf("KV cache = %.2f GiB, llama.cpp allocated %.2f", got, tt.measuredGiB)
+			}
+
+			// And confirm the old behaviour would have been badly wrong,
+			// so this test fails if the exclusion is ever dropped.
+			all := &GGUFMeta{NLayers: tt.layers, NEmbd: meta.NEmbd, NHead: tt.kvHeads}
+			computeKVScaling(all, tt.kvHeads, nil, tt.headDim, tt.headDim, 0, 0, 0, nil, 0, nil)
+			if all.KVFullPerTok <= meta.KVFullPerTok {
+				t.Fatal("counting every layer did not produce a larger cache; the fixture is wrong")
+			}
+			if ratio := float64(all.KVFullPerTok) / float64(meta.KVFullPerTok); math.Abs(ratio-float64(tt.interval)) > 0.3 {
+				t.Errorf("over-count ratio %.2f, want about the interval %d", ratio, tt.interval)
+			}
+		})
+	}
+}
+
+// An explicit array wins over the interval, matching llama.cpp's own
+// precedence.
+func TestRecurrentLayerArrayTakesPrecedence(t *testing.T) {
+	// Interval 4 would make layers 0,1,2 recurrent; the array says otherwise.
+	arr := []bool{false, false, false, true}
+	for il, wantRecr := range arr {
+		if got := isRecurrentLayer(il, 4, arr); got != wantRecr {
+			t.Errorf("layer %d: recurrent = %v, want %v", il, got, wantRecr)
+		}
+	}
+}
+
+// A model with neither key is not hybrid: every layer attends, and the
+// estimate must be exactly what it was before.
+func TestNonHybridUnaffected(t *testing.T) {
+	meta := &GGUFMeta{NLayers: 32, NEmbd: 4096, NHead: 32}
+	computeKVScaling(meta, 8, nil, 128, 128, 0, 0, 0, nil, 0, nil)
+	want := 32 * 8 * (128 + 128)
+	if meta.KVFullPerTok != want {
+		t.Errorf("KVFullPerTok = %d, want %d — a non-hybrid model must be untouched", meta.KVFullPerTok, want)
+	}
+	for il := 0; il < 32; il++ {
+		if isRecurrentLayer(il, 0, nil) {
+			t.Fatalf("layer %d treated as recurrent without either key", il)
+		}
+	}
+}

--- a/internal/models/hybrid_kv_test.go
+++ b/internal/models/hybrid_kv_test.go
@@ -1,9 +1,50 @@
 package models
 
 import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+// writeHybridGGUF builds a minimal GGUF carrying the hparams the KV
+// scaling needs plus full_attention_interval, so the backfill has a real
+// file to re-parse.
+func writeHybridGGUF(t *testing.T, dir, name string, layers, interval, kvHeads, headDim int) string {
+	t.Helper()
+	var b bytes.Buffer
+	wstr := func(s string) {
+		binary.Write(&b, binary.LittleEndian, uint64(len(s)))
+		b.WriteString(s)
+	}
+	kv := func(k string, v uint32) {
+		wstr(k)
+		binary.Write(&b, binary.LittleEndian, ggufTypeUint32)
+		binary.Write(&b, binary.LittleEndian, v)
+	}
+	b.WriteString("GGUF")
+	binary.Write(&b, binary.LittleEndian, uint32(3))
+	binary.Write(&b, binary.LittleEndian, uint64(0)) // no tensors
+	binary.Write(&b, binary.LittleEndian, uint64(8))
+	wstr("general.architecture")
+	binary.Write(&b, binary.LittleEndian, ggufTypeString)
+	wstr("hyb")
+	kv("hyb.block_count", uint32(layers))
+	kv("hyb.embedding_length", uint32(kvHeads*headDim))
+	kv("hyb.attention.head_count", uint32(kvHeads))
+	kv("hyb.attention.head_count_kv", uint32(kvHeads))
+	kv("hyb.attention.key_length", uint32(headDim))
+	kv("hyb.attention.value_length", uint32(headDim))
+	kv("hyb.full_attention_interval", uint32(interval))
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, b.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
 
 // A hybrid model interleaves recurrent (linear-attention) layers, which
 // hold no KV cache. Counting them made the estimate too large by the
@@ -81,5 +122,45 @@ func TestNonHybridUnaffected(t *testing.T) {
 		if isRecurrentLayer(il, 0, nil) {
 			t.Fatalf("layer %d treated as recurrent without either key", il)
 		}
+	}
+}
+
+// The correction is worthless if it cannot reach a model already in the
+// registry, and those records cannot be spotted by their values: the old
+// factors are non-zero and plausible, just too large. Keyed on a flag
+// instead — the same mistake as the per-layer embedding backfill, which
+// went unnoticed because the value it wrote was also merely absent.
+func TestBackfillCorrectsStaleHybridKV(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "config")
+	modelsDir := filepath.Join(dir, "models")
+	for _, d := range []string{cfgDir, modelsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	path := writeHybridGGUF(t, modelsDir, "hybrid.gguf", 8, 4, 2, 256)
+
+	// A record as an older build wrote it: every layer counted.
+	const stale = 8 * 2 * (256 + 256)
+	raw := fmt.Sprintf(`{"models":{"h":{"id":"h","filename":"hybrid.gguf","file_path":%q,`+
+		`"n_layers":8,"n_embd":512,"n_head":2,"kv_full_per_tok":%d}}}`, path, stale)
+	if err := os.WriteFile(filepath.Join(cfgDir, "models.json"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry(dir, modelsDir)
+	r.BackfillGGUFMeta()
+
+	m, err := r.Get("h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.KVRecurrentChecked {
+		t.Error("KVRecurrentChecked not set — the model would be re-parsed at every startup")
+	}
+	// Interval 4 over 8 layers leaves 2 attending.
+	if want := 2 * 2 * (256 + 256); m.KVFullPerTok != want {
+		t.Errorf("KVFullPerTok = %d, want %d (stale value was %d)", m.KVFullPerTok, want, stale)
 	}
 }

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -84,6 +84,12 @@ type Model struct {
 	// and get re-parsed once, which is how an already-downloaded model
 	// picks up its table size without being downloaded again.
 	PLEChecked bool `json:"ple_checked,omitempty"`
+	// KVRecurrentChecked distinguishes KV factors computed before
+	// recurrent layers were excluded from ones computed after. The old
+	// values are non-zero and plausible, just too large by the
+	// full-attention interval, so nothing about the numbers themselves
+	// reveals which parser produced them.
+	KVRecurrentChecked bool `json:"kv_recurrent_checked,omitempty"`
 
 	// Architecture parameters parsed from GGUF header.
 	Arch          string `json:"arch,omitempty"`
@@ -623,6 +629,11 @@ func (r *Registry) BackfillGGUFMeta() {
 		// Records parsed before KV scaling factors existed have layers but no
 		// per-token factors — re-parse once to repopulate them.
 		needsKV := m.NLayers > 0 && m.KVFullPerTok == 0 && m.KVSWAPerTok == 0
+		// A hybrid's factors were over-counted by the full-attention
+		// interval before recurrent layers were excluded. Those records
+		// hold a non-zero, plausible, wrong number, so needsKV above
+		// cannot see them — re-parse once, keyed on the flag.
+		needsKVRecurrent := m.NLayers > 0 && !m.KVRecurrentChecked
 		// Records parsed before reasoning detection existed have no reasoning
 		// verdict — re-parse once to inspect the chat template.
 		needsReasoning := m.NLayers > 0 && !m.ReasoningChecked
@@ -638,7 +649,7 @@ func (r *Registry) BackfillGGUFMeta() {
 		// scanned — re-parse once to find the per-layer embedding table.
 		needsPLE := m.NLayers > 0 && !m.PLEChecked
 
-		if !needsFull && !needsVision && !needsKV && !needsReasoning && !needsSampling && !needsVocab && !needsPLE {
+		if !needsFull && !needsVision && !needsKV && !needsKVRecurrent && !needsReasoning && !needsSampling && !needsVocab && !needsPLE {
 			continue
 		}
 		meta, err := ParseGGUFMeta(m.FilePath)
@@ -698,6 +709,19 @@ func (r *Registry) BackfillGGUFMeta() {
 				if meta.VocabSize > 0 {
 					m.VocabSize = meta.VocabSize
 					slog.Info("backfilled vocab size", "model", m.ID, "vocab", meta.VocabSize)
+				}
+			}
+			if needsKVRecurrent {
+				// Record the question as asked whatever the answer, so a
+				// model that was already correct is not re-parsed forever.
+				m.KVRecurrentChecked = true
+				changed = true
+				if meta.KVFullPerTok != m.KVFullPerTok || meta.KVSWAPerTok != m.KVSWAPerTok {
+					slog.Info("corrected KV scaling for recurrent layers", "model", m.ID,
+						"kv_full_per_tok", meta.KVFullPerTok, "was", m.KVFullPerTok)
+					m.KVFullPerTok = meta.KVFullPerTok
+					m.KVSWAPerTok = meta.KVSWAPerTok
+					m.SlidingWindow = meta.SlidingWindow
 				}
 			}
 			if needsPLE {

--- a/internal/models/vram_test.go
+++ b/internal/models/vram_test.go
@@ -18,7 +18,7 @@ func approx(t *testing.T, label string, got, want, tol float64) {
 // scaling the legacy formula assumes: nLayers · nKVHead · (k_dim+v_dim) per tok.
 func TestComputeKVScalingUniform(t *testing.T) {
 	meta := &GGUFMeta{NLayers: 4, NEmbd: 512, NHead: 8} // headDim = 64
-	computeKVScaling(meta, 2 /*kv*/, nil, 0, 0, 0, 0, 0, nil)
+	computeKVScaling(meta, 2 /*kv*/, nil, 0, 0, 0, 0, 0, nil, 0, nil)
 
 	if want := 4 * 2 * (64 + 64); meta.KVFullPerTok != want {
 		t.Errorf("KVFullPerTok = %d, want %d", meta.KVFullPerTok, want)
@@ -35,7 +35,7 @@ func TestComputeKVScalingUniform(t *testing.T) {
 // when the latter isn't a whole number (e.g. Qwen3.6: 5120/24 = 213.3).
 func TestComputeKVScalingExplicitHeadDim(t *testing.T) {
 	meta := &GGUFMeta{NLayers: 64, NEmbd: 5120, NHead: 24}
-	computeKVScaling(meta, 4 /*kv*/, nil, 256 /*keyLen*/, 256 /*valLen*/, 0, 0, 0, nil)
+	computeKVScaling(meta, 4 /*kv*/, nil, 256 /*keyLen*/, 256 /*valLen*/, 0, 0, 0, nil, 0, nil)
 
 	if want := 64 * 4 * (256 + 256); meta.KVFullPerTok != want {
 		t.Errorf("KVFullPerTok = %d, want %d", meta.KVFullPerTok, want)
@@ -48,7 +48,7 @@ func TestComputeKVScalingGemma(t *testing.T) {
 	meta := &GGUFMeta{NLayers: 6, NEmbd: 3840, NHead: 16}
 	kvHeads := []int{8, 8, 8, 8, 8, 1}
 	swa := []bool{true, true, true, true, true, false}
-	computeKVScaling(meta, 0, kvHeads, 512, 512, 256, 256, 1024, swa)
+	computeKVScaling(meta, 0, kvHeads, 512, 512, 256, 256, 1024, swa, 0, nil)
 
 	// 5 sliding-window layers: 8 kv heads × (256+256)
 	if want := 5 * 8 * (256 + 256); meta.KVSWAPerTok != want {


### PR DESCRIPTION
The largest single error in the VRAM estimate, found while working step 5 of the plan in `plan/ple-vram-findings.md`.

## The bug

A hybrid model interleaves recurrent (linear-attention) layers, which hold **no KV cache at all**. `computeKVScaling` looped over every layer, so a hybrid's cache came out too large by the full-attention interval — four times over on both Qwen hybrids I measured.

| Model | ctx | estimated KV | llama.cpp allocated |
|---|---|---|---|
| Qwen3.8-27B | 262144 | 65.00 GiB | **16.00 GiB** |
| Qwen3.8-Flash-Next | 262144 | 12.75 GiB | **3.19 GiB** |

With recurrent layers excluded, both land exactly on the measured figure.

## How the layers are identified

llama.cpp's own rule, from `qwen4exp.cpp`: an explicit `attention.recurrent_layers` array when the GGUF carries one, otherwise `full_attention_interval` — every layer except each interval-th. Both Qwen models state the interval explicitly:

```
qwen35.full_attention_interval   = 4     (65 layers -> 16 attend)
qwen4exp.full_attention_interval = 4     (48 layers -> 12 attend)
```

Array first, matching llama.cpp's precedence.

**A model with neither key is not hybrid**, so nothing changes for it. That's asserted in a test rather than assumed, since this touches the estimate for every model in the app.

## Verification

Both hybrid cases are pinned to hardware — the predicted cache is compared against what llama.cpp reported allocating at log verbosity 4 (#162), read out of `/api/service/logs`. The tests also assert the old behaviour would have been wrong by about the interval, so they fail if the exclusion is ever dropped rather than silently passing.

## Scope

This is one term. The estimate has other errors — it counts host-mapped weights it shouldn't, and models compute buffers not at all — and I am deliberately not touching those here. They pull in opposite directions, so correcting them separately is how you avoid trading one wrong number for another, and each wants its own evidence. The KV term is the one that now has an exact match on two independent models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt54KWjaay1Lzywdnkg3V2