### PR TITLE
feat(browse): show the file list at once, fill VRAM figures as they arrive

### DIFF
--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -28,6 +28,13 @@ type hfFileView struct {
 	huggingface.ModelFile
 	AlreadyDownloaded bool
 	FitsOnDisk        bool
+	// EstimatePending marks a file whose VRAM figure is still being
+	// measured. The measurement reads a slice of each shard's header over
+	// the network, which for a listing of large quants is the difference
+	// between a list that appears at once and one that appears after
+	// several seconds. Such a file renders a placeholder and is filled in
+	// when the answer arrives.
+	EstimatePending bool
 }
 
 // hfModelView is the template payload for the HF file-list partial.
@@ -38,6 +45,10 @@ type hfModelView struct {
 	AvailableBytes int64 // free - margin - in-flight
 	FreeBytes      int64
 	SafetyMargin   int64
+	// AnyPending drives the one deferred request that fills the pending
+	// cells. Absent when every file already has its answer, so a listing
+	// of small files or a repeat visit costs no second round trip.
+	AnyPending bool
 }
 
 func (s *Server) handleHFSearch(w http.ResponseWriter, r *http.Request) {
@@ -77,7 +88,7 @@ func (s *Server) handleHFModel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	source := s.requestSource(r.URL.Query().Get("source"))
-	detail, err := s.sourceClient(source).GetModel(r.Context(), modelID)
+	detail, err := s.modelDetail(r.Context(), source, modelID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
@@ -92,15 +103,16 @@ func (s *Server) handleHFModel(w http.ResponseWriter, r *http.Request) {
 		FreeBytes:      s.downloader.FreeBytes(),
 		SafetyMargin:   huggingface.DiskSafetyMarginBytes,
 	}
-	// Measure how much of each candidate is streamed rather than loaded,
-	// so the VRAM column reflects what actually reaches the card. Only
-	// the large files are probed and each is a small ranged read, but
-	// they are done together so the listing is not serialized behind
-	// them.
-	s.probeStreamedBytes(r.Context(), source, detail)
+	// Apply only what is already known. Measuring the rest reads a slice
+	// of every shard's header over the network, and doing that here is
+	// what made the file list take seconds to appear: the listing was
+	// serialized behind every probe in it. Those files render a
+	// placeholder and are filled in by one deferred request.
+	pending := s.applyCachedProbes(source, detail)
 
 	for _, f := range detail.Files {
-		fv := hfFileView{ModelFile: f}
+		fv := hfFileView{ModelFile: f, EstimatePending: pending[f.Filename]}
+		view.AnyPending = view.AnyPending || fv.EstimatePending
 		if _, ok := s.registry.HasFile(detail.ID, f.Filename); ok {
 			fv.AlreadyDownloaded = true
 		} else {
@@ -485,6 +497,91 @@ func (s *Server) onDownloadComplete(source, downloadID, modelID, filename string
 	// in the background — the GGUF-embedded default was already attached via
 	// meta.ApplyTo above.
 	go s.enrichModelPresets(m.ID)
+}
+
+// modelDetail fetches a repository's file list, briefly cached.
+//
+// The cache exists because the listing is now fetched twice for one click:
+// once to render the files, once by the deferred request that fills in
+// their VRAM figures. Without it that would double the calls this makes
+// against a host that rate-limits. The window is short because a
+// repository's contents can change; it only has to outlive one page.
+func (s *Server) modelDetail(ctx context.Context, source, modelID string) (*modelsource.Detail, error) {
+	key := source + "\x00" + modelID
+	s.detailMu.RLock()
+	e, ok := s.detailCache[key]
+	s.detailMu.RUnlock()
+	if ok && time.Since(e.at) < detailCacheTTL {
+		return copyDetail(e.detail), nil
+	}
+
+	detail, err := s.sourceClient(source).GetModel(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+	s.detailMu.Lock()
+	if s.detailCache == nil {
+		s.detailCache = map[string]detailEntry{}
+	}
+	s.detailCache[key] = detailEntry{detail: copyDetail(detail), at: time.Now()}
+	s.detailMu.Unlock()
+	return detail, nil
+}
+
+// copyDetail returns a detail whose Files can be mutated without touching
+// the cached copy — applyProbe writes into them.
+func copyDetail(d *modelsource.Detail) *modelsource.Detail {
+	out := *d
+	out.Files = append([]modelsource.File(nil), d.Files...)
+	return &out
+}
+
+// applyCachedProbes fills in every VRAM figure already known, and reports
+// which files still need measuring. A file the probe would skip is not
+// pending: its estimate is final now, and showing a placeholder that
+// resolves to the same number would be a lie about what is happening.
+func (s *Server) applyCachedProbes(source string, detail *modelsource.Detail) map[string]bool {
+	pending := map[string]bool{}
+	for i := range detail.Files {
+		f := &detail.Files[i]
+		if cached, ok := s.cachedProbe(source, detail.ID, f.Filename); ok {
+			applyProbe(f, cached)
+			continue
+		}
+		shards := len(f.Shards)
+		if shards == 0 {
+			shards = 1
+		}
+		if modelsource.ProbeApplies(f.Size, shards) {
+			pending[f.Filename] = true
+		}
+	}
+	return pending
+}
+
+// handleHFModelEstimates measures the files a listing left pending and
+// returns just the cells that changed, swapped into the page in place.
+// The listing itself is already on screen by the time this is asked for.
+func (s *Server) handleHFModelEstimates(w http.ResponseWriter, r *http.Request) {
+	modelID := r.URL.Query().Get("id")
+	if modelID == "" {
+		http.Error(w, "missing id parameter", http.StatusBadRequest)
+		return
+	}
+	source := s.requestSource(r.URL.Query().Get("source"))
+	detail, err := s.modelDetail(r.Context(), source, modelID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	s.probeStreamedBytes(r.Context(), source, detail)
+
+	view := hfModelView{ID: detail.ID, Source: source, Files: make([]hfFileView, 0, len(detail.Files))}
+	for _, f := range detail.Files {
+		view.Files = append(view.Files, hfFileView{ModelFile: f})
+	}
+	respondHTML(w)
+	s.renderPartial(w, "hf_file_estimates", view)
 }
 
 // probeStreamedBytes fills in StreamedBytes for the files in detail,

--- a/internal/api/hf_deferred_estimates_test.go
+++ b/internal/api/hf_deferred_estimates_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/modelsource"
+	"github.com/tmac1973/llama-toolchest/web"
+)
+
+func renderFiles(t *testing.T, name string, view hfModelView) string {
+	t.Helper()
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := base.ExecuteTemplate(&buf, name, view); err != nil {
+		t.Fatalf("execute %s: %v", name, err)
+	}
+	return buf.String()
+}
+
+const gibT = int64(1) << 30
+
+// The point of the change: a file whose figure is still being measured
+// shows a placeholder, and the file list is on screen without waiting for
+// the network reads that measurement needs.
+func TestPendingFileShowsPlaceholderAndAsksForTheAnswer(t *testing.T) {
+	view := hfModelView{
+		ID: "unsloth/Big-GGUF", Source: modelsource.SourceHuggingFace,
+		Files: []hfFileView{{
+			ModelFile:       modelsource.File{Filename: "big.gguf", Size: 68 * gibT, Quant: "Q4_K_M"},
+			FitsOnDisk:      true,
+			EstimatePending: true,
+		}},
+		AvailableBytes: 1 << 46,
+		AnyPending:     true,
+	}
+	out := renderFiles(t, "hf_files", view)
+
+	if !strings.Contains(out, "Calculating…") {
+		t.Errorf("no placeholder for a pending estimate; output=\n%s", out)
+	}
+	// The filename must be there already — that is the whole point.
+	if !strings.Contains(out, "big.gguf") {
+		t.Error("the file list is not rendered alongside the placeholder")
+	}
+	// And exactly one deferred request, not one per file.
+	if n := strings.Count(out, "/api/hf/model/estimates"); n != 1 {
+		t.Errorf("%d deferred requests, want exactly 1", n)
+	}
+}
+
+// A listing with nothing pending must not issue the deferred request at
+// all: a repeat visit is served from the probe cache, and a round trip
+// that changes nothing is just latency.
+func TestNothingPendingIssuesNoRequest(t *testing.T) {
+	view := hfModelView{
+		ID: "unsloth/Small-GGUF", Source: modelsource.SourceHuggingFace,
+		Files: []hfFileView{{
+			ModelFile:  modelsource.File{Filename: "small.gguf", Size: 3 * gibT, VRAMEstGB: 3.4},
+			FitsOnDisk: true,
+		}},
+		AvailableBytes: 1 << 46,
+	}
+	out := renderFiles(t, "hf_files", view)
+
+	if strings.Contains(out, "/api/hf/model/estimates") {
+		t.Error("issued a deferred request with nothing pending")
+	}
+	if strings.Contains(out, "Calculating…") {
+		t.Error("showed a placeholder for a figure that is already final")
+	}
+	if !strings.Contains(out, "3.4 GiB") {
+		t.Errorf("final estimate not shown; output=\n%s", out)
+	}
+}
+
+// The fill targets only the two cells per file. Replacing whole rows would
+// discard a download progress row that appeared while the user waited.
+func TestFillTargetsOnlyTheEstimateCells(t *testing.T) {
+	view := hfModelView{
+		ID: "unsloth/Big-GGUF", Source: modelsource.SourceHuggingFace,
+		Files: []hfFileView{{ModelFile: modelsource.File{
+			Filename: "big.gguf", Size: 68 * gibT,
+			StreamedBytes: 27 * gibT, StreamProbed: true,
+			VRAMEstGB: modelsource.EstimateVRAM(41 * gibT),
+		}}},
+	}
+	out := renderFiles(t, "hf_file_estimates", view)
+
+	if n := strings.Count(out, `hx-swap-oob="true"`); n != 2 {
+		t.Errorf("%d out-of-band swaps, want 2 (the VRAM cell and the fit cell)", n)
+	}
+	for _, want := range []string{"vram-", "fit-", "45.1 GiB", "held in system memory"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("fill is missing %q; output=\n%s", want, out)
+		}
+	}
+	// Nothing structural: no rows, no download buttons.
+	for _, unwanted := range []string{"<tr", "<button", "Download"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("fill contains %q — it should carry only the two cells", unwanted)
+		}
+	}
+}
+
+// Both renders must agree, or the number flickers to something else when
+// the answer lands.
+func TestFirstRenderAndFillAgree(t *testing.T) {
+	f := modelsource.File{
+		Filename: "big.gguf", Size: 68 * gibT,
+		StreamedBytes: 27 * gibT, StreamProbed: true,
+		VRAMEstGB: modelsource.EstimateVRAM(41 * gibT),
+	}
+	settled := renderFiles(t, "hf_files", hfModelView{
+		ID: "r", Files: []hfFileView{{ModelFile: f, FitsOnDisk: true}}, AvailableBytes: 1 << 46,
+	})
+	filled := renderFiles(t, "hf_file_estimates", hfModelView{
+		ID: "r", Files: []hfFileView{{ModelFile: f}},
+	})
+	for _, want := range []string{"45.1 GiB", "held in system memory"} {
+		if !strings.Contains(settled, want) || !strings.Contains(filled, want) {
+			t.Errorf("%q appears in only one of the two renders", want)
+		}
+	}
+}
+
+// A file the probe would never inspect must not be marked pending: its
+// estimate is final already, and a placeholder resolving to the same
+// number misrepresents what is happening.
+func TestOnlyProbableFilesArePending(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		size   int64
+		shards int
+		want   bool
+	}{
+		{"small single file", 3 * gibT, 1, false},
+		{"large single file", 68 * gibT, 1, false}, // unsplit files are not probed
+		{"large split file", 68 * gibT, 4, true},
+		{"small split file", 3 * gibT, 4, false},
+	} {
+		if got := modelsource.ProbeApplies(tt.size, tt.shards); got != tt.want {
+			t.Errorf("%s: ProbeApplies = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/internal/api/modelsource_test.go
+++ b/internal/api/modelsource_test.go
@@ -198,9 +198,11 @@ func TestDefaultModelSourceFallback(t *testing.T) {
 	}
 }
 
-// A streamed table must be excluded from the VRAM estimate and shown as
-// such, or the fit verdict stays wrong in exactly the case the probe
-// exists to fix.
+// The per-layer embedding table must be excluded from the VRAM estimate
+// and shown as such, or the fit verdict stays wrong in exactly the case
+// the probe exists to fix. The wording says system memory rather than
+// streaming: the table is off the card whatever the streaming mode, which
+// is what measurement showed.
 func TestFileListShowsStreamedPortion(t *testing.T) {
 	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
 		"templates/layout.html", "templates/partials/*.html")
@@ -226,8 +228,8 @@ func TestFileListShowsStreamedPortion(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	out := buf.String()
-	if !strings.Contains(out, "streamed from disk") {
-		t.Errorf("streamed portion not surfaced; output=\n%s", out)
+	if !strings.Contains(out, "held in system memory") {
+		t.Errorf("off-card portion not surfaced; output=\n%s", out)
 	}
 	// The full download is still what lands on disk, so Size must not be
 	// quietly reduced to the resident part.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -43,8 +43,15 @@ type Server struct {
 	// probeCache memoizes remote GGUF header probes, keyed by source,
 	// repo and file. A published file's layout does not change, so the
 	// answer is good for the life of the process.
-	probeMu     sync.RWMutex
-	probeCache  map[string]modelsource.ProbeResult
+	probeMu    sync.RWMutex
+	probeCache map[string]modelsource.ProbeResult
+
+	// detailCache holds a repository's file list for long enough to serve
+	// one page: the listing and the deferred request that fills in its
+	// VRAM figures both need it, and fetching twice per click would double
+	// the calls made against a host that rate-limits.
+	detailMu    sync.RWMutex
+	detailCache map[string]detailEntry
 	downloader  *huggingface.Downloader
 	registry    *models.Registry
 	presets     *presets.Fetcher
@@ -519,6 +526,7 @@ func (s *Server) buildRouter() chi.Router {
 		r.Route("/hf", func(r chi.Router) {
 			r.Get("/search", s.handleHFSearch)
 			r.Get("/model", s.handleHFModel)
+			r.Get("/model/estimates", s.handleHFModelEstimates)
 			r.Post("/download", s.handleHFDownload)
 			r.Get("/downloads", s.handleHFActiveDownloads)
 			r.Get("/downloads-panel", s.handleDownloadsPanel)
@@ -561,6 +569,16 @@ func (s *Server) buildRouter() chi.Router {
 
 	return r
 }
+
+// detailEntry is one cached repository listing and when it was fetched.
+type detailEntry struct {
+	detail *modelsource.Detail
+	at     time.Time
+}
+
+// detailCacheTTL is short on purpose: a repository's contents can change,
+// and this only has to outlive a single page's two requests.
+const detailCacheTTL = 90 * time.Second
 
 // pageData holds common template data for page rendering.
 type pageData struct {

--- a/internal/modelsource/ple_probe.go
+++ b/internal/modelsource/ple_probe.go
@@ -47,6 +47,17 @@ const (
 	probeMinBytes = 8 * 1024 * 1024 * 1024
 )
 
+// ProbeApplies reports whether ProbePLE would actually inspect a file,
+// given its total size and shard count. Exported because the UI needs to
+// know in advance which files have an answer coming — a file that will
+// never be probed should show its final estimate immediately rather than a
+// placeholder that resolves to the same number.
+//
+// Kept beside the conditions it mirrors so the two cannot drift.
+func ProbeApplies(totalBytes int64, shards int) bool {
+	return totalBytes >= probeMinBytes && shards >= 2
+}
+
 // ProbeResult is what a remote header probe learned about one file.
 type ProbeResult struct {
 	// StreamedBytes is the part of the download that never occupies VRAM:

--- a/web/templates/partials/hf_files.html
+++ b/web/templates/partials/hf_files.html
@@ -18,22 +18,16 @@
             <td><small>{{$f.Filename}}{{if $f.Shards}} ({{len $f.Shards}} parts){{end}}{{if $f.IsMMProj}} <mark style="padding:0 0.3rem;">vision</mark>{{end}}</small></td>
             <td><kbd>{{$f.Quant}}</kbd></td>
             <td>{{printf "%.1f" (divGB $f.Size)}} GiB</td>
-            <td>
-                {{printf "%.1f" $f.VRAMEstGB}} GiB
-                {{if gt $f.StreamedBytes 0}}<br><small title="This architecture keeps its per-layer embedding table on disk and reads rows on demand, so that part never occupies VRAM. Assumes the default Per-Layer Embeddings setting; choosing &quot;Keep resident in memory&quot; after download would add it back.">+{{printf "%.1f" (divGB $f.StreamedBytes)}} GiB streamed from disk</small>{{end}}
-            </td>
-            <td>
-                {{$fit := vramFit $f.VRAMEstGB}}
-                {{if eq $fit "too_large"}}
-                    <del>Too Large</del>
-                {{else if eq $fit "fits"}}
-                    <ins>Fits</ins>
-                {{else if eq $fit ""}}
-                    —
-                {{else}}
-                    <mark>{{$fit}}</mark>
-                {{end}}
-            </td>
+            <td><span id="vram-{{cssID $.ID}}-{{$i}}">
+                {{- if $f.EstimatePending -}}
+                    <small aria-busy="true" title="Reading this model's headers to find the part that never occupies VRAM.">Calculating…</small>
+                {{- else -}}
+                    {{template "hf_vram_cell" $f}}
+                {{- end -}}
+            </span></td>
+            <td><span id="fit-{{cssID $.ID}}-{{$i}}">
+                {{- if $f.EstimatePending -}}<small>—</small>{{- else -}}{{template "hf_fit_cell" $f}}{{- end -}}
+            </span></td>
             <td>
                 {{if $f.AlreadyDownloaded}}
                     <ins title="Already in your local model registry">Downloaded</ins>
@@ -59,4 +53,33 @@
         {{end}}
     </tbody>
 </table>
+{{if .AnyPending}}
+<div hx-get="/api/hf/model/estimates?id={{.ID}}&source={{.Source}}"
+     hx-trigger="load" hx-swap="none"></div>
+{{end}}
+{{end}}
+
+{{/* One file's VRAM figure. Shared so the deferred fill and the first
+     render cannot drift into showing different things. */}}
+{{define "hf_vram_cell"}}
+{{printf "%.1f" .VRAMEstGB}} GiB
+{{- if gt .StreamedBytes 0}}<br><small title="This architecture keeps its per-layer embedding table in system memory rather than on the graphics card, so that part does not count toward the VRAM estimate. It is still part of the download and still takes disk space.">+{{printf "%.1f" (divGB .StreamedBytes)}} GiB held in system memory</small>{{end}}
+{{end}}
+
+{{define "hf_fit_cell"}}
+{{- $fit := vramFit .VRAMEstGB -}}
+{{if eq $fit "too_large"}}<del>Too Large</del>
+{{else if eq $fit "fits"}}<ins>Fits</ins>
+{{else if eq $fit ""}}—
+{{else}}<mark>{{$fit}}</mark>{{end}}
+{{end}}
+
+{{/* The deferred fill: only the two cells per file, swapped in place, so
+     nothing else on the page is disturbed — a download started in the
+     meantime keeps its progress row. */}}
+{{define "hf_file_estimates"}}
+{{range $i, $f := .Files}}
+<span id="vram-{{cssID $.ID}}-{{$i}}" hx-swap-oob="true">{{template "hf_vram_cell" $f}}</span>
+<span id="fit-{{cssID $.ID}}-{{$i}}" hx-swap-oob="true">{{template "hf_fit_cell" $f}}</span>
+{{end}}
 {{end}}


### PR DESCRIPTION
Clicking **Files** paused for seconds before anything appeared. The handler measured every candidate's per-layer embedding table first — a ranged read of each shard's header, over the network — and only then rendered. The list was serialized behind work the list does not need.

## What changes

The file list renders immediately. Figures already known are applied on the spot, so a repeat visit is complete at once. The rest show `Calculating…` and are filled by **one** deferred request — one, not one per file, and only when something is actually pending.

## Details worth reviewing

**The fill swaps only the two cells per file**, out of band, rather than re-rendering rows. Re-rendering would discard a download progress row that appeared while the user was reading the list — a real possibility now that the list is up early.

**Both renders share the same two templates** (`hf_vram_cell`, `hf_fit_cell`), so the figure cannot change appearance when the answer lands.

**A file the probe would skip is never marked pending.** Its estimate is already final, and a placeholder resolving to the same number misrepresents what is happening. `modelsource.ProbeApplies` now exports the probe's own applicability rule so the UI and the probe cannot drift about which files have an answer coming.

**A short-lived listing cache.** The repository listing is now fetched twice per click — once to render, once by the deferred request — and without a cache that would double the calls made against a host that rate-limits. 90 seconds, long enough to outlive one page, short enough that a repository's contents are not held stale. Second visits to the same repository are also instant.

## One copy correction

The column said `+27.0 GiB streamed from disk`, which described the mechanism rather than the reason the bytes are excluded. Measurement showed the table is off the card *whichever* streaming mode is chosen, so it now reads `held in system memory`, with a tooltip noting it is still part of the download and still takes disk space. The old tooltip also claimed choosing "Keep resident in memory" would add it back to VRAM, which is not true.

## Testing

Placeholder-plus-filename in one render; no deferred request when nothing is pending; the fill carrying exactly two out-of-band swaps and no rows or buttons; and both renders agreeing on the figure. Suite green apart from the two pre-existing `internal/builder` git-tag failures.

Worth a look in a browser before merging — I have tested the rendering and the wiring, but not watched the swap happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt54KWjaay1Lzywdnkg3V2