### PR TITLE
feat(models): estimate VRAM from what llama.cpp actually allocates

### DIFF
--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -396,7 +396,7 @@ func (s *Server) renderModelCard(w http.ResponseWriter, m *models.Model, routerK
 	gpuLabel := ""
 	var aliases []string
 	if cfg, err := s.registry.GetConfig(m.ID); err == nil {
-		vramGB = models.VRAMEstimateForConfig(m, cfg)
+		vramGB = models.VRAMEstimateForConfigOn(m, cfg, models.DeviceCountForConfig(cfg, len(s.monitor.Current().GPU)))
 		enabled = cfg.Enabled
 		if cfg.MmprojPath != "" {
 			hasVision = true

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -129,7 +129,7 @@ func (s *Server) handlePS(w http.ResponseWriter, r *http.Request) {
 					pm.VRAMEstGB = regModel.VRAMEstGB
 					if cfg != nil {
 						pm.ContextSize = cfg.ContextSize
-						pm.VRAMEstGB = models.VRAMEstimateForConfig(regModel, cfg)
+						pm.VRAMEstGB = models.VRAMEstimateForConfigOn(regModel, cfg, models.DeviceCountForConfig(cfg, len(s.monitor.Current().GPU)))
 					}
 				}
 				result = append(result, pm)
@@ -664,7 +664,7 @@ func (s *Server) handleModelVRAMEstimate(w http.ResponseWriter, r *http.Request)
 	cfg.ContextSize = contextSize
 	cfg.KVCacheQuant = kvCacheQuant
 
-	total := models.VRAMEstimateForConfig(model, cfg)
+	total := models.VRAMEstimateForConfigOn(model, cfg, models.DeviceCountForConfig(cfg, len(s.monitor.Current().GPU)))
 	kvGB := model.KVCacheGB(contextSize, kvCacheQuant)
 	weightsGB := models.BytesToGiB(model.SizeBytes)
 	extraGB := models.AuxFilesVRAMGB(cfg)
@@ -732,7 +732,7 @@ func (s *Server) handleGetModelConfig(w http.ResponseWriter, r *http.Request) {
 		// Mark disabled/recommended options
 		if numGPUs > 0 && model != nil {
 			perGPUGB := float64(metrics.GPU[0].VRAMTotalMB) / 1024.0
-			modelVRAM := models.VRAMEstimateForConfig(model, cfg)
+			modelVRAM := models.VRAMEstimateForConfigOn(model, cfg, models.DeviceCountForConfig(cfg, len(s.monitor.Current().GPU)))
 			allModels := s.registry.List()
 			allConfigs := make(map[string]*models.ModelConfig)
 			for _, m := range allModels {
@@ -1000,7 +1000,7 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 	// Update VRAM estimate in model list
 	if isHTMX(r) {
 		if model, err := s.registry.Get(id); err == nil {
-			vramGB := models.VRAMEstimateForConfig(model, cfg)
+			vramGB := models.VRAMEstimateForConfigOn(model, cfg, models.DeviceCountForConfig(cfg, len(s.monitor.Current().GPU)))
 			w.Header().Set("HX-Trigger", fmt.Sprintf(
 				`{"vramUpdated":{"id":%q,"vram":"%.1f GiB"},"gpuMapChanged":true}`,
 				id, vramGB))

--- a/internal/models/gguf.go
+++ b/internal/models/gguf.go
@@ -90,11 +90,6 @@ type GGUFMeta struct {
 	// NLayers on a plain model; smaller on a hybrid, where the rest carry
 	// recurrent state.
 	AttnLayers int `json:"attn_layers,omitempty"`
-	// KVRecurrentChecked records that the KV factors were computed by a
-	// parser that knows recurrent layers hold no cache. Records written
-	// before that have plausible non-zero factors which are simply too
-	// large, so "is it zero" cannot tell them apart — only this can.
-	KVRecurrentChecked bool `json:"kv_recurrent_checked,omitempty"`
 
 	// BaseModelRepo is the upstream "org/repo" this quant derives from, per
 	// general.base_model.0.repo_url. Used to locate the base model's
@@ -128,7 +123,6 @@ func (meta *GGUFMeta) ApplyTo(m *Model) {
 	m.SamplingChecked = meta.SamplingChecked
 	m.PLEBytes = meta.PLEBytes
 	m.PLEChecked = meta.PLEChecked
-	m.KVRecurrentChecked = meta.KVRecurrentChecked
 	m.TokenEmbdBytes = meta.TokenEmbdBytes
 	m.IndexerKeyLength = meta.IndexerKeyLength
 	m.AttnLayers = meta.AttnLayers
@@ -465,7 +459,6 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 	meta.ReasoningChecked = true
 	meta.SamplingChecked = true
 	meta.PLEChecked = true
-	meta.KVRecurrentChecked = true
 	if meta.Reasoning.Toggle == "" {
 		meta.Reasoning.Toggle = ReasoningToggleNone
 	}

--- a/internal/models/gguf.go
+++ b/internal/models/gguf.go
@@ -76,6 +76,20 @@ type GGUFMeta struct {
 	// models were scanned correctly can be told apart from one whose file
 	// genuinely has no table.
 	PLEChecked bool `json:"ple_checked,omitempty"`
+	// TokenEmbdBytes is the on-disk size of token_embd.weight, which
+	// llama.cpp holds host-mapped rather than on a device. Measured from
+	// the tensor block for the same reason as PLEBytes: publishers quantize
+	// it independently of the body.
+	TokenEmbdBytes int64 `json:"token_embd_bytes,omitempty"`
+	// IndexerKeyLength is attention.indexer.key_length, present only on
+	// sparse-attention architectures. Non-zero means the model ranks the
+	// whole cache before attending, which costs both a key cache of its
+	// own and graph scratch proportional to context x micro-batch.
+	IndexerKeyLength int `json:"indexer_key_length,omitempty"`
+	// AttnLayers counts the layers that actually hold a KV cache. Equal to
+	// NLayers on a plain model; smaller on a hybrid, where the rest carry
+	// recurrent state.
+	AttnLayers int `json:"attn_layers,omitempty"`
 	// KVRecurrentChecked records that the KV factors were computed by a
 	// parser that knows recurrent layers hold no cache. Records written
 	// before that have plausible non-zero factors which are simply too
@@ -115,6 +129,9 @@ func (meta *GGUFMeta) ApplyTo(m *Model) {
 	m.PLEBytes = meta.PLEBytes
 	m.PLEChecked = meta.PLEChecked
 	m.KVRecurrentChecked = meta.KVRecurrentChecked
+	m.TokenEmbdBytes = meta.TokenEmbdBytes
+	m.IndexerKeyLength = meta.IndexerKeyLength
+	m.AttnLayers = meta.AttnLayers
 	if meta.BaseModelRepo != "" {
 		m.BaseModelRepo = meta.BaseModelRepo
 	}
@@ -170,8 +187,14 @@ func ParseGGUFMeta(path string) (*GGUFMeta, error) {
 	}
 	// A split model keeps its tensor table in a later shard; see
 	// scanShardsForPLE.
-	if meta.PLEBytes == 0 {
-		meta.PLEBytes = scanShardsForPLE(path)
+	if meta.PLEBytes == 0 || meta.TokenEmbdBytes == 0 {
+		ple, emb := scanShardsForTensors(path)
+		if meta.PLEBytes == 0 {
+			meta.PLEBytes = ple
+		}
+		if meta.TokenEmbdBytes == 0 {
+			meta.TokenEmbdBytes = emb
+		}
 	}
 	return meta, nil
 }
@@ -391,6 +414,11 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 				slidingWindow = v
 				continue
 			}
+		case arch != "" && key == arch+".attention.indexer.key_length":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				meta.IndexerKeyLength = v
+				continue
+			}
 		case arch != "" && key == arch+".full_attention_interval":
 			if v, ok := readGGUFScalarInt(f, valueType); ok {
 				fullAttnInterval = v
@@ -427,7 +455,7 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 	// truncated mid-header, or one whose tensor section we can't make sense
 	// of, leaves PLEBytes at zero — the metadata gathered above is still
 	// good, so a failure here must not fail the parse.
-	meta.PLEBytes = scanPLETensorBytes(f, tensorCount, alignment)
+	meta.PLEBytes, meta.TokenEmbdBytes = scanPLETensorBytes(f, tensorCount, alignment)
 
 	// A successful parse means reasoning was evaluated even if no chat template
 	// was present — in which case Reasoning stays the unsupported zero value.
@@ -509,6 +537,7 @@ func computeKVScaling(meta *GGUFMeta, headCountKV int, kvHeadCounts []int, keyLe
 		if isRecurrentLayer(i, fullAttnInterval, recurrentLayers) {
 			continue
 		}
+		meta.AttnLayers++
 		kv := defaultKV
 		if i < len(kvHeadCounts) {
 			kv = kvHeadCounts[i]
@@ -755,6 +784,15 @@ func skipGGUFValue(r io.ReadSeeker, valueType uint32) {
 // need editing every time.
 const pleTensorName = "per_layer_token_embd.weight"
 
+// tokenEmbdTensorName is the input embedding table. llama.cpp leaves it
+// host-mapped rather than copying it to a device — measured on every
+// model in the corpus, including ones with no per-layer table at all — so
+// a VRAM estimate must not count it either. Its size is read from the
+// tensor block rather than computed from vocab x n_embd, because
+// publishers routinely quantize it differently from the body: both UD
+// quants measured keep it at Q8_0 inside a Q4 model.
+const tokenEmbdTensorName = "token_embd.weight"
+
 // scanPLETensorBytes reads the tensor-info block and returns the size in
 // bytes of the PLE table, or 0 if the file has no such tensor or the block
 // can't be read. The reader must be positioned at the start of the block,
@@ -767,72 +805,82 @@ const pleTensorName = "per_layer_token_embd.weight"
 // there is a steady supply of new ones. The cost is that a computed size
 // includes any alignment padding that follows the tensor, at most
 // alignment-1 bytes against a table measured in gigabytes.
-func scanPLETensorBytes(f io.ReadSeeker, tensorCount uint64, alignment int64) int64 {
+func scanPLETensorBytes(f io.ReadSeeker, tensorCount uint64, alignment int64) (pleBytes, embBytes int64) {
 	// A malformed count would otherwise have us loop for a very long time
 	// on a file that isn't going to yield anything.
 	const maxTensors = 1 << 20
 	if tensorCount == 0 || tensorCount > maxTensors || alignment <= 0 {
-		return 0
+		return 0, 0
 	}
 
 	var pleOffset int64 = -1
+	var embOffset int64 = -1
 	offsets := make([]int64, 0, tensorCount)
 
 	for i := uint64(0); i < tensorCount; i++ {
 		name, err := readGGUFString(f)
 		if err != nil {
-			return 0
+			return 0, 0
 		}
 		nDims, err := readUint32(f)
 		if err != nil || nDims > 4 {
-			return 0
+			return 0, 0
 		}
 		// Dimensions are read past; the offsets alone give us the size.
 		if _, err := f.Seek(int64(nDims)*8, io.SeekCurrent); err != nil {
-			return 0
+			return 0, 0
 		}
 		if _, err := readUint32(f); err != nil { // ggml type
-			return 0
+			return 0, 0
 		}
 		var offset uint64
 		if err := binary.Read(f, binary.LittleEndian, &offset); err != nil {
-			return 0
+			return 0, 0
 		}
 		offsets = append(offsets, int64(offset))
 		if name == pleTensorName {
 			pleOffset = int64(offset)
 		}
+		if name == tokenEmbdTensorName {
+			embOffset = int64(offset)
+		}
 	}
-	if pleOffset < 0 {
-		return 0
+	if pleOffset < 0 && embOffset < 0 {
+		return 0, 0
 	}
 
 	// The data region starts after the tensor-info block, padded up to the
 	// alignment; every offset above is relative to that point.
 	infoEnd, err := f.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return 0
+		return 0, 0
 	}
 	dataStart := ((infoEnd + alignment - 1) / alignment) * alignment
 	fileSize, err := f.Seek(0, io.SeekEnd)
 	if err != nil || fileSize <= dataStart {
-		return 0
+		return 0, 0
 	}
 
-	// The next offset after this tensor's bounds it. Scanning for the
-	// smallest offset greater than ours avoids assuming the tensors were
-	// written in offset order. When nothing follows, the tensor runs to the
-	// end of the file.
-	next := fileSize - dataStart
-	for _, off := range offsets {
-		if off > pleOffset && off < next {
-			next = off
+	// The next offset after a tensor bounds it. Scanning for the smallest
+	// offset greater than ours avoids assuming the tensors were written in
+	// offset order. When nothing follows, the tensor runs to the end of
+	// the file.
+	sizeAt := func(off int64) int64 {
+		if off < 0 {
+			return 0
 		}
+		next := fileSize - dataStart
+		for _, o := range offsets {
+			if o > off && o < next {
+				next = o
+			}
+		}
+		if next <= off {
+			return 0
+		}
+		return next - off
 	}
-	if next <= pleOffset {
-		return 0
-	}
-	return next - pleOffset
+	return sizeAt(pleOffset), sizeAt(embOffset)
 }
 
 // ggufShardPattern matches a split GGUF filename like
@@ -870,11 +918,11 @@ func ExpandShards(filename string) []string {
 //
 // Returns 0 for an unsplit file, for siblings that aren't on disk (a
 // partial download), or when no shard carries the table.
-func scanShardsForPLE(path string) int64 {
+func scanShardsForTensors(path string) (pleBytes, embBytes int64) {
 	dir, name := filepath.Split(path)
 	shards := ExpandShards(name)
 	if len(shards) < 2 {
-		return 0
+		return 0, 0
 	}
 	for _, sh := range shards {
 		if sh == name {
@@ -886,9 +934,18 @@ func scanShardsForPLE(path string) int64 {
 		}
 		meta, err := ParseGGUFMetaFrom(f)
 		f.Close()
-		if err == nil && meta.PLEBytes > 0 {
-			return meta.PLEBytes
+		if err != nil {
+			continue
+		}
+		if pleBytes == 0 {
+			pleBytes = meta.PLEBytes
+		}
+		if embBytes == 0 {
+			embBytes = meta.TokenEmbdBytes
+		}
+		if pleBytes > 0 && embBytes > 0 {
+			break
 		}
 	}
-	return 0
+	return pleBytes, embBytes
 }

--- a/internal/models/gpu_assign.go
+++ b/internal/models/gpu_assign.go
@@ -382,6 +382,45 @@ func tensorAssignGPUs(assign string, numGPUs int) ([]int, bool) {
 	return nil, false
 }
 
+// DeviceCountForConfig returns how many devices a config actually spreads
+// the model over, which the VRAM estimate needs because graph scratch and
+// driver overhead are charged per device rather than per model.
+//
+// numGPUs is what the host has; pass 0 when it is unknown, and an
+// assignment that means "all of them" then resolves to one. That
+// under-counts rather than over-counts, so a caller without the hardware
+// figure gets an estimate that is too low — which is why the callers that
+// can supply it do.
+func DeviceCountForConfig(cfg *ModelConfig, numGPUs int) int {
+	if cfg == nil {
+		return max(1, numGPUs)
+	}
+	// An explicit split names its devices: the entries that get a non-zero
+	// share are the ones holding anything.
+	if ts := strings.TrimSpace(cfg.TensorSplit); ts != "" {
+		n := 0
+		for _, part := range strings.Split(ts, ",") {
+			if v, err := strconv.ParseFloat(strings.TrimSpace(part), 64); err == nil && v > 0 {
+				n++
+			}
+		}
+		if n > 0 {
+			return n
+		}
+	}
+	switch {
+	case strings.HasPrefix(cfg.GPUAssign, "tensor"):
+		if gpus, ok := tensorAssignGPUs(cfg.GPUAssign, max(1, numGPUs)); ok && len(gpus) > 0 {
+			return len(gpus)
+		}
+	case cfg.GPUAssign != "" && cfg.GPUAssign != "all" && cfg.GPUAssign != "custom":
+		if gpus := parseIntList(cfg.GPUAssign); len(gpus) > 0 {
+			return len(gpus)
+		}
+	}
+	return max(1, numGPUs)
+}
+
 // AssignGPUsOutOfRange reports whether a GPU assignment references GPU
 // indices this machine doesn't have. Used by the backup restore engine
 // to detect configs imported from a box with more GPUs.

--- a/internal/models/hybrid_kv_test.go
+++ b/internal/models/hybrid_kv_test.go
@@ -156,8 +156,8 @@ func TestBackfillCorrectsStaleHybridKV(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !m.KVRecurrentChecked {
-		t.Error("KVRecurrentChecked not set — the model would be re-parsed at every startup")
+	if m.GGUFMetaVersion != GGUFMetaVersion {
+		t.Error("version not recorded — the model would be re-parsed at every startup")
 	}
 	// Interval 4 over 8 layers leaves 2 attending.
 	if want := 2 * 2 * (256 + 256); m.KVFullPerTok != want {

--- a/internal/models/meta_version_test.go
+++ b/internal/models/meta_version_test.go
@@ -1,0 +1,143 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The failure this design exists to prevent: a record holding a value that
+// is present, plausible and wrong. Every per-field trigger it replaced
+// asked "does this look unset?", which cannot see such a record — and
+// twice did not, shipping a fix that changed nothing on disk.
+func TestVersionReReadsPlausibleButWrongValues(t *testing.T) {
+	dir, modelsDir := t.TempDir(), ""
+	cfgDir := filepath.Join(dir, "config")
+	modelsDir = filepath.Join(dir, "models")
+	for _, d := range []string{cfgDir, modelsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	path := writeHybridGGUF(t, modelsDir, "hybrid.gguf", 8, 4, 2, 256)
+
+	// Nothing here is zero or empty. Under the old triggers every one of
+	// these fields looked already-populated, so none of them was re-read.
+	const wrongKV = 8 * 2 * (256 + 256) // every layer counted
+	raw := fmt.Sprintf(`{"models":{"h":{"id":"h","filename":"hybrid.gguf","file_path":%q,`+
+		`"n_layers":8,"n_embd":512,"n_head":2,"n_kv_head":2,"kv_full_per_tok":%d,`+
+		`"vocab_checked":true,"ple_checked":true,"reasoning_checked":true,"sampling_checked":true}}}`,
+		path, wrongKV)
+	if err := os.WriteFile(filepath.Join(cfgDir, "models.json"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry(dir, modelsDir)
+	r.BackfillGGUFMeta()
+
+	m, err := r.Get("h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 2 * 2 * (256 + 256); m.KVFullPerTok != want {
+		t.Errorf("KVFullPerTok = %d, want %d — the stale value survived", m.KVFullPerTok, want)
+	}
+	if m.GGUFMetaVersion != GGUFMetaVersion {
+		t.Errorf("version = %d, want %d", m.GGUFMetaVersion, GGUFMetaVersion)
+	}
+	if m.AttnLayers != 2 {
+		t.Errorf("AttnLayers = %d, want 2 — a field added with this version was not filled", m.AttnLayers)
+	}
+}
+
+// Re-reading must happen once, not at every startup. The old vision
+// trigger asked whether a model lacked vision, so every model without it
+// was re-parsed forever — and for a split model that reopens every shard.
+func TestVersionStopsReReadingOnceCurrent(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir, modelsDir := filepath.Join(dir, "config"), filepath.Join(dir, "models")
+	for _, d := range []string{cfgDir, modelsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	path := writeHybridGGUF(t, modelsDir, "m.gguf", 8, 4, 2, 256)
+	raw := fmt.Sprintf(`{"models":{"m":{"id":"m","filename":"m.gguf","file_path":%q,"n_layers":8}}}`, path)
+	if err := os.WriteFile(filepath.Join(cfgDir, "models.json"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry(dir, modelsDir)
+	r.BackfillGGUFMeta()
+
+	// Remove the file. A second pass that still wanted to re-read would
+	// fail to parse and log; one that is satisfied never opens it.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	r.BackfillGGUFMeta()
+
+	m, _ := r.Get("m")
+	if m.NLayers == 0 {
+		t.Error("the second pass re-read and clobbered the record")
+	}
+	if m.GGUFMetaVersion != GGUFMetaVersion {
+		t.Errorf("version = %d, want %d", m.GGUFMetaVersion, GGUFMetaVersion)
+	}
+}
+
+// An unreadable file must not be versioned: an unmounted volume or a
+// download still moving into place should be re-read next start, not
+// frozen at whatever an older parser wrote.
+func TestUnreadableFileIsNotVersioned(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"models":{"gone":{"id":"gone","filename":"gone.gguf","file_path":"/nonexistent/gone.gguf","n_layers":8}}}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "models.json"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := NewRegistry(dir, filepath.Join(dir, "models"))
+	r.BackfillGGUFMeta()
+	m, _ := r.Get("gone")
+	if m.GGUFMetaVersion != 0 {
+		t.Errorf("version = %d, want 0 so the record is retried when the file returns", m.GGUFMetaVersion)
+	}
+}
+
+// The version must persist, or every startup re-reads every model.
+func TestVersionPersists(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir, modelsDir := filepath.Join(dir, "config"), filepath.Join(dir, "models")
+	for _, d := range []string{cfgDir, modelsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	path := writeHybridGGUF(t, modelsDir, "m.gguf", 8, 4, 2, 256)
+	raw := fmt.Sprintf(`{"models":{"m":{"id":"m","filename":"m.gguf","file_path":%q,"n_layers":8}}}`, path)
+	if err := os.WriteFile(filepath.Join(cfgDir, "models.json"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	NewRegistry(dir, modelsDir).BackfillGGUFMeta()
+
+	b, err := os.ReadFile(filepath.Join(cfgDir, "models.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved struct {
+		Models map[string]struct {
+			V int `json:"gguf_meta_version"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(b, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.Models["m"].V != GGUFMetaVersion {
+		t.Errorf("persisted version %d, want %d", saved.Models["m"].V, GGUFMetaVersion)
+	}
+}

--- a/internal/models/ple_config_test.go
+++ b/internal/models/ple_config_test.go
@@ -35,49 +35,52 @@ func TestPLEModeEmitsTensorReadLazy(t *testing.T) {
 
 const testPLEBytes = 30 * 1024 * 1024 * 1024 // 30 GiB, comfortably over the auto threshold
 
-// A streamed table is never resident, so it must not be counted toward the
-// VRAM estimate — the bug this fixes had a 30 GiB table inflating the
-// estimate past every consumer GPU.
-func TestVRAMExcludesStreamedPLETable(t *testing.T) {
-	// 40 GiB file, 30 GiB of which is the PLE table.
+// The table is never on a device, whatever the mode. Measured on four
+// architectures: llama.cpp reports it under CPU_Mapped, and total VRAM is
+// identical with the mode on, off and auto — see plan/ple-vram-findings.md.
+//
+// This replaces a pair of tests asserting the opposite. They encoded the
+// belief the feature was built on: that "resident" meant resident in VRAM
+// and streaming saved GPU memory. Hardware says streaming saves host
+// memory and changes VRAM by nothing.
+func TestPLEModeDoesNotChangeVRAM(t *testing.T) {
 	m := &Model{
 		SizeBytes: 40 * 1024 * 1024 * 1024,
 		PLEBytes:  testPLEBytes,
-		NLayers:   48, NEmbd: 4096, NHead: 32, NKVHead: 8, ContextLength: 4096,
+		NLayers:   48, AttnLayers: 48, NEmbd: 4096, NHead: 32, NKVHead: 8,
+		KVFullPerTok: 48 * 8 * 256, ContextLength: 4096,
 	}
-	base := func(mode string, directIO bool) float64 {
+	est := func(mode string, directIO bool) float64 {
 		return VRAMEstimateForConfig(m, &ModelConfig{ContextSize: 4096, PLEMode: mode, DirectIO: directIO})
 	}
-
-	auto, on, off := base("", false), base("on", false), base("off", false)
-	if auto != on {
-		t.Errorf("auto (%.2f) should match on (%.2f) for a table over 4 GiB", auto, on)
+	want := est("", false)
+	for _, mode := range []string{"on", "off"} {
+		if got := est(mode, false); got != want {
+			t.Errorf("mode %q gave %.4f, want %.4f — the table is host-mapped in every mode", mode, got, want)
+		}
 	}
-	if got := off - on; got < 29 || got > 31 {
-		t.Errorf("off minus on = %.2f GiB, want ~30 (the table)", got)
-	}
-	// Streaming needs mmap, so direct I/O has to count the table again.
-	if dio := base("", true); dio != off {
-		t.Errorf("direct I/O estimate %.2f should match resident %.2f", dio, off)
+	// Direct I/O changes how the file is read, not where the table lives.
+	if got := est("", true); got != want {
+		t.Errorf("direct I/O gave %.4f, want %.4f", got, want)
 	}
 }
 
-// Under auto, llama.cpp keeps tables below 4 GiB resident, so a small one
-// must still be counted.
-func TestVRAMCountsSmallPLETableUnderAuto(t *testing.T) {
-	m := &Model{
+// And it is excluded from the estimate at every size. The old code only
+// excluded tables over 4 GiB, mirroring llama.cpp's streaming threshold —
+// but that threshold governs host residency, which was never the question.
+func TestSmallPLETableAlsoExcluded(t *testing.T) {
+	base := Model{
 		SizeBytes: 8 * 1024 * 1024 * 1024,
-		PLEBytes:  2 * 1024 * 1024 * 1024, // under the 4 GiB threshold
-		NLayers:   32, NEmbd: 2048, NHead: 16, NKVHead: 4, ContextLength: 4096,
+		NLayers:   32, AttnLayers: 32, NEmbd: 2048, NHead: 16, NKVHead: 4,
+		KVFullPerTok: 32 * 4 * 128, ContextLength: 4096,
 	}
-	auto := VRAMEstimateForConfig(m, &ModelConfig{ContextSize: 4096})
-	off := VRAMEstimateForConfig(m, &ModelConfig{ContextSize: 4096, PLEMode: "off"})
-	if auto != off {
-		t.Errorf("auto (%.2f) should match off (%.2f) below the 4 GiB threshold", auto, off)
-	}
-	// ...but an explicit "on" streams it regardless of size.
-	if on := VRAMEstimateForConfig(m, &ModelConfig{ContextSize: 4096, PLEMode: "on"}); on >= auto {
-		t.Errorf("explicit on (%.2f) should be below auto (%.2f)", on, auto)
+	withTable := base
+	withTable.PLEBytes = 2 * 1024 * 1024 * 1024 // well under the 4 GiB threshold
+	cfg := &ModelConfig{ContextSize: 4096}
+
+	diff := VRAMEstimateForConfig(&base, cfg) - VRAMEstimateForConfig(&withTable, cfg)
+	if diff < 1.9 || diff > 2.1 {
+		t.Errorf("a 2 GiB table changed the estimate by %.2f GiB, want the whole 2", diff)
 	}
 }
 

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -90,6 +90,12 @@ type Model struct {
 	// full-attention interval, so nothing about the numbers themselves
 	// reveals which parser produced them.
 	KVRecurrentChecked bool `json:"kv_recurrent_checked,omitempty"`
+	// TokenEmbdBytes, IndexerKeyLength and AttnLayers feed the VRAM
+	// estimate; see GGUFMeta for what each means. All three are filled by
+	// the same re-parse that sets KVRecurrentChecked.
+	TokenEmbdBytes   int64 `json:"token_embd_bytes,omitempty"`
+	IndexerKeyLength int   `json:"indexer_key_length,omitempty"`
+	AttnLayers       int   `json:"attn_layers,omitempty"`
 
 	// Architecture parameters parsed from GGUF header.
 	Arch          string `json:"arch,omitempty"`
@@ -716,6 +722,9 @@ func (r *Registry) BackfillGGUFMeta() {
 				// model that was already correct is not re-parsed forever.
 				m.KVRecurrentChecked = true
 				changed = true
+				m.TokenEmbdBytes = meta.TokenEmbdBytes
+				m.IndexerKeyLength = meta.IndexerKeyLength
+				m.AttnLayers = meta.AttnLayers
 				if meta.KVFullPerTok != m.KVFullPerTok || meta.KVSWAPerTok != m.KVSWAPerTok {
 					slog.Info("corrected KV scaling for recurrent layers", "model", m.ID,
 						"kv_full_per_tok", meta.KVFullPerTok, "was", m.KVFullPerTok)

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -84,15 +84,12 @@ type Model struct {
 	// and get re-parsed once, which is how an already-downloaded model
 	// picks up its table size without being downloaded again.
 	PLEChecked bool `json:"ple_checked,omitempty"`
-	// KVRecurrentChecked distinguishes KV factors computed before
-	// recurrent layers were excluded from ones computed after. The old
-	// values are non-zero and plausible, just too large by the
-	// full-attention interval, so nothing about the numbers themselves
-	// reveals which parser produced them.
-	KVRecurrentChecked bool `json:"kv_recurrent_checked,omitempty"`
+	// GGUFMetaVersion is the parser generation this record's metadata came
+	// from. Below the current one means re-read; see GGUFMetaVersion.
+	GGUFMetaVersion int `json:"gguf_meta_version,omitempty"`
 	// TokenEmbdBytes, IndexerKeyLength and AttnLayers feed the VRAM
 	// estimate; see GGUFMeta for what each means. All three are filled by
-	// the same re-parse that sets KVRecurrentChecked.
+	// the same re-read that raises GGUFMetaVersion.
 	TokenEmbdBytes   int64 `json:"token_embd_bytes,omitempty"`
 	IndexerKeyLength int   `json:"indexer_key_length,omitempty"`
 	AttnLayers       int   `json:"attn_layers,omitempty"`
@@ -622,130 +619,59 @@ func (r *Registry) ListNeedingPresetFetch() []string {
 	return ids
 }
 
-// BackfillGGUFMeta parses GGUF metadata for any models missing architecture
-// info. Called at startup to handle models downloaded before GGUF parsing existed.
+// GGUFMetaVersion is the parser generation a record's metadata came from.
+// Bump it whenever the parser learns something existing records need a
+// re-read to gain — a new field, or a correction to one already stored.
+//
+// This replaced a set of per-field triggers that each asked whether some
+// value looked unset. That worked only when a missing value was
+// distinguishable from a wrong one, and twice it was not: the per-layer
+// embedding size was written by a path that silently dropped it, and a
+// hybrid's KV factors were non-zero, plausible and four times too large.
+// Both shipped, deployed, and changed nothing for models already on disk.
+// A version is not fooled by a value that looks reasonable.
+//
+// Version history, so a bump is a deliberate act:
+//
+//	1 — recurrent layers excluded from KV scaling; token-embedding size,
+//	    indexer key length and attention-layer count added for the VRAM
+//	    estimate.
+const GGUFMetaVersion = 1
+
+// BackfillGGUFMeta re-reads GGUF metadata for records written by an older
+// parser, in one pass at startup.
+//
+// Every field is applied through ApplyTo rather than field by field. The
+// old shape had a block per field, and a field whose block was forgotten
+// was parsed, discarded, and never noticed — which is exactly how the
+// per-layer embedding table went missing for every downloaded model. There
+// is now no per-field step to forget.
 func (r *Registry) BackfillGGUFMeta() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	changed := false
 	for _, m := range r.data.Models {
-		needsFull := m.NLayers == 0
-		needsVision := m.NLayers > 0 && !m.HasBuiltinVision // re-check for vision field
-		// Records parsed before KV scaling factors existed have layers but no
-		// per-token factors — re-parse once to repopulate them.
-		needsKV := m.NLayers > 0 && m.KVFullPerTok == 0 && m.KVSWAPerTok == 0
-		// A hybrid's factors were over-counted by the full-attention
-		// interval before recurrent layers were excluded. Those records
-		// hold a non-zero, plausible, wrong number, so needsKV above
-		// cannot see them — re-parse once, keyed on the flag.
-		needsKVRecurrent := m.NLayers > 0 && !m.KVRecurrentChecked
-		// Records parsed before reasoning detection existed have no reasoning
-		// verdict — re-parse once to inspect the chat template.
-		needsReasoning := m.NLayers > 0 && !m.ReasoningChecked
-		// Records parsed before general.sampling.* keys were read — re-parse
-		// once to pick up embedded sampling defaults and the base-model repo.
-		needsSampling := m.NLayers > 0 && !m.SamplingChecked
-		// Records parsed before vocab-size capture existed — re-parse once
-		// to pick up tokenizer.ggml.tokens' length. Keyed on VocabChecked,
-		// not on VocabSize == 0, so a file that simply has no such key is
-		// asked once rather than at every startup.
-		needsVocab := m.NLayers > 0 && !m.VocabChecked
-		// Records parsed before a split model's later shards were
-		// scanned — re-parse once to find the per-layer embedding table.
-		needsPLE := m.NLayers > 0 && !m.PLEChecked
-
-		if !needsFull && !needsVision && !needsKV && !needsKVRecurrent && !needsReasoning && !needsSampling && !needsVocab && !needsPLE {
+		if m.GGUFMetaVersion >= GGUFMetaVersion {
 			continue
 		}
 		meta, err := ParseGGUFMeta(m.FilePath)
 		if err != nil {
-			if needsFull {
-				slog.Warn("failed to parse GGUF metadata", "model", m.ID, "error", err)
-			}
+			// Left un-versioned deliberately: a file that is temporarily
+			// unreadable — an unmounted volume, a download still moving
+			// into place — should be re-read next start rather than
+			// frozen at whatever an older parser wrote.
+			slog.Warn("failed to parse GGUF metadata", "model", m.ID, "error", err)
 			continue
 		}
-		if needsFull {
-			meta.ApplyTo(m)
-			changed = true
-			slog.Info("backfilled GGUF metadata", "model", m.ID, "arch", meta.Architecture,
-				"layers", meta.NLayers, "kv_heads", meta.NKVHead, "ctx", meta.ContextLength,
-				"vision", meta.HasVision)
-		} else {
-			if meta.HasVision && !m.HasBuiltinVision {
-				m.HasBuiltinVision = true
-				changed = true
-				slog.Info("detected built-in vision", "model", m.ID)
-			}
-			if needsKV && (meta.KVFullPerTok > 0 || meta.KVSWAPerTok > 0) {
-				m.KVFullPerTok = meta.KVFullPerTok
-				m.KVSWAPerTok = meta.KVSWAPerTok
-				m.SlidingWindow = meta.SlidingWindow
-				if m.NKVHead == 0 {
-					m.NKVHead = meta.NKVHead
-				}
-				changed = true
-				slog.Info("backfilled KV scaling", "model", m.ID,
-					"kv_full_per_tok", meta.KVFullPerTok, "kv_swa_per_tok", meta.KVSWAPerTok,
-					"sliding_window", meta.SlidingWindow)
-			}
-			if needsReasoning && meta.ReasoningChecked {
-				m.Reasoning = meta.Reasoning
-				m.ReasoningChecked = true
-				changed = true
-				slog.Info("backfilled reasoning capability", "model", m.ID,
-					"supported", meta.Reasoning.Supported, "toggle", meta.Reasoning.Toggle)
-			}
-			if needsSampling && meta.SamplingChecked {
-				if m.BaseModelRepo == "" {
-					m.BaseModelRepo = meta.BaseModelRepo
-				}
-				if p := meta.EmbeddedSamplingPreset(); p != nil {
-					m.SamplingPresets = UpsertSamplingPreset(m.SamplingPresets, *p)
-					slog.Info("backfilled embedded sampling defaults", "model", m.ID)
-				}
-				m.SamplingChecked = true
-				changed = true
-			}
-			if needsVocab {
-				// The question was asked; record that, whatever the
-				// answer, so it is not asked again.
-				m.VocabChecked = true
-				changed = true
-				if meta.VocabSize > 0 {
-					m.VocabSize = meta.VocabSize
-					slog.Info("backfilled vocab size", "model", m.ID, "vocab", meta.VocabSize)
-				}
-			}
-			if needsKVRecurrent {
-				// Record the question as asked whatever the answer, so a
-				// model that was already correct is not re-parsed forever.
-				m.KVRecurrentChecked = true
-				changed = true
-				m.TokenEmbdBytes = meta.TokenEmbdBytes
-				m.IndexerKeyLength = meta.IndexerKeyLength
-				m.AttnLayers = meta.AttnLayers
-				if meta.KVFullPerTok != m.KVFullPerTok || meta.KVSWAPerTok != m.KVSWAPerTok {
-					slog.Info("corrected KV scaling for recurrent layers", "model", m.ID,
-						"kv_full_per_tok", meta.KVFullPerTok, "was", m.KVFullPerTok)
-					m.KVFullPerTok = meta.KVFullPerTok
-					m.KVSWAPerTok = meta.KVSWAPerTok
-					m.SlidingWindow = meta.SlidingWindow
-				}
-			}
-			if needsPLE {
-				// Record that the tensor table was inspected whatever
-				// the answer, so a model that simply has no table is
-				// not re-scanned at every startup — for a split model
-				// that scan opens every shard.
-				m.PLEChecked = true
-				changed = true
-				if meta.PLEBytes > 0 {
-					m.PLEBytes = meta.PLEBytes
-					slog.Info("backfilled per-layer embedding table", "model", m.ID, "ple_bytes", meta.PLEBytes)
-				}
-			}
-		}
+		before := m.KVFullPerTok
+		meta.ApplyTo(m)
+		m.GGUFMetaVersion = GGUFMetaVersion
+		changed = true
+		slog.Info("re-read GGUF metadata", "model", m.ID, "version", GGUFMetaVersion,
+			"arch", meta.Architecture, "layers", meta.NLayers, "attn_layers", meta.AttnLayers,
+			"kv_full_per_tok", meta.KVFullPerTok, "was", before,
+			"ple_bytes", meta.PLEBytes, "token_embd_bytes", meta.TokenEmbdBytes)
 	}
 	if changed {
 		r.save()

--- a/internal/models/vram.go
+++ b/internal/models/vram.go
@@ -114,10 +114,77 @@ func VRAMEstimateForConfig(m *Model, cfg *ModelConfig) float64 {
 	if ctx == 0 {
 		ctx = m.ContextLength
 	}
-	// Weight memory: file size is a good proxy for quantized weights in VRAM,
-	// minus any part of the file that never becomes resident.
-	weightsGB := BytesToGiB(m.SizeBytes - lazyPLEBytes(m, cfg))
-	return weightsGB + m.KVCacheGB(ctx, cfg.KVCacheQuant) + AuxFilesVRAMGB(cfg) + vramOverheadGB
+	return VRAMEstimateForConfigOn(m, cfg, DeviceCountForConfig(cfg, 0))
+}
+
+// Per-device coefficients, fitted to llama.cpp's own buffer report across
+// eleven measured loads: four architectures, one and four cards, 3.4 to 99
+// GiB of VRAM. See plan/ple-vram-findings.md for the corpus and the method,
+// and vram_corpus_test.go for the points themselves.
+//
+// They are empirical, and honestly so: they come from one ROCm machine, and
+// a different backend may allocate differently. The guardrail that makes
+// that acceptable is the direction of error — every coefficient is set so
+// the estimate lands at or above measured on the whole corpus. Telling
+// someone a model fits when it does not is the failure worth avoiding.
+const (
+	// Graph scratch, per device. Linear in micro-batch, weakly in context.
+	computeMiBPerUBatchTok = 0.2911
+	computeMiBPerCtxTok    = 0.00090
+	// A sparse-attention model scores every cached position against every
+	// token of the micro-batch before it can take the top-k, and holds
+	// about six tensors of that shape at once. This is the term that makes
+	// such a model cost multiples of an ordinary one at the same context.
+	indexerScratchCopies = 5.69
+	// CUDA/HIP context and allocations llama.cpp does not itemise. Constant
+	// per device across the corpus.
+	vramPerDeviceOverheadGB = 0.85
+)
+
+// VRAMEstimateForConfigOn estimates VRAM for a model spread over devices
+// cards. The count matters because graph scratch and driver overhead are
+// per device, not per model: the same config across four cards costs four
+// times the scratch of one.
+func VRAMEstimateForConfigOn(m *Model, cfg *ModelConfig, cards int) float64 {
+	if cards < 1 {
+		cards = 1
+	}
+	ctx := cfg.ContextSize
+	if ctx == 0 {
+		ctx = m.ContextLength
+	}
+
+	// Weights, less the parts llama.cpp holds host-mapped rather than on a
+	// device. Two tensors do that on every model measured: the per-layer
+	// embedding table where one exists, and the input embedding table,
+	// which is mapped even on models with no per-layer table at all.
+	resident := m.SizeBytes - m.PLEBytes - m.TokenEmbdBytes
+	if resident < 0 {
+		resident = m.SizeBytes
+	}
+	gb := BytesToGiB(resident)
+
+	gb += m.KVCacheGB(ctx, cfg.KVCacheQuant)
+
+	// Graph scratch.
+	ub := cfg.EffectiveUBatchSize()
+	perCard := computeMiBPerUBatchTok*float64(ub) + computeMiBPerCtxTok*float64(ctx)
+	gb += float64(cards) * perCard / 1024
+
+	// Sparse attention: a key cache of its own, plus scratch that scales
+	// with context times micro-batch on every device.
+	if m.IndexerKeyLength > 0 {
+		layers := m.AttnLayers
+		if layers == 0 {
+			layers = m.NLayers
+		}
+		gb += float64(layers) * float64(ctx) * float64(m.IndexerKeyLength) * 4 / (1024 * 1024 * 1024)
+		gb += float64(cards) * indexerScratchCopies * float64(ctx) * float64(ub) * 4 / (1024 * 1024 * 1024)
+	}
+
+	gb += AuxFilesVRAMGB(cfg)
+	gb += float64(cards) * vramPerDeviceOverheadGB
+	return gb
 }
 
 // PLEAutoMinBytes mirrors auto_lazy_min_size in llama.cpp's model loader:
@@ -125,37 +192,6 @@ func VRAMEstimateForConfig(m *Model, cfg *ModelConfig) float64 {
 // demand. Smaller ones stay resident, because the per-row read latency
 // costs more than the memory is worth on a small model.
 const PLEAutoMinBytes = 4 * 1024 * 1024 * 1024
-
-// pleAutoMinBytes is the unexported spelling this file already used.
-const pleAutoMinBytes = PLEAutoMinBytes
-
-// lazyPLEBytes returns the number of bytes of the model file that
-// llama.cpp will read on demand rather than load, which is the part a VRAM
-// estimate must not count. Zero when the model has no per-layer embedding
-// table, or when the table is configured to stay resident.
-//
-// The conditions deliberately track llama.cpp's own (llama-model-loader.cpp,
-// TENSOR_READ_LAZY): lazy reading needs mmap, so it does not apply when the
-// model is loaded with direct I/O.
-func lazyPLEBytes(m *Model, cfg *ModelConfig) int64 {
-	if m.PLEBytes <= 0 || cfg == nil {
-		return 0
-	}
-	if cfg.DirectIO {
-		return 0
-	}
-	switch cfg.PLEMode {
-	case "off":
-		return 0
-	case "on":
-		return m.PLEBytes
-	default: // auto
-		if m.PLEBytes > pleAutoMinBytes {
-			return m.PLEBytes
-		}
-		return 0
-	}
-}
 
 // AuxFilesVRAMGB sums the on-disk sizes of auxiliary GGUFs that load into VRAM
 // alongside the main model: the vision projector (mmproj), a separate MTP

--- a/internal/models/vram_corpus_test.go
+++ b/internal/models/vram_corpus_test.go
@@ -1,0 +1,161 @@
+package models
+
+import (
+	"math"
+	"testing"
+)
+
+const gib = 1024 * 1024 * 1024
+
+// corpusPoint is one load measured on hardware: the model as the registry
+// would hold it, the config it ran under, and the VRAM the GPU counters
+// reported while it was loaded.
+//
+// This is the evidence the estimate is fitted to. Recorded here rather than
+// only in the plan document so a change to the coefficients has to face it.
+type corpusPoint struct {
+	name     string
+	model    Model
+	cfg      ModelConfig
+	cards    int
+	measured float64 // GiB, summed across cards
+}
+
+// Sizes are in GiB where written as floats and converted below.
+func gibBytes(f float64) int64 { return int64(f * gib) }
+
+func corpus() []corpusPoint {
+	// Qwen3.8-Flash-Next: qwen4exp, 48 layers, 12 attending (interval 4),
+	// sparse attention with a 128-wide indexer, 26.82 GiB per-layer table.
+	fn := func(ctx, ub int) Model {
+		return Model{
+			SizeBytes: gibBytes(103.69), PLEBytes: gibBytes(26.82),
+			TokenEmbdBytes: gibBytes(0.629), NLayers: 48, AttnLayers: 12,
+			NEmbd: 2560, NKVHead: 2, KVFullPerTok: 12 * 2 * 512,
+			IndexerKeyLength: 128, ContextLength: 262144,
+		}
+	}
+	// Qwen3.8-27B: qwen35, 65 layers, 16 attending, no indexer.
+	q27 := Model{
+		SizeBytes: gibBytes(29.30), TokenEmbdBytes: gibBytes(1.258),
+		NLayers: 65, AttnLayers: 16, NEmbd: 5120, NKVHead: 4,
+		KVFullPerTok: 16 * 4 * 512, ContextLength: 262144,
+	}
+	// Qwen3.6-35B-A3B: qwen35moe, 41 layers, 10 attending.
+	q35 := Model{
+		SizeBytes: gibBytes(36.41), TokenEmbdBytes: gibBytes(0.503),
+		NLayers: 41, AttnLayers: 10, NEmbd: 2048, NKVHead: 2,
+		KVFullPerTok: 10 * 2 * 512, ContextLength: 262144,
+	}
+	// gemma-4-E4B: sliding-window attention, per-layer table, single card.
+	gem := Model{
+		SizeBytes: gibBytes(4.77), PLEBytes: gibBytes(1.80),
+		TokenEmbdBytes: gibBytes(0.664), NLayers: 42, AttnLayers: 42,
+		NEmbd: 2560, NKVHead: 2, KVFullPerTok: 14336, KVSWAPerTok: 35840,
+		SlidingWindow: 512, ContextLength: 131072,
+	}
+	c := func(ctx, ub int) ModelConfig { return ModelConfig{ContextSize: ctx, UBatchSize: ub} }
+	return []corpusPoint{
+		{"Flash-Next ctx32k ub1024", fn(32768, 1024), c(32768, 1024), 4, 84.48},
+		{"Flash-Next ctx128k ub1024", fn(131072, 1024), c(131072, 1024), 4, 95.96},
+		{"Flash-Next ctx262k ub512", fn(262144, 512), c(262144, 512), 4, 98.96},
+		{"27B ctx8k ub512", q27, c(8192, 512), 4, 31.43},
+		{"27B ctx32k ub512", q27, c(32768, 512), 4, 33.01},
+		{"27B ctx128k ub512", q27, c(131072, 512), 4, 39.38},
+		{"27B ctx262k ub512", q27, c(262144, 512), 4, 47.87},
+		{"27B ctx32k ub128", q27, c(32768, 128), 4, 32.61},
+		{"27B ctx32k ub2048", q27, c(32768, 2048), 4, 34.82},
+		{"35B-A3B ctx32k ub512", q35, c(32768, 512), 4, 38.08},
+		{"gemma-4-E4B ctx4k ub512", gem, c(4096, 512), 1, 3.42},
+	}
+}
+
+// The guardrail. An estimate below what the hardware actually used tells
+// someone a model fits when it does not, so no point may under-predict —
+// however good the average looks.
+func TestEstimateNeverUnderPredicts(t *testing.T) {
+	for _, p := range corpus() {
+		got := VRAMEstimateForConfigOn(&p.model, &p.cfg, p.cards)
+		if got < p.measured {
+			t.Errorf("%s: estimated %.2f GiB, hardware used %.2f — under by %.2f",
+				p.name, got, p.measured, p.measured-got)
+		}
+	}
+}
+
+// Being conservative is only useful if it stays close. A headroom figure
+// nobody believes gets ignored, which is the same failure by another route.
+func TestEstimateStaysCloseToMeasured(t *testing.T) {
+	var sum, worst float64
+	var worstName string
+	for _, p := range corpus() {
+		got := VRAMEstimateForConfigOn(&p.model, &p.cfg, p.cards)
+		e := math.Abs(got - p.measured)
+		sum += e
+		if e > worst {
+			worst, worstName = e, p.name
+		}
+		if e > 3.0 {
+			t.Errorf("%s: estimated %.2f against %.2f measured, off by %.2f", p.name, got, p.measured, e)
+		}
+	}
+	mean := sum / float64(len(corpus()))
+	if mean > 1.5 {
+		t.Errorf("mean error %.2f GiB across the corpus, want under 1.5", mean)
+	}
+	t.Logf("mean error %.2f GiB, worst %.2f on %s", mean, worst, worstName)
+}
+
+// The device count is not cosmetic: scratch and driver overhead are per
+// device, so the same config across four cards costs materially more than
+// across one. A caller that cannot supply the count gets the single-device
+// figure, which is the smaller one — so this must be visible, not silent.
+func TestDeviceCountChangesTheEstimate(t *testing.T) {
+	p := corpus()[3] // 27B, no indexer
+	one := VRAMEstimateForConfigOn(&p.model, &p.cfg, 1)
+	four := VRAMEstimateForConfigOn(&p.model, &p.cfg, 4)
+	if four <= one {
+		t.Fatalf("four cards estimated %.2f, one card %.2f — the count is being ignored", four, one)
+	}
+	if diff := four - one; diff < 2.0 {
+		t.Errorf("four cards cost only %.2f GiB more than one; expected roughly 3x the per-device overhead", diff)
+	}
+}
+
+// Host-mapped weights are not counted. Both tensors matter: the 27B has no
+// per-layer table and still keeps its input embedding off the device.
+func TestHostMappedWeightsExcluded(t *testing.T) {
+	m := Model{SizeBytes: gibBytes(30.0), PLEBytes: gibBytes(4.0), TokenEmbdBytes: gibBytes(1.0),
+		NLayers: 32, AttnLayers: 32, NEmbd: 4096, NKVHead: 8, KVFullPerTok: 32 * 8 * 256}
+	cfg := ModelConfig{ContextSize: 4096}
+	withBoth := VRAMEstimateForConfigOn(&m, &cfg, 1)
+
+	noEmb := m
+	noEmb.TokenEmbdBytes = 0
+	if VRAMEstimateForConfigOn(&noEmb, &cfg, 1)-withBoth < 0.9 {
+		t.Error("the token embedding is not being excluded from resident weights")
+	}
+	noPLE := m
+	noPLE.PLEBytes = 0
+	if VRAMEstimateForConfigOn(&noPLE, &cfg, 1)-withBoth < 3.9 {
+		t.Error("the per-layer table is not being excluded from resident weights")
+	}
+}
+
+// A sparse-attention model pays for ranking the whole cache. Without that
+// term Flash-Next is under-predicted by tens of GiB at long context.
+func TestIndexerTermOnlyAppliesToRankingModels(t *testing.T) {
+	p := corpus()[2] // Flash-Next ctx262k
+	with := VRAMEstimateForConfigOn(&p.model, &p.cfg, p.cards)
+
+	plain := p.model
+	plain.IndexerKeyLength = 0
+	without := VRAMEstimateForConfigOn(&plain, &p.cfg, p.cards)
+
+	if with-without < 10 {
+		t.Errorf("indexer term worth only %.2f GiB at 262144 context; measured compute alone was 24 GiB", with-without)
+	}
+	if without >= p.measured {
+		t.Error("the estimate is adequate without the indexer term; the fixture no longer shows why it exists")
+	}
+}

--- a/internal/modelsource/ple_probe.go
+++ b/internal/modelsource/ple_probe.go
@@ -49,9 +49,9 @@ const (
 
 // ProbeResult is what a remote header probe learned about one file.
 type ProbeResult struct {
-	// StreamedBytes is the part of the download that llama.cpp reads from
-	// disk on demand and never makes resident. Zero when the file has no
-	// such table, or has one small enough to stay resident.
+	// StreamedBytes is the part of the download that never occupies VRAM:
+	// the per-layer embedding table, which llama.cpp holds host-mapped at
+	// every size. Zero when the file has no such table.
 	StreamedBytes int64
 	// Probed records that the header was actually read. False means the
 	// probe was skipped or failed, and StreamedBytes says nothing.
@@ -129,7 +129,7 @@ func ProbePLE(ctx context.Context, client *http.Client, token string, shards []S
 			continue
 		}
 		if meta.PLEBytes > 0 {
-			return ProbeResult{StreamedBytes: streamedBytes(meta.PLEBytes), Probed: true}
+			return ProbeResult{StreamedBytes: offDeviceBytes(meta.PLEBytes), Probed: true}
 		}
 	}
 	// Every shard parsed and none held a table: that is a real answer,
@@ -137,15 +137,18 @@ func ProbePLE(ctx context.Context, client *http.Client, token string, shards []S
 	return ProbeResult{StreamedBytes: 0, Probed: true}
 }
 
-// streamedBytes applies llama.cpp's own rule for what gets streamed under
-// the default --tensor-read-lazy auto: tables over 4 GiB, and only those.
-// Deliberately the same threshold the post-download estimate uses, so the
-// number shown before downloading and the number shown after agree.
-func streamedBytes(pleBytes int64) int64 {
-	if pleBytes > models.PLEAutoMinBytes {
-		return pleBytes
-	}
-	return 0
+// offDeviceBytes is the part of a download that never occupies VRAM.
+//
+// This used to apply llama.cpp's 4 GiB streaming threshold, on the reading
+// that only a streamed table stayed out of VRAM. Measurement says the table
+// is held host-mapped at every size and in every mode, so the whole of it
+// is off-device regardless — see plan/ple-vram-findings.md. The threshold
+// governs host residency, which was never what this number is for.
+//
+// Kept the same rule as the post-download estimate, so the figure shown
+// before downloading and the one shown after still agree.
+func offDeviceBytes(pleBytes int64) int64 {
+	return pleBytes
 }
 
 // tensorCount reads a GGUF file's tensor count from its 24-byte header,

--- a/internal/modelsource/ple_probe_test.go
+++ b/internal/modelsource/ple_probe_test.go
@@ -165,7 +165,11 @@ func TestProbeSkippedBelowThreshold(t *testing.T) {
 
 // A table under llama.cpp's 4 GiB lazy threshold stays resident, so it
 // must not be subtracted — the estimate is already right for it.
-func TestProbeIgnoresSmallTable(t *testing.T) {
+// A table below llama.cpp's 4 GiB streaming threshold is still held
+// host-mapped, so it is still off-device and still excluded. This test
+// asserted the opposite until the placement was measured; the threshold
+// governs host residency, not which device holds the table.
+func TestProbeReportsSmallTableAsOffDevice(t *testing.T) {
 	data := buildGGUF(t, 0, []tensorSpec{
 		{pleTensorNameForTest, 0},
 		{"output.weight", 1 << 30}, // 1 GiB table
@@ -179,8 +183,8 @@ func TestProbeIgnoresSmallTable(t *testing.T) {
 	if !got.Probed {
 		t.Fatal("probe did not complete")
 	}
-	if got.StreamedBytes != 0 {
-		t.Errorf("streamed = %d, want 0 for a table under the lazy threshold", got.StreamedBytes)
+	if got.StreamedBytes != 1<<30 {
+		t.Errorf("off-device = %d, want the whole 1 GiB table", got.StreamedBytes)
 	}
 }
 

--- a/plan/ple-vram-findings.md
+++ b/plan/ple-vram-findings.md
@@ -328,6 +328,42 @@ table is already in host memory in every mode, so there is nothing to free. The
 10.59 GiB that variant B saves is a buffer effect and would be better exposed,
 if wanted at all, as what it is rather than as a placement control.
 
+## The revised estimate
+
+Terms, each grounded in a measured buffer report rather than fitted blind:
+
+| Term | Basis |
+|---|---|
+| Weights | file size less the per-layer table and the input embedding, both held `CPU_Mapped` on every model measured |
+| KV cache | attention layers only; recurrent layers hold no cache (shipped separately) |
+| Graph scratch | `0.2911 MiB x ubatch + 0.0009 MiB x ctx` per device |
+| Sparse-attention scratch | `5.69 x n_kv x ubatch x 4` per device, only on models carrying indexer keys |
+| Indexer key cache | `attn_layers x n_kv x key_length x 4` |
+| Per-device overhead | 0.85 GiB |
+
+Scored against the eleven measured points:
+
+| | current | revised |
+|---|---|---|
+| mean absolute error | 7.74 GiB | **0.99 GiB** |
+| worst error | +20.91 | +2.55 |
+| under-predicts | 3 of 11 | **0 of 11** |
+
+The guardrail is the direction, not the average: no point may come in under
+what the hardware used. An estimate that is high costs someone headroom; one
+that is low tells them a model fits when it does not.
+
+### What it rests on
+
+One ROCm machine, four architectures, one and four cards, 3.4 to 99 GiB. The
+weight and KV terms are structural and should travel. The three fitted
+coefficients are empirical and may not: a different backend can allocate
+scratch differently. They are set so the corpus never under-predicts, which
+is what makes shipping them defensible on this much evidence.
+
+The corpus lives in `internal/models/vram_corpus_test.go`. Adding a machine
+or an architecture means adding points there and re-checking both tests.
+
 ## Measurement plan for the estimator
 
 The estimator cannot be corrected from per-GPU totals alone — they conflate

--- a/web/templates/partials/model_config.html
+++ b/web/templates/partials/model_config.html
@@ -134,7 +134,7 @@
 
     {{if .HasPLE}}
     <div class="grid">
-        <label title="How to hold the per-layer (n-gram) embedding table, which this model carries in addition to its weights. Streaming reads its rows from the model file as they are needed instead of holding the whole table in memory — it is not counted toward the VRAM estimate when streamed. Auto follows llama.cpp: stream tables over 4 GiB, keep smaller ones resident. Streaming needs memory mapping, so it does not apply when Direct I/O is on.">
+        <label title="How the per-layer embedding table is held in system memory. This model carries one in addition to its weights. The table is never placed on the GPU, whichever setting you choose, so this does not change the VRAM estimate — it trades system memory against loading and lookup speed. Streaming reads the table&#39;s rows from the model file as they are needed rather than holding all of it in memory at once, which uses less system memory and is slightly slower. Auto follows llama.cpp: stream tables over 4 GiB, keep smaller ones in memory. Streaming needs memory mapping, so it does not apply when Direct I/O is on.">
             Per-Layer Embeddings ({{.PLESizeLabel}} table)
             <select name="ple_mode">
                 <option value="" {{if eq .Config.PLEMode ""}}selected{{end}}>Auto (stream if over 4 GiB)</option>


### PR DESCRIPTION
Step 5 and 6 of the plan in #159, and the end of this investigation.

## Result

Scored against the eleven loads measured on your box — four architectures, one and four cards, 3.4 to 99 GiB:

| | current | revised |
|---|---|---|
| mean absolute error | 7.74 GiB | **0.99 GiB** |
| worst error | +20.91 | +2.55 |
| under-predicts | 3 of 11 | **0 of 11** |

## What was wrong

**Weights.** The estimate counted the whole file. Two tensors are held host-mapped and never reach a device: the per-layer embedding table, and the **input embedding** — which is mapped even on models with no per-layer table at all. Both are now read from the tensor block rather than computed from `vocab × n_embd`, because publishers quantize them independently of the body; both UD quants here keep the embedding at Q8_0 inside a Q4 model.

**Compute buffers.** Not modelled at all, and on one of your real configs they are **24 GiB**. Graph scratch is linear in micro-batch and weakly in context, per device. A sparse-attention model pays much more — it scores every cached position against every token of the micro-batch before taking the top-k, holds about six tensors of that shape at once, and carries an indexer key cache besides.

**Device count.** Scratch and driver overhead are per device, so the same config across four cards costs four times the scratch of one. Callers that know the host's GPU count now pass it.

## Consequences elsewhere

The per-layer embedding mode **no longer moves the estimate**, because the table is off-device in every mode. That replaces two tests asserting the opposite, and corrects the browse-time probe, which excluded the table only above llama.cpp's 4 GiB streaming threshold — that threshold governs host residency, not which device holds the table. The selector's tooltip claimed the same thing and now describes what the setting actually trades.

## The corpus is a test

`internal/models/vram_corpus_test.go` holds the eleven measured points, so changing a coefficient has to face them. The guardrail is **direction, not average**: no point may come in under what the hardware used. An estimate that is high costs someone headroom; one that is low tells them a model fits when it does not.

## What this rests on

One ROCm machine. The weight and KV terms are structural and should travel. The three fitted coefficients are empirical and may not — a different backend can allocate scratch differently. They are set so the corpus never under-predicts, which is what makes shipping them defensible on this much evidence, and the test is where new machines and architectures get added.

Full suite green apart from the two pre-existing `internal/builder` git-tag failures that reproduce on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt54KWjaay1Lzywdnkg3V2