### PR TITLE
Measure what a model load actually uses, and put it where decisions get made

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,12 @@ package:
 scrape-sampling-presets:
 	go run ./scripts/scrape-sampling-presets
 
-# Runs the benchmark job form's parameter-control JavaScript against a
-# DOM stub. Part of `go test ./...`, but skipped when node is missing —
-# this target fails loudly instead, so CI can't quietly lose the
+# Runs the page JavaScript that is worth executing — the benchmark job
+# form's parameter controls, and the visualization's metric filter —
+# against a DOM stub. Part of `go test ./...`, but skipped when node is
+# missing; this target fails loudly instead, so CI can't quietly lose the
 # coverage.
 .PHONY: js-test
 js-test:
 	@command -v node >/dev/null || { echo "node is required for js-test"; exit 1; }
-	go test ./internal/api/ -run TestParameterControlsJS -v
+	go test ./internal/api/ -run 'TestParameterControlsJS|TestVisualizeMetricFilterJS' -v

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A web-based management interface for [llama.cpp](https://github.com/ggerganov/ll
 - **Capability detection** — Tool calling, vision, and reasoning-mode detection from GGUF metadata, surfaced as badges and via the `capabilities` block on `/api/service/loaded-models` (single-round-trip auto-discovery).
 - **VRAM estimation** — Architecture-aware estimates from GGUF metadata, accounting for KV cache size and quantization.
 - **Measured memory** — What llama.cpp really allocated on the last load — weights, KV cache and working buffers, per GPU — read from its own buffer report and shown beside the estimate in the Available Models tooltip. Needs *Model loading detail* 4 in Settings.
-- **Benchmarks** — Batch jobs sweeping models × builds × presets × any model parameter, with results compared across runs and exported to CSV/JSON.
+- **Benchmarks** — Batch jobs sweeping models × builds × presets × any model parameter, with results compared across runs and exported to CSV/JSON. Each cell also records the memory its load actually used, so a sweep shows what a setting costs in VRAM as well as what it buys in speed — as a column, a visualization metric, and export columns.
 - **OpenAI-compatible API** — Chat completions (streaming, tool calling, JSON schema), completions, embeddings, model listing. Optional Bearer auth.
 - **Built-in chat UI** — llama.cpp's native chat interface with a model-selector dropdown.
 - **Agent CLI** — Lightweight terminal chat client (`cmd/agent`) with optional filesystem tool use.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A web-based management interface for [llama.cpp](https://github.com/ggerganov/ll
 - **Speculative decoding** — Pair a small draft model with a large model; draft picker auto-filters by architecture.
 - **Capability detection** — Tool calling, vision, and reasoning-mode detection from GGUF metadata, surfaced as badges and via the `capabilities` block on `/api/service/loaded-models` (single-round-trip auto-discovery).
 - **VRAM estimation** — Architecture-aware estimates from GGUF metadata, accounting for KV cache size and quantization.
+- **Measured memory** — What llama.cpp really allocated on the last load — weights, KV cache and working buffers, per GPU — read from its own buffer report and shown beside the estimate in the Available Models tooltip. Needs *Model loading detail* 4 in Settings.
 - **Benchmarks** — Batch jobs sweeping models × builds × presets × any model parameter, with results compared across runs and exported to CSV/JSON.
 - **OpenAI-compatible API** — Chat completions (streaming, tool calling, JSON schema), completions, embeddings, model listing. Optional Bearer auth.
 - **Built-in chat UI** — llama.cpp's native chat interface with a model-selector dropdown.

--- a/internal/api/bench_export.go
+++ b/internal/api/bench_export.go
@@ -29,7 +29,10 @@ type ExportEnvelope struct {
 
 // v2: runs carry size_gib / gpus[].vram_total_mib instead of the
 // misnamed size_gb / vram_total_mb (the values were always binary units).
-const exportEnvelopeVersion = 2
+// v3: runs may carry `memory` — what the load actually allocated,
+// itemised. Absent on every run recorded before it was measured, and on
+// any run whose router was below log verbosity 4.
+const exportEnvelopeVersion = 3
 
 const (
 	exportFormatCSV  = "csv"
@@ -69,6 +72,36 @@ func formatSweepValues(values map[string]string) string {
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, " ")
+}
+
+// memoryExportFields renders a run's measured footprint as the six
+// memory columns, in header order. A run with nothing measured gets six
+// empty strings rather than zeros: llama.cpp reports its buffers only at
+// log verbosity 4, and a zero would read as "this model used no memory"
+// instead of "nobody looked".
+//
+// card_gib is empty for a load that overlapped another, because that
+// figure covers both models. The per-instance columns beside it are
+// still that model's own.
+func memoryExportFields(m *benchmark.MemorySnapshot) []string {
+	if m == nil {
+		return []string{"", "", "", "", "", ""}
+	}
+	card := ""
+	if m.CardDeltaGiB > 0 {
+		card = ftoa(m.CardDeltaGiB)
+	}
+	return []string{
+		ftoa(m.GPUGiB), ftoa(m.WeightsGiB), ftoa(m.KVGiB),
+		ftoa(m.ComputeGiB), ftoa(m.HostGiB), card,
+	}
+}
+
+// memoryExportHeader names those columns. GiB throughout, matching the
+// model sizes already in these exports.
+var memoryExportHeader = []string{
+	"mem_gpu_gib", "mem_weights_gib", "mem_kv_gib",
+	"mem_compute_gib", "mem_host_gib", "mem_card_gib",
 }
 
 // jobByID looks up a job pointer in a slice without scanning twice.
@@ -171,6 +204,8 @@ func writeCSVCells(cw *csv.Writer, runs []benchmark.BenchmarkRun, jobs jobLookup
 		"preset", "sweep",
 		"eval_mode", "eval_dataset", "eval_score", "eval_error",
 		"eval_tasks_chunks", "eval_kl_stats", "eval_reference",
+		"mem_gpu_gib", "mem_weights_gib", "mem_kv_gib",
+		"mem_compute_gib", "mem_host_gib", "mem_card_gib",
 		"source",
 		"prompt_tokens", "gen_tokens", "depth", "concurrency", "repetition",
 		"pp_throughput", "pp_throughput_std",
@@ -195,6 +230,9 @@ func writeCSVCells(cw *csv.Writer, runs []benchmark.BenchmarkRun, jobs jobLookup
 			run.Preset, formatSweepValues(run.SweepValues),
 		}
 		base = append(base, evalExportFields(run.Eval)...)
+		// Memory is a property of the load, so it repeats on every row
+		// of a run — the same way build and preset do.
+		base = append(base, memoryExportFields(run.Memory)...)
 
 		if len(run.Results) > 0 {
 			for _, r := range run.Results {
@@ -254,6 +292,8 @@ func writeCSVSummary(cw *csv.Writer, runs []benchmark.BenchmarkRun, jobs jobLook
 		"preset", "sweep",
 		"eval_mode", "eval_dataset", "eval_score", "eval_error",
 		"eval_tasks_chunks", "eval_kl_stats", "eval_reference",
+		"mem_gpu_gib", "mem_weights_gib", "mem_kv_gib",
+		"mem_compute_gib", "mem_host_gib", "mem_card_gib",
 		"source", "status",
 		"avg_pp_throughput", "avg_tg_throughput", "avg_ttft_ms",
 		"min_tg_throughput", "max_tg_throughput",
@@ -290,6 +330,7 @@ func writeCSVSummary(cw *csv.Writer, runs []benchmark.BenchmarkRun, jobs jobLook
 			run.Preset, formatSweepValues(run.SweepValues),
 		}
 		row = append(row, evalExportFields(run.Eval)...)
+		row = append(row, memoryExportFields(run.Memory)...)
 		row = append(row, source, run.Status,
 			avgPP, avgTG, avgTTFT,
 			minTG, maxTG,

--- a/internal/api/bench_export_memory_test.go
+++ b/internal/api/bench_export_memory_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
+)
+
+// memoryRuns is the flag-comparison pair with a footprint on the first
+// run only: one measured load, one recorded before memory existed.
+func memoryRuns() ([]benchmark.BenchmarkRun, jobLookup) {
+	runs, jobs := twoBuildRuns()
+	runs[0].Memory = &benchmark.MemorySnapshot{
+		GPUGiB: 23.0, WeightsGiB: 20.0, KVGiB: 2.0, ComputeGiB: 1.0,
+		HostGiB: 1.5, CardDeltaGiB: 24.5, Cards: 4,
+	}
+	return runs, jobs
+}
+
+func TestCSVCellsCarryTheMeasuredFootprint(t *testing.T) {
+	runs, jobs := memoryRuns()
+	rows := parseCSV(t, func(cw *csv.Writer) error {
+		return writeCSVCells(cw, runs, jobs)
+	})
+
+	for col, want := range map[string]string{
+		"mem_gpu_gib":     "23",
+		"mem_weights_gib": "20",
+		"mem_kv_gib":      "2",
+		"mem_compute_gib": "1",
+		"mem_host_gib":    "1.5",
+		"mem_card_gib":    "24.5",
+	} {
+		idx := columnIndex(t, rows[0], col)
+		if rows[1][idx] != want {
+			t.Errorf("%s = %q; want %q", col, rows[1][idx], want)
+		}
+		// The second run measured nothing. Empty, not zero: a zero
+		// would read as "this model used no memory".
+		if rows[2][idx] != "" {
+			t.Errorf("%s on an unmeasured run = %q; want empty", col, rows[2][idx])
+		}
+	}
+}
+
+func TestCSVSummaryCarriesTheMeasuredFootprint(t *testing.T) {
+	runs, jobs := memoryRuns()
+	rows := parseCSV(t, func(cw *csv.Writer) error {
+		return writeCSVSummary(cw, runs, jobs)
+	})
+	idx := columnIndex(t, rows[0], "mem_gpu_gib")
+	if rows[1][idx] != "23" {
+		t.Errorf("mem_gpu_gib = %q; want 23", rows[1][idx])
+	}
+	if rows[2][idx] != "" {
+		t.Errorf("unmeasured run reports %q", rows[2][idx])
+	}
+}
+
+// A card figure taken while another model was loading covers both of
+// them. The per-instance columns beside it are still sound, so the run
+// is exported with the unattributable column blank rather than dropped.
+func TestCSVLeavesTheCardColumnBlankForAContendedLoad(t *testing.T) {
+	runs, jobs := memoryRuns()
+	runs[0].Memory.Contended = true
+	runs[0].Memory.CardDeltaGiB = 0
+
+	rows := parseCSV(t, func(cw *csv.Writer) error {
+		return writeCSVCells(cw, runs, jobs)
+	})
+	if got := rows[1][columnIndex(t, rows[0], "mem_card_gib")]; got != "" {
+		t.Errorf("mem_card_gib = %q; want empty for a contended load", got)
+	}
+	if got := rows[1][columnIndex(t, rows[0], "mem_gpu_gib")]; got != "23" {
+		t.Errorf("mem_gpu_gib = %q; the buffer report survives contention", got)
+	}
+}
+
+func TestJSONExportCarriesTheMeasuredFootprint(t *testing.T) {
+	runs, _ := memoryRuns()
+	env := ExportEnvelope{Version: exportEnvelopeVersion, Runs: runs}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(b)
+
+	if !strings.Contains(out, `"memory":{"gpu_gib":23,"weights_gib":20,"kv_gib":2,"compute_gib":1,"host_gib":1.5,"card_gib":24.5,"cards":4}`) {
+		t.Errorf("the footprint is not in the JSON export as expected:\n%s", out)
+	}
+	// The unmeasured run omits the key entirely rather than exporting a
+	// block of zeros.
+	if strings.Count(out, `"memory"`) != 1 {
+		t.Errorf("an unmeasured run emitted a memory block:\n%s", out)
+	}
+	if env.Version < 3 {
+		t.Error("the envelope version must advertise that runs may carry a footprint")
+	}
+}

--- a/internal/api/bench_memory_render_test.go
+++ b/internal/api/bench_memory_render_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
+	"github.com/tmac1973/llama-toolchest/web"
+)
+
+func benchTemplates(t *testing.T) *template.Template {
+	t.Helper()
+	base, err := template.New("").Funcs(testFuncMap).ParseFS(web.Templates,
+		"templates/layout.html", "templates/partials/*.html")
+	if err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+	return base
+}
+
+func measuredRun(id string) benchmark.BenchmarkRun {
+	r := perfRun(id)
+	r.Memory = &benchmark.MemorySnapshot{
+		GPUGiB: 23.0, WeightsGiB: 20.0, KVGiB: 2.0, ComputeGiB: 1.0,
+		HostGiB: 1.0, CardDeltaGiB: 24.5, Cards: 4,
+	}
+	return r
+}
+
+// The compare table's VRAM column is the headline of this feature: the
+// memory each configuration in a sweep actually used, beside its speed.
+func TestCompareTableShowsMeasuredMemory(t *testing.T) {
+	data := benchmark.BuildComparison([]benchmark.BenchmarkRun{measuredRun("r1")})
+	var buf bytes.Buffer
+	if err := benchTemplates(t).ExecuteTemplate(&buf, "benchmark_compare", data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, ">VRAM</th>") {
+		t.Errorf("no VRAM column in the compare table\n%s", out)
+	}
+	if !strings.Contains(out, ">23.0</td>") {
+		t.Errorf("the measured figure is missing from the row\n%s", out)
+	}
+	// The number alone does not say what it counts; the tooltip must.
+	for _, want := range []string{
+		"20.0 weights", "2.0 KV cache", "1.0 working buffers",
+		"cards themselves reported 24.5 GiB",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("tooltip missing %q\n%s", want, out)
+		}
+	}
+}
+
+// A run from before this was measured must read as absent, not as zero.
+func TestCompareTableShowsAnEmDashWhenNothingWasMeasured(t *testing.T) {
+	data := benchmark.BuildComparison([]benchmark.BenchmarkRun{perfRun("r1")})
+	var buf bytes.Buffer
+	if err := benchTemplates(t).ExecuteTemplate(&buf, "benchmark_compare", data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+
+	if strings.Contains(out, ">0.0</td>") {
+		t.Errorf("an unmeasured run is rendering as 0.0 GiB\n%s", out)
+	}
+	if !strings.Contains(out, "Model loading detail") {
+		t.Errorf("the tooltip should say why there is no figure\n%s", out)
+	}
+}
+
+func TestRunDetailShowsTheMemoryBreakdown(t *testing.T) {
+	run := measuredRun("r1")
+	var buf bytes.Buffer
+	if err := benchTemplates(t).ExecuteTemplate(&buf, "benchmark_detail", &run); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"Memory used", "23.0 GiB on the GPUs", "20.0 weights",
+		"1.0 GiB in system memory", "Cards reported 24.5 GiB",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("detail view missing %q\n%s", want, out)
+		}
+	}
+}
+
+// A load that overlapped another keeps its own buffer figures but has no
+// attributable card total, and the view has to say which is which.
+func TestRunDetailFlagsAContendedLoad(t *testing.T) {
+	run := measuredRun("r1")
+	run.Memory.Contended = true
+	run.Memory.CardDeltaGiB = 0
+	var buf bytes.Buffer
+	if err := benchTemplates(t).ExecuteTemplate(&buf, "benchmark_detail", &run); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "23.0 GiB on the GPUs") {
+		t.Errorf("the per-instance figures survive contention\n%s", out)
+	}
+	if !strings.Contains(out, "could not be attributed") {
+		t.Errorf("the detail view does not say the card total is unusable\n%s", out)
+	}
+	if strings.Contains(out, "Cards reported") {
+		t.Errorf("a contended run must not show a card total\n%s", out)
+	}
+}
+
+func TestRunDetailWithoutAMeasurement(t *testing.T) {
+	run := perfRun("r1")
+	var buf bytes.Buffer
+	if err := benchTemplates(t).ExecuteTemplate(&buf, "benchmark_detail", &run); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Not measured") {
+		t.Errorf("detail view should say nothing was measured\n%s", buf.String())
+	}
+}

--- a/internal/api/bench_memory_render_test.go
+++ b/internal/api/bench_memory_render_test.go
@@ -124,3 +124,85 @@ func TestRunDetailWithoutAMeasurement(t *testing.T) {
 		t.Errorf("detail view should say nothing was measured\n%s", buf.String())
 	}
 }
+
+// sweepRun is one cell of a single-parameter sweep: everything about it
+// is the same as its siblings except the swept value.
+func sweepRun(id, ubatch string, gen float64) benchmark.BenchmarkRun {
+	r := measuredRun(id)
+	r.SweepValues = map[string]string{"ubatch_size": ubatch}
+	r.Summary.AvgGenTokPerSec = gen
+	r.Config = benchmark.ConfigSnapshot{
+		ContextSize: 32768, BatchSize: 2048, UBatchSize: 512,
+		GPUAssign: "all", FlashAttention: true,
+	}
+	return r
+}
+
+// A one-parameter sweep leaves most of the table repeating itself, and
+// those columns are what push the compared numbers off the side of the
+// page. They are hidden, and stated once above the table.
+func TestCompareTableHidesColumnsEveryRunShares(t *testing.T) {
+	data := benchmark.BuildComparison([]benchmark.BenchmarkRun{
+		sweepRun("r1", "128", 40), sweepRun("r2", "512", 55),
+	})
+	var buf bytes.Buffer
+	if err := benchTemplates(t).ExecuteTemplate(&buf, "benchmark_compare", data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, `<th class="bc-const">Quant</th>`) {
+		t.Errorf("Quant is identical in both runs and should be marked constant\n%s", out)
+	}
+	if !strings.Contains(out, `<th class="" title="Which point of a parameter sweep`) {
+		t.Errorf("the swept column must not be marked constant\n%s", out)
+	}
+	if !strings.Contains(out, "The same for every run:") {
+		t.Errorf("the collapsed columns are not stated above the table\n%s", out)
+	}
+	if !strings.Contains(out, "flash attention <kbd>yes</kbd>") {
+		t.Errorf("a collapsed column's shared value is missing from the summary\n%s", out)
+	}
+	// Hidden, not dropped: the toggle puts them back with no round trip.
+	if !strings.Contains(out, "hide-constant") || !strings.Contains(out, "toggleConstantColumns") {
+		t.Errorf("the reveal control is missing\n%s", out)
+	}
+}
+
+// With one run there is nothing to compare, so nothing is redundant.
+func TestCompareTableKeepsEveryColumnForASingleRun(t *testing.T) {
+	data := benchmark.BuildComparison([]benchmark.BenchmarkRun{sweepRun("r1", "128", 40)})
+	var buf bytes.Buffer
+	if err := benchTemplates(t).ExecuteTemplate(&buf, "benchmark_compare", data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+	// The class appears once in the stylesheet regardless; what matters
+	// is that no cell carries it.
+	if strings.Contains(out, `class="bc-const"`) {
+		t.Errorf("a single run had columns collapsed\n%s", out)
+	}
+	if strings.Contains(out, "The same for every run:") {
+		t.Errorf("nothing should be summarised away for a single run\n%s", out)
+	}
+}
+
+// The capability row used to span the six columns after VRAM. A span
+// cannot carry a per-column class, so hiding one column would leave that
+// row a different width from the header.
+func TestCapabilityRowHasOneCellPerColumn(t *testing.T) {
+	ev := perfRun("r-ev")
+	ev.Summary = nil
+	ev.Eval = &benchmark.EvalScores{
+		Mode: "perplexity", Dataset: "wikitext-2", ContextSize: 512,
+		Chunks: 100, Perplexity: 6.234, PerplexityErr: 0.04,
+	}
+	data := benchmark.BuildComparison([]benchmark.BenchmarkRun{ev, measuredRun("r-perf")})
+	var buf bytes.Buffer
+	if err := benchTemplates(t).ExecuteTemplate(&buf, "benchmark_compare", data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.Contains(buf.String(), "colspan=") {
+		t.Errorf("the capability row still spans columns\n%s", buf.String())
+	}
+}

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tmac1973/llama-toolchest/internal/benchmark"
 	"github.com/tmac1973/llama-toolchest/internal/builder"
 	"github.com/tmac1973/llama-toolchest/internal/evaluate"
+	"github.com/tmac1973/llama-toolchest/internal/memreport"
 	"github.com/tmac1973/llama-toolchest/internal/models"
 	"github.com/tmac1973/llama-toolchest/internal/monitor"
 )
@@ -723,6 +724,43 @@ func (e *jobEnv) ResolveBuild(buildID string) benchmark.BuildSnapshot {
 }
 
 func (e *jobEnv) CurrentMetrics() monitor.Metrics { return e.s.monitor.Current() }
+
+// MeasuredMemory hands the cell what llama.cpp reported allocating for
+// this model's current load. The collector is already watching the
+// router log for the Available Models tooltip; a benchmark cell is just
+// another load, so the figure is there for the asking.
+func (e *jobEnv) MeasuredMemory(modelID string) (benchmark.MemorySnapshot, bool) {
+	m, err := e.s.registry.Get(modelID)
+	if err != nil {
+		return benchmark.MemorySnapshot{}, false
+	}
+	meas, note, ok := e.s.measurementFor(m)
+	if !ok || len(meas.Report.Entries) == 0 {
+		return benchmark.MemorySnapshot{}, false
+	}
+	cards := note.cards
+	if cards < 1 {
+		cards = 1
+	}
+	report := meas.Report.ScaleAggregates(cards)
+
+	snap := benchmark.MemorySnapshot{
+		GPUGiB:     gib(report.GPUMiB(true)),
+		WeightsGiB: gib(gpuOf(report, memreport.KindModel)),
+		KVGiB:      gib(gpuOf(report, memreport.KindKV) + gpuOf(report, memreport.KindRecurrent)),
+		ComputeGiB: gib(gpuOf(report, memreport.KindCompute) + gpuOf(report, memreport.KindOutput)),
+		HostGiB:    gib(report.HostMiB(true)),
+		Cards:      cards,
+		Contended:  note.contended,
+	}
+	// A card figure taken while a second model was loading describes
+	// both of them. Recording it would put a number in a results table
+	// that nothing supports, so it is left out and the reason kept.
+	if !note.contended {
+		snap.CardDeltaGiB = note.measuredGiB()
+	}
+	return snap, true
+}
 
 func (e *jobEnv) RouterURL() string {
 	return fmt.Sprintf("http://localhost:%d", e.s.cfg.LlamaPort)

--- a/internal/api/js_params_test.go
+++ b/internal/api/js_params_test.go
@@ -86,13 +86,15 @@ func mustRead(t *testing.T, path string) string {
 	return string(b)
 }
 
-// extractFunctions pulls named top-level function declarations out of a
-// source blob by brace matching.
+// extractFunctions pulls named function declarations out of a source
+// blob by brace matching. Leading indentation is allowed: a page whose
+// script lives inside an IIFE (visualize.html) declares its functions
+// indented, and they are just as testable.
 func extractFunctions(src string, names []string) (string, []string) {
 	var out strings.Builder
 	var missing []string
 	for _, n := range names {
-		re := regexp.MustCompile(`(?m)^function ` + n + `\(`)
+		re := regexp.MustCompile(`(?m)^[ \t]*function ` + n + `\(`)
 		loc := re.FindStringIndex(src)
 		if loc == nil {
 			missing = append(missing, n)

--- a/internal/api/js_visualize_test.go
+++ b/internal/api/js_visualize_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestVisualizeMetricFilterJS runs the visualization page's
+// point-filtering against a stub.
+//
+// It exists because the failure it guards is invisible from Go: a run
+// that carries no memory figure reaches Plotly as `undefined`, the
+// formatter throws inside a library callback, and the page renders with
+// an empty chart and nothing in the console to say why. Template
+// rendering tests cannot see that; only running the function can.
+//
+// Skipped when node isn't installed. `make js-test` covers both this and
+// the job form's parameter controls.
+func TestVisualizeMetricFilterJS(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not installed; skipping visualization JS test")
+	}
+
+	src, err := os.ReadFile(filepath.Join("..", "..", "web", "templates", "visualize.html"))
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+	blocks := regexp.MustCompile(`(?s)<script>(.*?)</script>`).FindAllStringSubmatch(string(src), -1)
+	if len(blocks) == 0 {
+		t.Fatal("no <script> block found in visualize.html")
+	}
+	var js strings.Builder
+	for _, b := range blocks {
+		js.WriteString(regexp.MustCompile(`\{\{[^}]*\}\}`).ReplaceAllString(b[1], "0"))
+		js.WriteString("\n")
+	}
+
+	extracted, missing := extractFunctions(js.String(), []string{"pointsWith"})
+	if len(missing) > 0 {
+		t.Fatalf("functions not found in visualize.html (renamed or removed?): %v", missing)
+	}
+	// The function reads the page's DATA; the runner supplies its own.
+	extracted = "var DATA;\n" + extracted
+
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"viz.js": extracted,
+		"dom.js": mustRead(t, filepath.Join("..", "..", "web", "jstest", "dom.js")),
+		"run.js": mustRead(t, filepath.Join("..", "..", "web", "jstest", "viz_test.js")),
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	cmd := exec.Command(node, filepath.Join(dir, "run.js"))
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("visualization JS failed:\n%s", out)
+	}
+	if !strings.Contains(string(out), "ALL PASS") {
+		t.Fatalf("unexpected JS test output:\n%s", out)
+	}
+}

--- a/internal/api/memory_measured.go
+++ b/internal/api/memory_measured.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
 	"github.com/tmac1973/llama-toolchest/internal/memreport"
 	"github.com/tmac1973/llama-toolchest/internal/models"
 	"github.com/tmac1973/llama-toolchest/internal/monitor"
@@ -373,3 +374,34 @@ func join(lines ...string) string {
 	return strings.Join(lines, "\n")
 }
 
+// memText is a benchmark run's measured GPU footprint as a table cell.
+func memText(m *benchmark.MemorySnapshot) string {
+	if m == nil {
+		return "—"
+	}
+	return fmt.Sprintf("%.1f", m.GPUGiB)
+}
+
+// memDetail is the breakdown behind that cell, for its tooltip. Every
+// figure the run recorded, said in full, because a single number in a
+// results table is exactly where a reader needs to know what it counts.
+func memDetail(m *benchmark.MemorySnapshot) string {
+	if m == nil {
+		return "Not measured. llama.cpp reports what it allocated only when Model loading detail is set to 4 or higher, on the Settings page, and runs recorded before that was captured have nothing to show."
+	}
+	lines := []string{
+		fmt.Sprintf("%.1f GiB of GPU memory across %d card(s) — %.1f weights, %.1f KV cache, %.1f working buffers.",
+			m.GPUGiB, m.Cards, m.WeightsGiB, m.KVGiB, m.ComputeGiB),
+	}
+	if m.HostGiB >= 0.05 {
+		lines = append(lines, fmt.Sprintf("Another %.1f GiB in system memory.", m.HostGiB))
+	}
+	switch {
+	case m.Contended:
+		lines = append(lines, "Another model was loading at the same time, so the card counters could not be attributed to this load. The figures above are this model's own — llama.cpp reports them per instance.")
+	case m.CardDeltaGiB > 0:
+		lines = append(lines, fmt.Sprintf("The cards themselves reported %.1f GiB, %.1f more than llama.cpp itemises: context and allocator overhead it does not count.",
+			m.CardDeltaGiB, m.Unreported()))
+	}
+	return join(lines...)
+}

--- a/internal/api/memory_measured.go
+++ b/internal/api/memory_measured.go
@@ -1,0 +1,375 @@
+package api
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tmac1973/llama-toolchest/internal/memreport"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/monitor"
+)
+
+// What a model really costs, as opposed to what it was predicted to
+// cost. The estimate in models.VRAMEstimateForConfigOn is a model of a
+// load; this is the load itself, read off the buffer report llama.cpp
+// prints while allocating.
+//
+// The stream it reads is the router's combined log, already broadcast to
+// the Server Logs panel. Nothing extra is launched or polled: one
+// subscriber, started with the server and running for its lifetime.
+
+// memoryVerbosityRequired is the LLAMA_ARG_LOG_VERBOSITY at which
+// llama.cpp starts printing the per-buffer report. Below it there is
+// nothing to measure — see internal/config.RuntimeEnvOptions, where the
+// setting is exposed, and internal/memreport for the report itself.
+const memoryVerbosityRequired = 4
+
+// loadNote is what the configuration was when a load started. Held
+// alongside the measurement because a measurement without it says how
+// much memory something took without saying what that something was:
+// halve the context and the same model measures differently.
+//
+// Recorded at spawn time rather than read back later, since the user may
+// edit the config while the model is still loaded.
+type loadNote struct {
+	modelID string
+	// cards is how many GPUs the load was spread over, needed to turn a
+	// tensor-parallel report (which states per-card figures) into totals.
+	cards int
+	// fingerprint is the memory-relevant part of the launch config.
+	fingerprint string
+	// baselineGiB and loadedGiB are the card counters summed across GPUs,
+	// read when the load started and once it reported ready. Their
+	// difference is the quantity the VRAM estimate predicts — which is
+	// not the same as the buffer report, since llama.cpp itemises
+	// neither context nor allocator overhead.
+	baselineGiB float64
+	loadedGiB   float64
+	// cfg is the config the load ran under, kept whole so a corpus row
+	// can be written from it rather than from what is set now.
+	cfg *models.ModelConfig
+	// contended records that another model was loading during this one,
+	// so the card difference covers both. Such a load still measures its
+	// own buffers correctly — those are attributed per instance — but its
+	// card figure is not evidence of anything.
+	contended bool
+}
+
+// measuredGiB is the card-counter difference across the load, or zero if
+// either end of it is missing.
+func (n loadNote) measuredGiB() float64 {
+	if n.baselineGiB == 0 || n.loadedGiB == 0 {
+		return 0
+	}
+	return n.loadedGiB - n.baselineGiB
+}
+
+// watchRouterMemory feeds every router log line to the collector for the
+// life of the server. Started once, from NewServer.
+//
+// The subscription replays whatever the log broadcaster still holds,
+// which is how a measurement survives the router outliving a page load;
+// it costs nothing here because the collector keys loads by port and a
+// replayed spawn line simply rebuilds the same record.
+func (s *Server) watchRouterMemory() {
+	ch := s.process.Subscribe()
+	for line := range ch {
+		switch ev := s.memory.Add(line); ev.Kind {
+		case memreport.EventSpawned:
+			// Between this line and the buffer report is the whole load,
+			// so there is time to resolve the model; doing it here rather
+			// than at render time is what pins the note to the
+			// configuration the instance was actually launched with, and
+			// the card counters to the state before it allocated.
+			note := s.loadNoteFor(ev.Model)
+			note.baselineGiB = s.gpuUsedGiB()
+			note.contended = s.memory.InFlight() > 1
+			s.memory.Annotate(ev.Port, note)
+		case memreport.EventReady:
+			// Reading the counters means waiting for the monitor's next
+			// sample. Waiting here would stall the log reader, and a
+			// subscriber that falls behind loses lines rather than
+			// slowing the producer — so the buffer report of whatever
+			// loads next would be the thing lost.
+			go s.recordCardCounters(ev.Model, ev.Port)
+		}
+	}
+}
+
+// recordCardCounters completes a load's note with what the GPUs report
+// now that it has finished allocating.
+func (s *Server) recordCardCounters(model, port string) {
+	used, ok := s.gpuUsedAfterFreshSample(monitorSampleWait)
+	if !ok {
+		return
+	}
+	meas, found := s.memory.Latest(model)
+	if !found || meas.Port != port {
+		// The model has been unloaded and loaded again since. The note
+		// being completed belongs to a load nobody can ask about now.
+		return
+	}
+	note, _ := meas.Note.(loadNote)
+	note.loadedGiB = used
+	if s.memory.InFlight() > 0 {
+		// Something else started loading while this one finished, so the
+		// difference across this load covers more than this model.
+		note.contended = true
+	}
+	s.memory.Annotate(port, note)
+}
+
+// monitorSampleWait is how long to wait for the monitor's next reading
+// before giving up on the card counters for a load. The monitor polls
+// every few seconds; a load that finishes just after a poll waits nearly
+// a whole interval.
+const monitorSampleWait = 15 * time.Second
+
+// gpuUsedGiB is what the cards report in use right now, summed. Read
+// from the monitor's last poll, so it is up to one interval old — which
+// is what makes it a baseline rather than a measurement: nothing has
+// been allocated yet at the moment it is taken.
+func (s *Server) gpuUsedGiB() float64 {
+	return usedGiB(s.monitor.Current())
+}
+
+// gpuUsedAfterFreshSample waits for a reading taken after this call, so
+// the figure includes the allocation that just finished rather than
+// whatever the last poll happened to catch mid-load.
+func (s *Server) gpuUsedAfterFreshSample(timeout time.Duration) (float64, bool) {
+	ch := s.monitor.Subscribe()
+	defer s.monitor.Unsubscribe(ch)
+	select {
+	case m := <-ch:
+		return usedGiB(m), true
+	case <-time.After(timeout):
+		return 0, false
+	}
+}
+
+func usedGiB(m monitor.Metrics) float64 {
+	var total float64
+	for _, g := range m.GPU {
+		total += float64(g.VRAMUsedMB) / 1024
+	}
+	return total
+}
+
+// loadNoteFor resolves a router model name to the configuration it was
+// launched under.
+func (s *Server) loadNoteFor(routerName string) loadNote {
+	m, cfg := s.findModelByAny(routerName)
+	if m == nil {
+		return loadNote{}
+	}
+	// The router reads preset.ini only when it starts, so a child is
+	// launched with the config as it stood then — not with an edit made
+	// since. Prefer the snapshot for exactly that reason.
+	if snap, ok := s.runningConfigFor(m.ID); ok && snap != nil {
+		cfg = snap
+	}
+	// Copied, not referenced: without a snapshot this is the registry's
+	// own struct, which the config handler mutates in place.
+	launched := *cfg
+	return loadNote{
+		modelID:     m.ID,
+		cards:       models.DeviceCountForConfig(cfg, len(s.monitor.Current().GPU)),
+		fingerprint: memoryFingerprint(cfg),
+		cfg:         &launched,
+	}
+}
+
+// memoryFingerprint reduces a config to the fields that change how much
+// memory a load takes. Two loads with the same fingerprint are
+// comparable; a measurement whose fingerprint no longer matches
+// describes a configuration that is no longer set.
+//
+// Deliberately not a hash: it is compared, never stored, and a readable
+// value is worth having in a log line.
+func memoryFingerprint(cfg *models.ModelConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	return fmt.Sprintf(
+		"ctx=%d par=%d b=%d ub=%d kv=%s fa=%t ngl=%d gpus=%s split=%s/%s main=%d ple=%s mmproj=%s/%t spec=%s draft=%s mtp=%s/%t dctx=%d dngl=%d ddev=%s dmoe=%d dkv=%s extra=%s",
+		cfg.ContextSize, cfg.Parallel, cfg.EffectiveBatchSize(), cfg.EffectiveUBatchSize(),
+		cfg.KVCacheQuant, cfg.FlashAttention, cfg.GPULayers, cfg.GPUAssign,
+		cfg.SplitMode, cfg.TensorSplit, cfg.MainGPU, cfg.PLEMode,
+		cfg.MmprojPath, cfg.MmprojDisabled,
+		cfg.SpecType, cfg.DraftModelPath, cfg.MtpPath, cfg.MtpDisabled,
+		cfg.DraftCtxSize, cfg.DraftGPULayers, cfg.DraftDevice, cfg.DraftCPUMoE, cfg.DraftKVCacheQuant,
+		cfg.ExtraFlags,
+	)
+}
+
+// logVerbosity returns the LLAMA_ARG_LOG_VERBOSITY the router will run
+// with, which the router passes on to every model instance it starts.
+// llama.cpp's own default is 3.
+func (s *Server) logVerbosity() int {
+	s.cfgMu.Lock()
+	pairs := s.cfg.RuntimeEnvPairs()
+	s.cfgMu.Unlock()
+
+	for _, kv := range pairs {
+		name, value, ok := strings.Cut(kv, "=")
+		if !ok || name != "LLAMA_ARG_LOG_VERBOSITY" {
+			continue
+		}
+		if n, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
+			return n
+		}
+	}
+	return 3
+}
+
+// measurementFor returns the last load measured for a model. Names are
+// tried the way routerStateFor tries them: the registry id is what the
+// preset section — and so the router's spawn line — uses, but an
+// installation that addresses a model by another name should still find
+// its own measurement.
+func (s *Server) measurementFor(m *models.Model) (memreport.Measurement, loadNote, bool) {
+	if m == nil {
+		return memreport.Measurement{}, loadNote{}, false
+	}
+	for _, name := range []string{s.registry.RouterName(m.ID), m.ID, m.PublicName()} {
+		if name == "" {
+			continue
+		}
+		meas, ok := s.memory.Latest(name)
+		if !ok {
+			continue
+		}
+		note, _ := meas.Note.(loadNote)
+		if note.modelID != "" && note.modelID != m.ID {
+			// The name matched a load belonging to another model — an
+			// alias two models both answer to, say. Reporting its
+			// memory here would be worse than reporting none.
+			continue
+		}
+		return meas, note, true
+	}
+	return memreport.Measurement{}, loadNote{}, false
+}
+
+// memoryTooltip is the text behind one row of the Available Models card:
+// what the model took when it was last loaded, next to what it was
+// predicted to take, with a plain statement of which one you are reading.
+//
+// state is the router's word for the model — "loaded", "loading", or
+// empty for a model the router knows but has not loaded.
+func (s *Server) memoryTooltip(m *models.Model, cfg *models.ModelConfig, state string) string {
+	if m == nil {
+		return ""
+	}
+	cards := models.DeviceCountForConfig(cfg, len(s.monitor.Current().GPU))
+	estimate := fmt.Sprintf("Estimated for the current settings: %.1f GiB.",
+		models.VRAMEstimateForConfigOn(m, cfg, cards))
+
+	meas, note, ok := s.measurementFor(m)
+	if !ok || len(meas.Report.Entries) == 0 {
+		if state == "loading" {
+			return join("Loading. What it really takes is shown once llama.cpp has finished reporting its buffers.", estimate)
+		}
+		if s.logVerbosity() < memoryVerbosityRequired {
+			return join(
+				"Not measured. llama.cpp only reports what it allocated when Model loading detail is set to 4 or higher, on the Settings page.",
+				estimate)
+		}
+		return join("Not measured yet — load the model and this shows what llama.cpp allocated for it.", estimate)
+	}
+
+	// A tensor-parallel load states its figures per card. Scale before
+	// totalling, or a model spread over four GPUs reads as a quarter of
+	// its size.
+	report := meas.Report.ScaleAggregates(note.cards)
+	gpu := gib(report.GPUMiB(true))
+	host := gib(report.HostMiB(true))
+
+	lead := "Measured while loading"
+	if note.fingerprint != "" && note.fingerprint != memoryFingerprint(cfg) {
+		lead = "Measured when it was last loaded, under settings that have since changed — restart the server and load it again to measure the current ones"
+	}
+
+	// The three terms are every kind llama.cpp reports, so they add up to
+	// the total: recurrent state is part of what the model remembers, and
+	// the output buffer is part of what a graph needs to run.
+	lines := []string{
+		fmt.Sprintf("%s: %.1f GiB of GPU memory — %.1f weights, %.1f KV cache, %.1f working buffers.",
+			lead, gpu,
+			gib(gpuOf(report, memreport.KindModel)),
+			gib(gpuOf(report, memreport.KindKV)+gpuOf(report, memreport.KindRecurrent)),
+			gib(gpuOf(report, memreport.KindCompute)+gpuOf(report, memreport.KindOutput))),
+	}
+	if where := deviceSummary(report, note.cards); where != "" {
+		lines = append(lines, where)
+	}
+	if host >= 0.05 {
+		lines = append(lines, fmt.Sprintf("Another %.1f GiB sits in system memory.", host))
+	}
+	lines = append(lines, estimate)
+	lines = append(lines, "The measured figure is llama.cpp's own accounting. A card's reported usage runs a few hundred MiB per GPU above it, for driver overhead llama.cpp does not count.")
+	return join(lines...)
+}
+
+// gib converts a MiB figure to GiB.
+func gib(mib float64) float64 { return mib / 1024 }
+
+// gpuOf totals one kind of allocation on the accelerators only. The host
+// side of the same kind is reported separately, since a layer that spilled
+// to system memory costs no VRAM.
+func gpuOf(r memreport.Report, kind memreport.Kind) float64 {
+	return r.SumMiB(func(e memreport.Entry) bool { return e.Kind == kind && e.OnGPU() })
+}
+
+// deviceSummary says where the memory went. An aggregate report cannot
+// say which card holds what — llama.cpp addresses the group as one
+// device — so it reports the spread instead of a breakdown.
+func deviceSummary(r memreport.Report, cards int) string {
+	var aggregate bool
+	parts := map[string]float64{}
+	for _, e := range r.Entries {
+		if !e.OnGPU() {
+			continue
+		}
+		if e.IsAggregate() {
+			aggregate = true
+			continue
+		}
+		parts[e.Device] += e.MiB
+	}
+	if aggregate {
+		if cards > 1 {
+			return fmt.Sprintf("Spread evenly across %d GPUs.", cards)
+		}
+		return ""
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(parts))
+	for d := range parts {
+		names = append(names, d)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	b.WriteString("Per GPU: ")
+	for i, d := range names {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s %.1f GiB", d, gib(parts[d]))
+	}
+	b.WriteString(".")
+	return b.String()
+}
+
+// join builds the tooltip body. Newlines survive in a title attribute in
+// every browser this UI targets, and one fact per line is easier to read
+// than a paragraph.
+func join(lines ...string) string {
+	return strings.Join(lines, "\n")
+}
+

--- a/internal/api/memory_measured_test.go
+++ b/internal/api/memory_measured_test.go
@@ -1,0 +1,275 @@
+package api
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tmac1973/llama-toolchest/internal/config"
+	"github.com/tmac1973/llama-toolchest/internal/memreport"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/monitor"
+	"github.com/tmac1973/llama-toolchest/internal/process"
+)
+
+// oneLoad is a single instance's report, trimmed to one line per kind:
+// 20 GiB of weights and 1 GiB of them host-mapped, a 2 GiB KV cache, a
+// 1 GiB compute buffer and the small output buffer that llama.cpp puts
+// in host memory.
+const oneLoad = `0.00.100.000 I srv          load: spawning server instance with name=m1 on port 46231
+[46231] 0.14.275.753 I load_tensors:        ROCm0 model buffer size = 20480.00 MiB
+[46231] 0.14.275.751 I load_tensors:   CPU_Mapped model buffer size =  1024.00 MiB
+[46231] 0.16.162.940 I llama_kv_cache:      ROCm0 KV buffer size =  2048.00 MiB
+[46231] 0.16.260.662 I sched_reserve:       ROCm0 compute buffer size =  1024.00 MiB
+[46231] 0.17.752.569 I llama_context:   ROCm_Host output buffer size =     4.00 MiB`
+
+func memTestServer(t *testing.T, verbosity string) *Server {
+	t.Helper()
+	env := map[string]string{}
+	if verbosity != "" {
+		env["LLAMA_ARG_LOG_VERBOSITY"] = verbosity
+	}
+	return &Server{
+		cfg:      &config.Config{RuntimeEnv: env},
+		registry: models.NewRegistry(t.TempDir(), t.TempDir()),
+		monitor:  monitor.New(time.Hour), // never polled: no GPUs
+		memory:   memreport.NewCollector(),
+	}
+}
+
+func memTestModel() *models.Model {
+	return &models.Model{
+		ID:            "m1",
+		ModelID:       "unsloth/Test-GGUF",
+		Filename:      "test-Q4_K_M.gguf",
+		SizeBytes:     21 << 30,
+		Arch:          "qwen3",
+		NLayers:       48,
+		ContextLength: 32768,
+	}
+}
+
+func feedLoad(s *Server, log string, note loadNote) {
+	for _, line := range strings.Split(log, "\n") {
+		if ev := s.memory.Add(line); ev.Kind == memreport.EventSpawned {
+			s.memory.Annotate(ev.Port, note)
+		}
+	}
+}
+
+func TestMemoryTooltipReportsWhatWasAllocated(t *testing.T) {
+	s := memTestServer(t, "4")
+	cfg := &models.ModelConfig{ContextSize: 8192, GPULayers: 99}
+	feedLoad(s, oneLoad, loadNote{modelID: "m1", cards: 1, fingerprint: memoryFingerprint(cfg)})
+
+	got := s.memoryTooltip(memTestModel(), cfg, "loaded")
+
+	// 20480 weights + 2048 KV + 1024 compute on the card; the host-mapped
+	// weights and the output buffer are not on it.
+	for _, want := range []string{
+		"Measured while loading: 23.0 GiB of GPU memory",
+		"20.0 weights",
+		"2.0 KV cache",
+		"1.0 working buffers",
+		"Per GPU: ROCm0 23.0 GiB",
+		"Another 1.0 GiB sits in system memory",
+		"Estimated for the current settings:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("tooltip missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestMemoryTooltipFlagsAConfigChangedSinceTheLoad(t *testing.T) {
+	s := memTestServer(t, "4")
+	loaded := &models.ModelConfig{ContextSize: 8192}
+	feedLoad(s, oneLoad, loadNote{modelID: "m1", cards: 1, fingerprint: memoryFingerprint(loaded)})
+
+	// The user has since doubled the context, which the running instance
+	// knows nothing about: the measurement describes the old setting.
+	now := &models.ModelConfig{ContextSize: 16384}
+	got := s.memoryTooltip(memTestModel(), now, "loaded")
+
+	if !strings.Contains(got, "settings that have since changed") {
+		t.Errorf("a measurement from another configuration must say so; got:\n%s", got)
+	}
+	if !strings.Contains(got, "23.0 GiB of GPU memory") {
+		t.Errorf("the old measurement is still worth showing; got:\n%s", got)
+	}
+}
+
+// Below verbosity 4 llama.cpp prints no buffer report at all, so there is
+// nothing to measure. Saying why beats showing an estimate that looks
+// like a measurement.
+func TestMemoryTooltipExplainsTheMissingSetting(t *testing.T) {
+	s := memTestServer(t, "3")
+	got := s.memoryTooltip(memTestModel(), &models.ModelConfig{ContextSize: 8192}, "")
+
+	if !strings.Contains(got, "Model loading detail") {
+		t.Errorf("tooltip must name the setting that enables measurement; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Estimated for the current settings:") {
+		t.Errorf("tooltip must still offer the estimate; got:\n%s", got)
+	}
+}
+
+func TestMemoryTooltipWaitsForAModelThatIsStillLoading(t *testing.T) {
+	s := memTestServer(t, "4")
+	got := s.memoryTooltip(memTestModel(), &models.ModelConfig{ContextSize: 8192}, "loading")
+	if !strings.Contains(got, "Loading.") {
+		t.Errorf("a loading model must not read as unmeasurable; got:\n%s", got)
+	}
+}
+
+func TestMemoryTooltipWithVerbosityOnButNothingLoadedYet(t *testing.T) {
+	s := memTestServer(t, "4")
+	got := s.memoryTooltip(memTestModel(), &models.ModelConfig{ContextSize: 8192}, "")
+	if !strings.Contains(got, "Not measured yet") {
+		t.Errorf("got:\n%s", got)
+	}
+	if strings.Contains(got, "Model loading detail") {
+		t.Errorf("the setting is already right; don't tell the user to change it; got:\n%s", got)
+	}
+}
+
+// A tensor-parallel load reports per card. Reading those as totals would
+// quarter a model spread over four GPUs.
+func TestMemoryTooltipScalesATensorParallelLoad(t *testing.T) {
+	const split = `0.00.100.000 I srv          load: spawning server instance with name=m1 on port 46231
+[46231] 0.14.275.753 I load_tensors:       Meta() model buffer size = 5120.00 MiB
+[46231] 0.16.162.940 I llama_kv_cache:     Meta() KV buffer size = 1024.00 MiB`
+
+	s := memTestServer(t, "4")
+	cfg := &models.ModelConfig{ContextSize: 8192, GPUAssign: "all", TensorSplit: "1,1,1,1"}
+	feedLoad(s, split, loadNote{modelID: "m1", cards: 4, fingerprint: memoryFingerprint(cfg)})
+
+	got := s.memoryTooltip(memTestModel(), cfg, "loaded")
+	if !strings.Contains(got, "24.0 GiB of GPU memory") {
+		t.Errorf("4 x (5120 + 1024) MiB = 24 GiB; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Spread evenly across 4 GPUs") {
+		t.Errorf("an aggregate report cannot name the cards, and should say so; got:\n%s", got)
+	}
+}
+
+func TestMemoryFingerprintTracksTheFieldsThatCostMemory(t *testing.T) {
+	base := models.ModelConfig{ContextSize: 8192, GPULayers: 99, KVCacheQuant: "q8_0"}
+
+	changes := map[string]func(*models.ModelConfig){
+		"context size":     func(c *models.ModelConfig) { c.ContextSize = 16384 },
+		"parallel slots":   func(c *models.ModelConfig) { c.Parallel = 4 },
+		"micro-batch":      func(c *models.ModelConfig) { c.UBatchSize = 2048 },
+		"KV cache quant":   func(c *models.ModelConfig) { c.KVCacheQuant = "q4_0" },
+		"flash attention":  func(c *models.ModelConfig) { c.FlashAttention = true },
+		"GPU layers":       func(c *models.ModelConfig) { c.GPULayers = 20 },
+		"tensor split":     func(c *models.ModelConfig) { c.TensorSplit = "1,0" },
+		"vision projector": func(c *models.ModelConfig) { c.MmprojPath = "/models/mmproj.gguf" },
+		"speculation mode": func(c *models.ModelConfig) { c.SpecType = "draft-mtp" },
+		"MTP drafter head": func(c *models.ModelConfig) { c.MtpPath = "/models/MTP/head.gguf" },
+		"draft GPU layers": func(c *models.ModelConfig) { c.DraftGPULayers = 40 },
+		"per-layer embeds": func(c *models.ModelConfig) { c.PLEMode = "off" },
+		"extra flags":      func(c *models.ModelConfig) { c.ExtraFlags = "--n-cpu-moe 20" },
+	}
+	for what, change := range changes {
+		cfg := base
+		change(&cfg)
+		if memoryFingerprint(&cfg) == memoryFingerprint(&base) {
+			t.Errorf("%s changes how much memory a load takes, but the fingerprint didn't move", what)
+		}
+	}
+
+	// Sampling does not allocate anything, so a preset change must not
+	// invalidate a perfectly good measurement.
+	same := base
+	temp := 0.7
+	same.Temperature = &temp
+	same.SamplingPreset = "thinking"
+	same.Aliases = []string{"fast"}
+	if memoryFingerprint(&same) != memoryFingerprint(&base) {
+		t.Error("sampling settings must not invalidate a measurement")
+	}
+}
+
+func TestLogVerbosityReadsTheEffectiveValue(t *testing.T) {
+	s := memTestServer(t, "")
+	if got := s.logVerbosity(); got != 3 {
+		t.Errorf("unset = %d; want llama.cpp's own default of 3", got)
+	}
+
+	s = memTestServer(t, "4")
+	if got := s.logVerbosity(); got != 4 {
+		t.Errorf("curated = %d; want 4", got)
+	}
+
+	// The free-form block overrides the curated dropdown, and the
+	// tooltip has to agree with what the router will really run with.
+	s = memTestServer(t, "3")
+	s.cfg.RuntimeEnvExtra = "LLAMA_ARG_LOG_VERBOSITY=5"
+	if got := s.logVerbosity(); got != 5 {
+		t.Errorf("extra env = %d; want 5", got)
+	}
+}
+
+// The unit tests above feed the collector directly. This one drives the
+// whole path a real load takes: a router process writing to stdout, the
+// process manager broadcasting those lines, and watchRouterMemory
+// subscribing to them — the wiring no amount of parser testing covers.
+func TestWatchRouterMemoryCollectsFromTheLiveLogStream(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("no sh available: %v", err)
+	}
+	binDir := t.TempDir()
+	binary := filepath.Join(binDir, "llama-server")
+	script := "#!/bin/sh\n"
+	for _, line := range strings.Split(oneLoad, "\n") {
+		script += "echo '" + line + "'\n"
+	}
+	script += "while :; do sleep 1; done\n"
+	if err := os.WriteFile(binary, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := memTestServer(t, "4")
+	s.process = process.NewManager()
+	t.Cleanup(func() {
+		if s.process.IsRunning() {
+			s.process.Stop()
+		}
+	})
+	go s.watchRouterMemory()
+
+	// A free port, so the manager's health poll knocks on a door nobody
+	// is behind rather than on whatever holds the default.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	if err := s.process.Start(process.RouterConfig{
+		BinaryPath: binary, Host: "127.0.0.1", Port: port,
+	}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if meas, ok := s.memory.Latest("m1"); ok && len(meas.Report.Entries) == 5 {
+			if got := meas.Report.GPUMiB(true); got != 23552 {
+				t.Errorf("GPU = %v MiB; want 23552", got)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			meas, ok := s.memory.Latest("m1")
+			t.Fatalf("nothing collected from the log stream: found=%v entries=%d", ok, len(meas.Report.Entries))
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tmac1973/llama-toolchest/internal/config"
 	"github.com/tmac1973/llama-toolchest/internal/evaluate"
 	"github.com/tmac1973/llama-toolchest/internal/huggingface"
+	"github.com/tmac1973/llama-toolchest/internal/memreport"
 	"github.com/tmac1973/llama-toolchest/internal/models"
 	"github.com/tmac1973/llama-toolchest/internal/modelscope"
 	"github.com/tmac1973/llama-toolchest/internal/modelsource"
@@ -85,6 +86,13 @@ type Server struct {
 	// env is the JobEnv handed to the queue, kept so interactive handlers
 	// can ask whether a job currently controls the router.
 	env *jobEnv
+
+	// memory records what each load actually allocated, read off the
+	// router's log stream by watchRouterMemory. Distinct from the VRAM
+	// estimate everywhere else in the UI: this is measurement, and it
+	// exists only for models that have been loaded since the server
+	// started. See internal/api/memory_measured.go.
+	memory *memreport.Collector
 }
 
 // jobEnv returns the benchmark job environment, if wired.
@@ -191,7 +199,11 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 		bench:          benchmark.NewStore(cfg.DataDir, builderResolver(bld)),
 		dirtyModels:    make(map[string]bool),
 		runningConfigs: make(map[string]*models.ModelConfig),
+		memory:         memreport.NewCollector(),
 	}
+	// Subscribes to the router log for the life of the process. Started
+	// before anything can launch the router, so no load goes unwatched.
+	go s.watchRouterMemory()
 	s.env = newJobEnv(s)
 	s.jobs = benchmark.NewJobQueue(s.bench, s.env)
 	s.downloader.SetOnComplete(s.onDownloadComplete)
@@ -783,7 +795,15 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 				`onclick="copyFromButton(this)">%s</button>`,
 				html.EscapeString(copySVG), html.EscapeString(checkSVG), html.EscapeString(pn), copySVG)
 
-			fmt.Fprintf(&buf, `<div class="available-model-row">%s%s<code>%s</code>%s</div>`,
+			// What this model actually took the last time it loaded,
+			// against what it is estimated to take. Per model, because
+			// the answer depends on the configuration each one runs.
+			cfg, err := s.registry.GetConfig(m.ID)
+			if err != nil {
+				cfg = nil
+			}
+			fmt.Fprintf(&buf, `<div class="available-model-row" title="%s">%s%s<code>%s</code>%s</div>`,
+				html.EscapeString(s.memoryTooltip(m, cfg, state)),
 				loadIcon, copyBtn, html.EscapeString(pn), tag)
 			shown++
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -310,6 +310,18 @@ func (s *Server) templateFuncs() template.FuncMap {
 		"evalScoreText": func(e *benchmark.EvalScores) string {
 			return evalScoreText(e)
 		},
+		// constCol marks a column of the compare table that every run
+		// agrees on. Such a column is hidden until the reader asks for
+		// it, because a table wide enough to need sideways scrolling
+		// hides the columns that do differ. A nil map means there was
+		// nothing to compare (fewer than two runs), so nothing is
+		// collapsed.
+		"constCol": func(varies map[string]bool, name string) string {
+			if varies == nil || varies[name] {
+				return ""
+			}
+			return "bc-const"
+		},
 		// memText and memDetail render a run's measured footprint: the
 		// figure for a table cell, and the breakdown behind it for the
 		// cell's tooltip. A run with nothing measured reads as an

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -534,6 +534,7 @@ func (s *Server) buildRouter() chi.Router {
 			r.Put("/{id}/config", s.handleUpdateModelConfig)
 			r.Post("/{id}/refresh-presets", s.handleRefreshPresets)
 			r.Get("/{id}/vram-estimate", s.handleModelVRAMEstimate)
+			r.Get("/{id}/vram-corpus", s.handleVRAMCorpus)
 		})
 		r.Route("/hf", func(r chi.Router) {
 			r.Get("/search", s.handleHFSearch)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -310,6 +310,13 @@ func (s *Server) templateFuncs() template.FuncMap {
 		"evalScoreText": func(e *benchmark.EvalScores) string {
 			return evalScoreText(e)
 		},
+		// memText and memDetail render a run's measured footprint: the
+		// figure for a table cell, and the breakdown behind it for the
+		// cell's tooltip. A run with nothing measured reads as an
+		// em-dash, the same as any other absent measurement here — a
+		// zero would claim the model used no memory.
+		"memText":   memText,
+		"memDetail": memDetail,
 		// evalScoreValue is the comparable magnitude behind evalScoreText,
 		// used only for sorting the compare view. Zero for performance
 		// runs — the score sort button is hidden in that case.

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -527,6 +527,13 @@ func (s *Server) startRouterWith(opt routerOptions) error {
 		"env", extraEnv,
 	)
 
+	// Ports are allocated per model instance and reused freely between
+	// router runs, so measurements in flight against the old run's ports
+	// must not collect the new run's buffers. Done before the start, not
+	// after, so there is no window where a spawn line lands on a mapping
+	// that is about to be cleared.
+	s.memory.Reset()
+
 	if err := s.process.Start(process.RouterConfig{
 		BinaryPath: build.BinaryPath,
 		PresetPath: presetPath,

--- a/internal/api/vram_corpus.go
+++ b/internal/api/vram_corpus.go
@@ -1,0 +1,188 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tmac1973/llama-toolchest/internal/memreport"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+)
+
+// The VRAM estimate is fitted to measured loads, kept as a corpus in
+// internal/models/vram_corpus_test.go. Every point in it was assembled by
+// hand: load the model, watch the GPU counters, read the buffer report,
+// transcribe a dozen fields into a Go literal without a typo.
+//
+// The collector already holds all of that for every load. This turns it
+// into the row, so adding evidence costs a copy and paste rather than an
+// afternoon — which is the difference between a corpus that grows and one
+// that stays at eleven points from one machine.
+//
+// GET /api/models/{id}/vram-corpus
+
+// handleVRAMCorpus returns a ready-to-paste corpus row for the model's
+// last measured load.
+func (s *Server) handleVRAMCorpus(w http.ResponseWriter, r *http.Request) {
+	id := s.registry.ResolveID(chi.URLParam(r, "id"))
+	m, err := s.registry.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	meas, note, ok := s.measurementFor(m)
+	if !ok || len(meas.Report.Entries) == 0 {
+		msg := "no measured load for this model — load it and try again"
+		if s.logVerbosity() < memoryVerbosityRequired {
+			msg = "no measured load for this model: llama.cpp reports what it allocated only at Model loading detail 4 or higher, on the Settings page"
+		}
+		http.Error(w, msg, http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprint(w, corpusRow(m, meas, note, s.runningBuild()))
+}
+
+// corpusRow renders one measured load as a corpusPoint literal.
+//
+// Deliberately a string of Go source rather than JSON: the corpus is
+// source, the reviewer of a change to it reads Go, and a row that has to
+// be converted before it can be pasted is a row that will not be added.
+func corpusRow(m *models.Model, meas memreport.Measurement, note loadNote, build string) string {
+	cfg := note.cfg
+	if cfg == nil {
+		cfg = &models.ModelConfig{}
+	}
+	cards := note.cards
+	if cards < 1 {
+		cards = 1
+	}
+	report := meas.Report.ScaleAggregates(cards)
+
+	ctx := cfg.ContextSize
+	if ctx == 0 {
+		ctx = m.ContextLength
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "// %s, %d card(s)", m.PublicName(), cards)
+	if build != "" {
+		fmt.Fprintf(&b, ", build %s", build)
+	}
+	fmt.Fprintf(&b, ", measured %s.\n", meas.At.Format("2006-01-02"))
+
+	measured := note.measuredGiB()
+	reported := gib(report.GPUMiB(true))
+	switch {
+	case note.contended:
+		b.WriteString("// NOT USABLE AS MEASURED: another model was loading at the same time, so the\n")
+		b.WriteString("// card figure below covers both. The buffer report is still this model's own.\n")
+		b.WriteString("// Load this model on its own and export again.\n")
+	case measured <= 0:
+		b.WriteString("// The card counters were not captured for this load, so the measured column\n")
+		b.WriteString("// is 0 and has to be filled in by hand. It should be a little above the\n")
+		b.WriteString("// buffer report — context and allocator overhead are not itemised.\n")
+	default:
+		fmt.Fprintf(&b, "// Card counters rose %.2f GiB; llama.cpp itemised %.2f, leaving %.2f unreported.\n",
+			measured, reported, measured-reported)
+	}
+	if m.NLayers == 0 || m.NEmbd == 0 || (m.KVFullPerTok == 0 && m.KVSWAPerTok == 0) {
+		b.WriteString("// INCOMPLETE: this registry record has no parsed GGUF metadata, so the estimate\n")
+		b.WriteString("// falls back to file size alone and the row cannot test the term model. Rescan\n")
+		b.WriteString("// the model, load it again, and export again.\n")
+	}
+	if host := gib(report.HostMiB(true)); host >= 0.05 {
+		fmt.Fprintf(&b, "// A further %.2f GiB went to system memory, which no VRAM figure counts.\n", host)
+	}
+
+	fmt.Fprintf(&b, "{%q, %s,\n\t%s, %d, %.2f,\n\t&reportedTerms{weights: %.2f, kv: %.2f, recurrent: %.2f, compute: %.2f}},\n",
+		fmt.Sprintf("%s ctx%s ub%d", m.PublicName(), ctxLabel(ctx), cfg.EffectiveUBatchSize()),
+		modelLiteral(m),
+		configLiteral(cfg),
+		cards,
+		measured,
+		gib(gpuOf(report, memreport.KindModel)),
+		gib(gpuOf(report, memreport.KindKV)),
+		gib(gpuOf(report, memreport.KindRecurrent)),
+		gib(gpuOf(report, memreport.KindCompute)+gpuOf(report, memreport.KindOutput)))
+	return b.String()
+}
+
+// ctxLabel shortens a context length the way the corpus names it.
+func ctxLabel(ctx int) string {
+	if ctx >= 1024 && ctx%1024 == 0 {
+		return fmt.Sprintf("%dk", ctx/1024)
+	}
+	return fmt.Sprintf("%d", ctx)
+}
+
+// modelLiteral writes the registry fields the estimate reads, and only
+// those: a row carrying fields the estimator ignores invites the reader
+// to think they were part of the measurement.
+func modelLiteral(m *models.Model) string {
+	var f []string
+	add := func(format string, args ...any) { f = append(f, fmt.Sprintf(format, args...)) }
+
+	add("SizeBytes: gibBytes(%.2f)", models.BytesToGiB(m.SizeBytes))
+	// Zero fields are omitted rather than written out: a zero in the
+	// registry means "never parsed", and writing it into the corpus would
+	// record an absence as a measurement.
+	if m.PLEBytes > 0 {
+		add("PLEBytes: gibBytes(%.2f)", models.BytesToGiB(m.PLEBytes))
+	}
+	if m.TokenEmbdBytes > 0 {
+		add("TokenEmbdBytes: gibBytes(%.3f)", models.BytesToGiB(m.TokenEmbdBytes))
+	}
+	if m.NLayers > 0 {
+		add("NLayers: %d", m.NLayers)
+	}
+	if m.AttnLayers > 0 {
+		add("AttnLayers: %d", m.AttnLayers)
+	}
+	if m.NEmbd > 0 {
+		add("NEmbd: %d", m.NEmbd)
+	}
+	if m.NKVHead > 0 {
+		add("NKVHead: %d", m.NKVHead)
+	}
+	if m.KVFullPerTok > 0 {
+		add("KVFullPerTok: %d", m.KVFullPerTok)
+	}
+	if m.KVSWAPerTok > 0 {
+		add("KVSWAPerTok: %d", m.KVSWAPerTok)
+	}
+	if m.SlidingWindow > 0 {
+		add("SlidingWindow: %d", m.SlidingWindow)
+	}
+	if m.IndexerKeyLength > 0 {
+		add("IndexerKeyLength: %d", m.IndexerKeyLength)
+	}
+	if m.ContextLength > 0 {
+		add("ContextLength: %d", m.ContextLength)
+	}
+	return "Model{" + strings.Join(f, ", ") + "}"
+}
+
+// configLiteral writes the launch settings that move the estimate.
+func configLiteral(cfg *models.ModelConfig) string {
+	f := []string{
+		fmt.Sprintf("ContextSize: %d", cfg.ContextSize),
+		fmt.Sprintf("UBatchSize: %d", cfg.EffectiveUBatchSize()),
+	}
+	if cfg.KVCacheQuant != "" {
+		f = append(f, fmt.Sprintf("KVCacheQuant: %q", cfg.KVCacheQuant))
+	}
+	if cfg.MmprojPath != "" && !cfg.MmprojDisabled {
+		f = append(f, fmt.Sprintf("MmprojPath: %q", cfg.MmprojPath))
+	}
+	if cfg.MtpPath != "" && !cfg.MtpDisabled {
+		f = append(f, fmt.Sprintf("MtpPath: %q", cfg.MtpPath))
+	}
+	if cfg.SpecType == "draft" && cfg.DraftModelPath != "" {
+		f = append(f, fmt.Sprintf("SpecType: %q, DraftModelPath: %q", cfg.SpecType, cfg.DraftModelPath))
+	}
+	return "ModelConfig{" + strings.Join(f, ", ") + "}"
+}

--- a/internal/api/vram_corpus_test.go
+++ b/internal/api/vram_corpus_test.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"go/parser"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tmac1973/llama-toolchest/internal/memreport"
+	"github.com/tmac1973/llama-toolchest/internal/models"
+	"github.com/tmac1973/llama-toolchest/internal/monitor"
+)
+
+// corpusTestLoad feeds one load through a collector and hands back what
+// the exporter works from.
+func corpusTestLoad(t *testing.T, note loadNote) (memreport.Measurement, loadNote) {
+	t.Helper()
+	c := memreport.NewCollector()
+	for _, line := range strings.Split(oneLoad, "\n") {
+		if ev := c.Add(line); ev.Kind == memreport.EventSpawned {
+			c.Annotate(ev.Port, note)
+		}
+	}
+	meas, ok := c.Latest("m1")
+	if !ok {
+		t.Fatal("no measurement")
+	}
+	return meas, note
+}
+
+func TestCorpusRowIsValidGo(t *testing.T) {
+	cfg := &models.ModelConfig{ContextSize: 8192, UBatchSize: 512, KVCacheQuant: "q8_0"}
+	meas, note := corpusTestLoad(t, loadNote{
+		modelID: "m1", cards: 1, cfg: cfg,
+		baselineGiB: 1.5, loadedGiB: 26.0,
+	})
+
+	row := corpusRow(memTestModel(), meas, note, "b10679-rocm")
+
+	// The whole point is pasting it into a Go table, so it has to parse
+	// as one. Comments and all.
+	if _, err := parser.ParseExpr("[]corpusPoint{\n" + row + "}"); err != nil {
+		t.Fatalf("exported row is not valid Go: %v\nrow:\n%s", err, row)
+	}
+}
+
+func TestCorpusRowCarriesTheMeasurementAndItsTerms(t *testing.T) {
+	cfg := &models.ModelConfig{ContextSize: 8192, UBatchSize: 512}
+	meas, note := corpusTestLoad(t, loadNote{
+		modelID: "m1", cards: 1, cfg: cfg,
+		baselineGiB: 1.5, loadedGiB: 26.0,
+	})
+
+	row := corpusRow(memTestModel(), meas, note, "b10679-rocm")
+
+	for _, want := range []string{
+		"build b10679-rocm",
+		// 26.0 - 1.5 card counters, against 23.0 llama.cpp itemised.
+		"Card counters rose 24.50 GiB; llama.cpp itemised 23.00, leaving 1.50 unreported.",
+		"ctx8k ub512",
+		"ContextSize: 8192, UBatchSize: 512",
+		"&reportedTerms{weights: 20.00, kv: 2.00, recurrent: 0.00, compute: 1.00}",
+		", 1, 24.50,",
+		"A further 1.00 GiB went to system memory",
+	} {
+		if !strings.Contains(row, want) {
+			t.Errorf("row missing %q; got:\n%s", want, row)
+		}
+	}
+}
+
+// A row measured while something else was loading is worse than no row:
+// it looks like evidence and is not.
+func TestCorpusRowRefusesToPassOffAContendedLoad(t *testing.T) {
+	cfg := &models.ModelConfig{ContextSize: 8192, UBatchSize: 512}
+	meas, note := corpusTestLoad(t, loadNote{
+		modelID: "m1", cards: 1, cfg: cfg,
+		baselineGiB: 1.5, loadedGiB: 40.0, contended: true,
+	})
+
+	row := corpusRow(memTestModel(), meas, note, "")
+	if !strings.Contains(row, "NOT USABLE AS MEASURED") {
+		t.Errorf("a contended load must say so; got:\n%s", row)
+	}
+	if !strings.Contains(row, "buffer report is still this model's own") {
+		t.Errorf("the per-instance figures survive contention and the row should say which half is sound; got:\n%s", row)
+	}
+}
+
+func TestCorpusRowWithoutCardCounters(t *testing.T) {
+	cfg := &models.ModelConfig{ContextSize: 8192, UBatchSize: 512}
+	meas, note := corpusTestLoad(t, loadNote{modelID: "m1", cards: 1, cfg: cfg})
+
+	row := corpusRow(memTestModel(), meas, note, "")
+	if !strings.Contains(row, "filled in by hand") {
+		t.Errorf("a row with no card figure must say so rather than claiming 0 GiB; got:\n%s", row)
+	}
+	if !strings.Contains(row, ", 1, 0.00,") {
+		t.Errorf("the measured column should be an obvious zero; got:\n%s", row)
+	}
+}
+
+// A tensor-parallel load reports per card, and a corpus row states
+// totals. Getting this wrong quarters a four-card model.
+func TestCorpusRowScalesAggregatedFigures(t *testing.T) {
+	const split = `0.00.100.000 I srv          load: spawning server instance with name=m1 on port 46231
+[46231] 0.14.275.753 I load_tensors:       Meta() model buffer size = 5120.00 MiB
+[46231] 0.16.162.940 I llama_kv_cache:     Meta() KV buffer size = 1024.00 MiB`
+
+	c := memreport.NewCollector()
+	note := loadNote{modelID: "m1", cards: 4, cfg: &models.ModelConfig{ContextSize: 8192, UBatchSize: 512},
+		baselineGiB: 2.0, loadedGiB: 28.0}
+	for _, line := range strings.Split(split, "\n") {
+		if ev := c.Add(line); ev.Kind == memreport.EventSpawned {
+			c.Annotate(ev.Port, note)
+		}
+	}
+	meas, _ := c.Latest("m1")
+
+	row := corpusRow(memTestModel(), meas, note, "")
+	if !strings.Contains(row, "weights: 20.00") {
+		t.Errorf("4 x 5120 MiB = 20 GiB of weights; got:\n%s", row)
+	}
+	if !strings.Contains(row, ", 4, 26.00,") {
+		t.Errorf("row should state 4 cards and the 26 GiB the counters rose; got:\n%s", row)
+	}
+}
+
+func TestUsedGiBSumsEveryCard(t *testing.T) {
+	got := usedGiB(monitor.Metrics{GPU: []monitor.GPUInfo{
+		{VRAMUsedMB: 1024}, {VRAMUsedMB: 2048}, {VRAMUsedMB: 512},
+	}})
+	if got != 3.5 {
+		t.Errorf("used = %v GiB; want 3.5", got)
+	}
+}
+
+// A load that finishes while the monitor is not running must not block
+// the goroutine waiting on it forever.
+func TestGPUSampleGivesUpWhenTheMonitorIsQuiet(t *testing.T) {
+	s := memTestServer(t, "4")
+	start := time.Now()
+	if _, ok := s.gpuUsedAfterFreshSample(50 * time.Millisecond); ok {
+		t.Error("a sample was reported by a monitor that never polled")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("waited %v for a 50ms timeout", elapsed)
+	}
+}

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -66,6 +66,16 @@ type BenchmarkRun struct {
 	LlamaBench  *LlamaBenchResult   `json:"llama_bench,omitempty"`
 	LlamaBenchy []LlamaBenchyResult `json:"llama_benchy,omitempty"`
 
+	// Memory is what the load actually allocated, read from llama.cpp's
+	// own buffer report while the model was loading. Nil when the report
+	// was not available — llama.cpp prints it only at log verbosity 4 —
+	// and on every run recorded before this was captured.
+	//
+	// Distinct from the VRAM estimate shown elsewhere in the UI: this is
+	// measurement. A cell already pays for the load, so it costs nothing
+	// to record what that load cost.
+	Memory *MemorySnapshot `json:"memory,omitempty"`
+
 	// Eval holds capability-evaluation scores (perplexity, KL
 	// divergence, HellaSwag, Winogrande) for runs of capability
 	// presets. Nil on performance runs.
@@ -95,6 +105,37 @@ type BenchmarkRun struct {
 	// from jobs that declared overrides back when overrides were never
 	// applied. Never set on runs produced after that fix.
 	ConfigUnverified bool `json:"config_unverified,omitempty"`
+}
+
+// MemorySnapshot is one load's memory footprint, in GiB, as llama.cpp
+// itemised it while allocating.
+//
+// The four GPU terms add up to GPUGiB: they are every kind llama.cpp
+// reports, and keeping them apart is what lets a sweep answer "what did
+// that setting cost, and to which part of the footprint".
+type MemorySnapshot struct {
+	GPUGiB       float64 `json:"gpu_gib"`
+	WeightsGiB   float64 `json:"weights_gib"`
+	KVGiB        float64 `json:"kv_gib"`      // attention cache and recurrent state
+	ComputeGiB   float64 `json:"compute_gib"` // compute and output buffers
+	HostGiB      float64 `json:"host_gib"`    // weights left mapped, pinned staging, spilled layers
+	CardDeltaGiB float64 `json:"card_gib"`    // what the GPU counters rose by, 0 when not captured
+	Cards        int     `json:"cards"`
+
+	// Contended marks a load that overlapped another. Its own buffer
+	// figures are still sound — those are attributed per instance — but
+	// CardDeltaGiB covers both models and is left at zero.
+	Contended bool `json:"contended,omitempty"`
+}
+
+// Unreported is what the card counters saw that llama.cpp never
+// itemised: context and allocator overhead. Zero when the counters were
+// not captured.
+func (m MemorySnapshot) Unreported() float64 {
+	if m.CardDeltaGiB == 0 {
+		return 0
+	}
+	return m.CardDeltaGiB - m.GPUGiB
 }
 
 // ConfigSnapshot freezes model config at benchmark time.

--- a/internal/benchmark/compare_columns_test.go
+++ b/internal/benchmark/compare_columns_test.go
@@ -1,0 +1,158 @@
+package benchmark
+
+import "testing"
+
+func colRun(id string) BenchmarkRun {
+	return BenchmarkRun{
+		ID: id, ModelName: "Qwen3.8-27B", Quant: "Q4_K_XL", SizeGiB: 29.3,
+		Preset: "internal-standard",
+		Config: ConfigSnapshot{
+			ContextSize: 32768, BatchSize: 2048, UBatchSize: 512,
+			GPUAssign: "all", FlashAttention: true,
+		},
+		Build:   BuildSnapshot{ID: "b1", Profile: "rocm", GitRef: "b10679"},
+		Summary: &BenchmarkSummary{AvgGenTokPerSec: 40, AvgPromptTokPerSec: 100},
+	}
+}
+
+func has(common []CommonColumn, name string) (string, bool) {
+	for _, c := range common {
+		if c.Name == name {
+			return c.Value, true
+		}
+	}
+	return "", false
+}
+
+// The case this exists for: a sweep of one parameter on one model and
+// one build. Everything except the swept value is the same in every row,
+// and those columns push the ones that matter off the side of the page.
+func TestOneParameterSweepCollapsesEverythingElse(t *testing.T) {
+	var runs []BenchmarkRun
+	for _, ub := range []string{"128", "512", "2048"} {
+		r := colRun("r" + ub)
+		r.SweepValues = map[string]string{"ubatch_size": ub}
+		r.Config.UBatchSize = 512 // config is the saved one; the sweep is the axis
+		runs = append(runs, r)
+	}
+
+	c := BuildComparison(runs)
+
+	if !c.Varies["sweep"] {
+		t.Error("the swept column must stay: it is the whole comparison")
+	}
+	for _, name := range []string{"quant", "size", "context", "batch", "KV cache", "flash attention", "build", "GPUs"} {
+		if c.Varies[name] {
+			t.Errorf("%q is identical in every run but was kept", name)
+		}
+		if _, ok := has(c.Common, name); !ok {
+			t.Errorf("%q was collapsed without being stated in the summary", name)
+		}
+	}
+}
+
+// Nothing is collapsed silently: every column taken out of the table has
+// to appear above it, with the value the runs share.
+func TestCollapsedColumnsKeepTheTemplateWording(t *testing.T) {
+	a, b := colRun("a"), colRun("b")
+	a.Config.KVCacheQuant, b.Config.KVCacheQuant = "", ""
+	a.Config.GPUAssign, b.Config.GPUAssign = "", ""
+	a.Config.BatchSize, b.Config.BatchSize = 0, 0
+	a.Config.UBatchSize, b.Config.UBatchSize = 0, 0
+	a.Summary.AvgGenTokPerSec = 55
+
+	c := BuildComparison([]BenchmarkRun{a, b})
+
+	// Each of these mirrors a fallback the table cell prints, and the
+	// two have to agree — the toggle shows the cell beside the summary.
+	for name, want := range map[string]string{
+		"KV cache":        "f16",
+		"GPUs":            "all",
+		"size":            "29.3 GiB",
+		"flash attention": "yes",
+		"build":           "rocm · b10679",
+	} {
+		got, ok := has(c.Common, name)
+		if !ok {
+			t.Errorf("%q missing from the summary", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s = %q; the table cell shows %q", name, got, want)
+		}
+	}
+
+	// Batch and sweep are em-dashes in both rows here. They collapse
+	// like any other constant, but there is nothing to state about them
+	// — see TestBlankColumnsAreHiddenWithoutBeingStated.
+	for _, name := range []string{"batch", "sweep"} {
+		if c.Varies[name] {
+			t.Errorf("%q is the same in both runs and should be collapsed", name)
+		}
+		if v, ok := has(c.Common, name); ok {
+			t.Errorf("%q appears in the summary as %q", name, v)
+		}
+	}
+}
+
+// A column that differs stays in the table and out of the summary, or
+// the comparison loses the thing being compared.
+func TestVaryingColumnsAreKept(t *testing.T) {
+	a, b := colRun("a"), colRun("b")
+	b.Quant = "Q8_0"
+	b.SizeGiB = 51.2
+	b.Config.FlashAttention = false
+
+	c := BuildComparison([]BenchmarkRun{a, b})
+
+	for _, name := range []string{"quant", "size", "flash attention"} {
+		if !c.Varies[name] {
+			t.Errorf("%q differs between the runs but was collapsed", name)
+		}
+		if v, ok := has(c.Common, name); ok {
+			t.Errorf("%q is in the summary as %q although the runs disagree", name, v)
+		}
+	}
+	if c.Varies["build"] {
+		t.Error("build is identical here and should have been collapsed")
+	}
+}
+
+// One run is not a comparison. Its table is a statement of what it was,
+// and every column of it is worth reading.
+func TestASingleRunCollapsesNothing(t *testing.T) {
+	c := BuildComparison([]BenchmarkRun{colRun("a")})
+	if c.Common != nil {
+		t.Errorf("common = %+v; want nothing collapsed for a single run", c.Common)
+	}
+	if c.Varies != nil {
+		t.Errorf("varies = %+v; want nil, which the view reads as show everything", c.Varies)
+	}
+}
+
+// A column blank in every row is hidden like any other constant, but
+// there is nothing to state about it: "build —" in the summary reads as
+// a shared setting rather than as missing data.
+func TestBlankColumnsAreHiddenWithoutBeingStated(t *testing.T) {
+	a, b := colRun("a"), colRun("b")
+	a.Build, b.Build = BuildSnapshot{}, BuildSnapshot{}
+	a.BuildProfile, b.BuildProfile = "", ""
+	a.BuildRef, b.BuildRef = "", ""
+	a.Summary.AvgGenTokPerSec = 55
+
+	c := BuildComparison([]BenchmarkRun{a, b})
+
+	if c.Varies["build"] {
+		t.Error("an empty build column should still be collapsed")
+	}
+	if v, ok := has(c.Common, "build"); ok {
+		t.Errorf("build is in the summary as %q; an absence is not a shared value", v)
+	}
+	if v, ok := has(c.Common, "sweep"); ok {
+		t.Errorf("sweep is in the summary as %q although neither run swept anything", v)
+	}
+	// The columns that do hold something are unaffected.
+	if _, ok := has(c.Common, "quant"); !ok {
+		t.Error("quant should still be stated")
+	}
+}

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -138,6 +138,12 @@ type JobEnv interface {
 
 	// RunEval executes one evaluation and returns parsed scores.
 	RunEval(ctx context.Context, spec evaluate.Spec) (evaluate.Result, error)
+
+	// MeasuredMemory returns what the model's current load allocated, as
+	// llama.cpp reported it while loading. False when nothing was
+	// measured: the report appears only at log verbosity 4, and the
+	// model may have been loaded before the reader was watching.
+	MeasuredMemory(modelID string) (MemorySnapshot, bool)
 }
 
 // ModelInfo bundles registry data for a single model so the JobRunner
@@ -494,6 +500,7 @@ func (q *JobQueue) runCell(ctx context.Context, job *BenchmarkJob, cell *JobCell
 		HFToken:    q.env.HFToken(),
 		HFHome:     q.env.HFCacheDir(),
 		Sampling:   samplingFromOverrides(cellOv),
+		Memory:     q.env.MeasuredMemory,
 	}, nil)
 
 	final, err := q.store.Get(run.ID)

--- a/internal/benchmark/job_runner_test.go
+++ b/internal/benchmark/job_runner_test.go
@@ -30,6 +30,7 @@ type fakeEnv struct {
 	cleared       int
 	clearedT      []time.Time
 	dirty         bool
+	memReport     *MemorySnapshot
 	buildSwitches []string
 	buildRestarts int
 
@@ -136,9 +137,20 @@ func (f *fakeEnv) ResolveBuild(id string) BuildSnapshot {
 	return BuildSnapshot{ID: id, Profile: "rocm", GitRef: "b1"}
 }
 func (f *fakeEnv) CurrentMetrics() monitor.Metrics { return monitor.Metrics{} }
-func (f *fakeEnv) RouterURL() string               { return f.routerURL }
-func (f *fakeEnv) HFToken() string                 { return "" }
-func (f *fakeEnv) HFCacheDir() string              { return "" }
+
+// MeasuredMemory reports what memReport holds, so a test can drive both
+// the "the load was measured" and "verbosity was too low" paths.
+func (f *fakeEnv) MeasuredMemory(modelID string) (MemorySnapshot, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.memReport == nil {
+		return MemorySnapshot{}, false
+	}
+	return *f.memReport, true
+}
+func (f *fakeEnv) RouterURL() string  { return f.routerURL }
+func (f *fakeEnv) HFToken() string    { return "" }
+func (f *fakeEnv) HFCacheDir() string { return "" }
 
 // --- JobEnv capability methods ---------------------------------------
 

--- a/internal/benchmark/runner.go
+++ b/internal/benchmark/runner.go
@@ -22,6 +22,15 @@ type RunConfig struct {
 	HFToken    string // forwarded as HF_TOKEN to llama-benchy (avoids HF rate limiting)
 	HFHome     string // forwarded as HF_HOME so the tokenizer cache persists across runs
 	Sampling   SamplingParams
+
+	// Memory returns what the model's current load allocated, once it is
+	// loaded. Nil, or a false second return, when nothing was measured —
+	// llama.cpp itemises its buffers only at log verbosity 4, so a cell
+	// run with the default setting has timings and no footprint.
+	//
+	// A callback rather than a value because the load happens inside
+	// Run: the figure does not exist when the RunConfig is built.
+	Memory func(modelID string) (MemorySnapshot, bool)
 }
 
 // SamplingParams are per-request generation settings. Unlike everything
@@ -137,6 +146,17 @@ func (r *Runner) Run(ctx context.Context, cfg RunConfig, progress chan<- Progres
 		run.Error = fmt.Sprintf("warmup failed after retries: %v", warmupErr)
 		send("error", run.Error, 0)
 		return
+	}
+
+	// The model is up and has served a request, so everything it will
+	// allocate has been allocated. Recorded before the benchmark rather
+	// than after, so a cell that fails mid-run still reports what it
+	// cost to load — which is often the answer being looked for when a
+	// cell fails.
+	if cfg.Memory != nil {
+		if mem, ok := cfg.Memory(run.ModelID); ok {
+			run.Memory = &mem
+		}
 	}
 
 	// Step 3: Run benchmarks (internal API loop or llama-benchy shell-out).

--- a/internal/benchmark/runner_memory_test.go
+++ b/internal/benchmark/runner_memory_test.go
@@ -1,0 +1,118 @@
+package benchmark
+
+import "testing"
+
+// The measurement is taken inside Run, after the model is up: the figure
+// does not exist when the RunConfig is built. These cover the wiring
+// that carries it onto the run.
+
+func TestRunConfigMemoryCallbackRecordsTheFootprint(t *testing.T) {
+	var asked string
+	cfg := RunConfig{
+		Run: BenchmarkRun{ModelID: "m1"},
+		Memory: func(modelID string) (MemorySnapshot, bool) {
+			asked = modelID
+			return MemorySnapshot{GPUGiB: 23, Cards: 4}, true
+		},
+	}
+
+	run := cfg.Run
+	if cfg.Memory != nil {
+		if mem, ok := cfg.Memory(run.ModelID); ok {
+			run.Memory = &mem
+		}
+	}
+
+	if asked != "m1" {
+		t.Errorf("callback asked about %q; want the run's own model", asked)
+	}
+	if run.Memory == nil || run.Memory.GPUGiB != 23 {
+		t.Errorf("footprint not recorded: %+v", run.Memory)
+	}
+}
+
+// Below log verbosity 4 llama.cpp itemises nothing, so a cell has
+// timings and no footprint. That must leave the field nil rather than a
+// zeroed struct, which every reader downstream treats as "measured, and
+// it used nothing".
+func TestRunKeepsMemoryNilWhenNothingWasMeasured(t *testing.T) {
+	cfg := RunConfig{
+		Run:    BenchmarkRun{ModelID: "m1"},
+		Memory: func(string) (MemorySnapshot, bool) { return MemorySnapshot{}, false },
+	}
+
+	run := cfg.Run
+	if mem, ok := cfg.Memory(run.ModelID); ok {
+		run.Memory = &mem
+	}
+	if run.Memory != nil {
+		t.Errorf("memory = %+v; want nil", run.Memory)
+	}
+}
+
+func TestMemorySnapshotUnreported(t *testing.T) {
+	m := MemorySnapshot{GPUGiB: 23.0, CardDeltaGiB: 24.5}
+	if got := m.Unreported(); got < 1.49 || got > 1.51 {
+		t.Errorf("unreported = %v; want 1.5", got)
+	}
+	// Without a card reading there is no remainder to state.
+	none := MemorySnapshot{GPUGiB: 23.0}
+	if got := none.Unreported(); got != 0 {
+		t.Errorf("unreported = %v; want 0 when the counters were not captured", got)
+	}
+}
+
+// End to end through a job cell: the cell already pays for the load, so
+// what that load cost is recorded on the run beside its timings.
+func TestJobCellRecordsWhatTheLoadCost(t *testing.T) {
+	router := newFakeRouter(t)
+	env := &fakeEnv{
+		routerURL: router.URL,
+		saved:     ConfigSnapshot{GPULayers: 999, ContextSize: 8192, Threads: 8},
+		memReport: &MemorySnapshot{
+			GPUGiB: 23, WeightsGiB: 20, KVGiB: 2, ComputeGiB: 1,
+			HostGiB: 1.5, CardDeltaGiB: 24.5, Cards: 4,
+		},
+	}
+
+	job, store := runJob(t, oneCellJob(nil), env)
+	if job.Status != JobStatusCompleted {
+		t.Fatalf("job status = %s, want completed", job.Status)
+	}
+	runs := store.RunsForJob(job.ID)
+	if len(runs) != 1 {
+		t.Fatalf("got %d runs, want 1", len(runs))
+	}
+	mem := runs[0].Memory
+	if mem == nil {
+		t.Fatal("the cell recorded no footprint")
+	}
+	if mem.GPUGiB != 23 || mem.WeightsGiB != 20 || mem.Cards != 4 {
+		t.Errorf("footprint = %+v", mem)
+	}
+}
+
+// A router below log verbosity 4 itemises nothing. The cell still runs
+// and still reports its timings; the footprint is simply absent.
+func TestJobCellSurvivesAnUnmeasuredLoad(t *testing.T) {
+	router := newFakeRouter(t)
+	env := &fakeEnv{
+		routerURL: router.URL,
+		saved:     ConfigSnapshot{GPULayers: 999, ContextSize: 8192, Threads: 8},
+	}
+
+	job, store := runJob(t, oneCellJob(nil), env)
+	if job.Status != JobStatusCompleted {
+		t.Fatalf("job status = %s, want completed", job.Status)
+	}
+	runs := store.RunsForJob(job.ID)
+	if len(runs) != 1 {
+		t.Fatalf("got %d runs, want 1", len(runs))
+	}
+	if runs[0].Memory != nil {
+		t.Errorf("memory = %+v; want nil", runs[0].Memory)
+	}
+	if runs[0].Summary == nil {
+		t.Error("the cell lost its timings")
+	}
+}

--- a/internal/benchmark/stats.go
+++ b/internal/benchmark/stats.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -133,6 +134,25 @@ type ComparisonData struct {
 	BestGenRunID    string
 	BestPromptRunID string
 
+	// Varies says, per descriptive column of the details table, whether
+	// the compared runs actually differ on it. A column every run agrees
+	// on carries no information about which run won, and a wide table
+	// that has to be scrolled sideways hides the columns that do. The
+	// view marks such columns constant, folds their shared value into
+	// Common above the table, and offers a control to show them anyway.
+	//
+	// Keys are the column names used in the template. A key that is
+	// absent means "show it": a comparison of fewer than two runs has
+	// nothing to collapse, and a column not listed here was never a
+	// candidate.
+	Varies map[string]bool
+
+	// Common lists the columns every compared run agrees on, with the
+	// value they share, in table order. This is where the collapsed
+	// columns go: dropping them without saying what they held would
+	// leave the reader to assume rather than read.
+	Common []CommonColumn
+
 	// MixedPromptSizes is true when the compared runs did not all
 	// measure the same prompt lengths. The bar charts show each run's
 	// average across whatever it measured, and prompt throughput climbs
@@ -182,7 +202,141 @@ func BuildComparison(runs []BenchmarkRun) ComparisonData {
 		sizeSets[promptSizeKey(r)] = true
 	}
 	c.MixedPromptSizes = len(sizeSets) > 1
+	c.Varies, c.Common = compareColumnVariance(runs)
 	return c
+}
+
+// CommonColumn is one descriptive column the compared runs all agree on.
+type CommonColumn struct {
+	Name  string
+	Value string
+}
+
+// compareColumns are the details table's descriptive columns: name, and
+// the text the cell shows.
+//
+// The formatting is duplicated from the template on purpose, and it has
+// to stay in step — a shared value stated one way in the summary line
+// and another in the cell that the "show every column" control reveals
+// would read as two different facts. compare_columns_test.go pins each
+// one against the template's own fallbacks.
+//
+// The measured columns are deliberately absent: throughput, score and
+// VRAM are what the reader came for, and a comparison where two runs
+// scored identically is still a comparison about those numbers. Model is
+// absent too — it anchors each row and carries the run's full label and
+// any unverified warning, so it stays even when every run shares it.
+func compareColumns() []struct {
+	Name  string
+	Value func(BenchmarkRun) string
+} {
+	type col = struct {
+		Name  string
+		Value func(BenchmarkRun) string
+	}
+	return []col{
+		{"quant", func(r BenchmarkRun) string { return r.Quant }},
+		{"sweep", func(r BenchmarkRun) string { return sweepCellText(r) }},
+		{"prompt sizes", func(r BenchmarkRun) string { return r.PromptSizesText() }},
+		{"size", func(r BenchmarkRun) string { return fmt.Sprintf("%.1f GiB", r.SizeGiB) }},
+		{"GPUs", func(r BenchmarkRun) string {
+			if r.Config.GPUAssign == "" {
+				return "all"
+			}
+			return r.Config.GPUAssign
+		}},
+		{"context", func(r BenchmarkRun) string { return strconv.Itoa(r.Config.ContextSize) }},
+		{"batch", func(r BenchmarkRun) string { return batchCellText(r) }},
+		{"KV cache", func(r BenchmarkRun) string {
+			if r.Config.KVCacheQuant == "" {
+				return "f16"
+			}
+			return r.Config.KVCacheQuant
+		}},
+		{"flash attention", func(r BenchmarkRun) string {
+			if r.Config.FlashAttention {
+				return "yes"
+			}
+			return "no"
+		}},
+		{"build", func(r BenchmarkRun) string { return compareBuildCellText(r) }},
+	}
+}
+
+// compareColumnVariance splits the descriptive columns into those that
+// differ across the compared runs and those that do not.
+//
+// Below two runs there is nothing to compare, so nothing is collapsed:
+// a single run's table is a statement of what it was, and every column
+// of it is worth reading.
+func compareColumnVariance(runs []BenchmarkRun) (map[string]bool, []CommonColumn) {
+	if len(runs) < 2 {
+		return nil, nil
+	}
+	varies := map[string]bool{}
+	var common []CommonColumn
+	for _, c := range compareColumns() {
+		first := c.Value(runs[0])
+		differs := false
+		for _, r := range runs[1:] {
+			if c.Value(r) != first {
+				differs = true
+				break
+			}
+		}
+		varies[c.Name] = differs
+		// A column that is blank in every row is hidden with no note.
+		// "build —" or "sweep —" in the summary states an absence as
+		// though it were a shared setting; there is nothing to say.
+		if !differs && first != "" && first != "—" {
+			common = append(common, CommonColumn{Name: c.Name, Value: first})
+		}
+	}
+	return varies, common
+}
+
+// sweepCellText, batchCellText and compareBuildCellText mirror the three
+// cells whose text the template assembles rather than prints.
+func sweepCellText(r BenchmarkRun) string {
+	if len(r.SweepValues) == 0 {
+		return "—"
+	}
+	keys := make([]string, 0, len(r.SweepValues))
+	for k := range r.SweepValues {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+r.SweepValues[k])
+	}
+	return strings.Join(parts, " ")
+}
+
+func batchCellText(r BenchmarkRun) string {
+	if r.Config.BatchSize == 0 && r.Config.UBatchSize == 0 {
+		return "—"
+	}
+	part := func(n int) string {
+		if n == 0 {
+			return "—"
+		}
+		return strconv.Itoa(n)
+	}
+	return part(r.Config.BatchSize) + "/" + part(r.Config.UBatchSize)
+}
+
+func compareBuildCellText(r BenchmarkRun) string {
+	b := r.EffectiveBuild()
+	switch {
+	case b.Profile != "" && b.GitRef != "":
+		return b.Profile + " · " + b.GitRef
+	case b.Profile != "":
+		return b.Profile
+	case b.GitRef != "":
+		return b.GitRef
+	}
+	return "—"
 }
 
 // promptSizeKey renders the set of prompt lengths a run measured, so

--- a/internal/benchmark/visualize.go
+++ b/internal/benchmark/visualize.go
@@ -77,6 +77,21 @@ var vizMetrics = []VizMetric{
 	{Key: "ttft", Label: "Time to first token", Unit: "ms", HigherIsBetter: false},
 }
 
+// vizMemoryMetrics are offered only when the runs carry a measured
+// footprint. Lower is better on all of them, which is the point of
+// plotting them beside the speeds: a setting that buys throughput
+// usually spends memory, and the trade is what the chart is for.
+//
+// Kept separate from vizMetrics because they are conditional. A metric
+// in the picker that plots nothing is worse than one that is absent.
+var vizMemoryMetrics = []VizMetric{
+	{Key: "mem_gpu", Label: "GPU memory", Unit: "GiB", HigherIsBetter: false},
+	{Key: "mem_weights", Label: "GPU memory: weights", Unit: "GiB", HigherIsBetter: false},
+	{Key: "mem_kv", Label: "GPU memory: KV cache", Unit: "GiB", HigherIsBetter: false},
+	{Key: "mem_compute", Label: "GPU memory: working buffers", Unit: "GiB", HigherIsBetter: false},
+	{Key: "mem_host", Label: "System memory", Unit: "GiB", HigherIsBetter: false},
+}
+
 // BuildVisualization turns a set of runs into the visualization
 // payload: the dimensions they vary on, the metrics available, and one
 // point per run that produced timings.
@@ -84,7 +99,9 @@ func BuildVisualization(runs []BenchmarkRun) VizData {
 	labels := BuildRunLabels(runs)
 	dims := comparisonDimensions(runs)
 
-	out := VizData{Metrics: vizMetrics}
+	// Copied, because the memory metrics are appended conditionally and
+	// appending to the package-level slice would leak into the next call.
+	out := VizData{Metrics: append([]VizMetric(nil), vizMetrics...)}
 
 	// Only runs with timings can be plotted. Collect them first so the
 	// dimensions describe what is actually on the chart rather than
@@ -122,6 +139,17 @@ func BuildVisualization(runs []BenchmarkRun) VizData {
 		})
 	}
 
+	// Offer the memory metrics only when something carries them. A run
+	// measured before this existed, or under a router below log
+	// verbosity 4, has timings and no footprint; the page drops those
+	// points from a memory chart and says how many it dropped.
+	for _, r := range plotted {
+		if r.Memory != nil {
+			out.Metrics = append(out.Metrics, vizMemoryMetrics...)
+			break
+		}
+	}
+
 	for _, r := range plotted {
 		p := VizPoint{
 			RunID:  r.ID,
@@ -133,6 +161,16 @@ func BuildVisualization(runs []BenchmarkRun) VizData {
 				"prompt": r.Summary.AvgPromptTokPerSec,
 				"ttft":   r.Summary.AvgTTFTMs,
 			},
+		}
+		// Absent rather than zero: a missing key is a point the chart
+		// leaves out, while a zero is a claim that the model used no
+		// memory.
+		if m := r.Memory; m != nil {
+			p.Metrics["mem_gpu"] = m.GPUGiB
+			p.Metrics["mem_weights"] = m.WeightsGiB
+			p.Metrics["mem_kv"] = m.KVGiB
+			p.Metrics["mem_compute"] = m.ComputeGiB
+			p.Metrics["mem_host"] = m.HostGiB
 		}
 		for _, d := range dims {
 			if v := d.Value(r); v != "" {

--- a/internal/benchmark/visualize_memory_test.go
+++ b/internal/benchmark/visualize_memory_test.go
@@ -1,0 +1,88 @@
+package benchmark
+
+import "testing"
+
+// vizMemRun is vizRun (visualize_test.go) with a footprint attached.
+func vizMemRun(id string, gen float64, mem *MemorySnapshot) BenchmarkRun {
+	return BenchmarkRun{
+		ID: id, ModelName: "M-4B", Quant: "Q4_K_XL", Preset: "internal-standard",
+		SweepValues: map[string]string{"ubatch_size": id},
+		Summary: &BenchmarkSummary{
+			AvgGenTokPerSec: gen, AvgPromptTokPerSec: 100, AvgTTFTMs: 10,
+		},
+		Memory: mem,
+	}
+}
+
+func metricKeys(d VizData) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range d.Metrics {
+		out[m.Key] = true
+	}
+	return out
+}
+
+// The point of plotting memory beside speed: a setting that buys
+// throughput usually spends memory, and the chart is where that trade
+// becomes visible.
+func TestVisualizationOffersMemoryWhenRunsCarryIt(t *testing.T) {
+	d := BuildVisualization([]BenchmarkRun{
+		vizMemRun("128", 40, &MemorySnapshot{GPUGiB: 23, WeightsGiB: 20, KVGiB: 2, ComputeGiB: 1, HostGiB: 1.5, Cards: 4}),
+		vizMemRun("512", 55, &MemorySnapshot{GPUGiB: 25, WeightsGiB: 20, KVGiB: 2, ComputeGiB: 3, HostGiB: 1.5, Cards: 4}),
+	})
+
+	keys := metricKeys(d)
+	for _, want := range []string{"mem_gpu", "mem_weights", "mem_kv", "mem_compute", "mem_host"} {
+		if !keys[want] {
+			t.Errorf("metric %q is not offered", want)
+		}
+	}
+	for _, m := range d.Metrics {
+		if m.Key == "mem_gpu" && m.HigherIsBetter {
+			t.Error("more memory is not better; a heatmap would be coloured backwards")
+		}
+	}
+	if len(d.Points) != 2 {
+		t.Fatalf("points = %d; want 2", len(d.Points))
+	}
+	if got := d.Points[0].Metrics["mem_compute"]; got != 1 {
+		t.Errorf("mem_compute = %v; want 1", got)
+	}
+}
+
+// A run measured before this existed has timings and no footprint. It
+// must not be plotted at zero, which would read as "used no memory".
+func TestVisualizationLeavesMemoryAbsentRatherThanZero(t *testing.T) {
+	d := BuildVisualization([]BenchmarkRun{
+		vizMemRun("128", 40, &MemorySnapshot{GPUGiB: 23, Cards: 1}),
+		vizMemRun("512", 55, nil),
+	})
+
+	if _, ok := d.Points[1].Metrics["mem_gpu"]; ok {
+		t.Error("a run with no measurement carries a memory value")
+	}
+	if _, ok := d.Points[1].Metrics["gen"]; !ok {
+		t.Error("the run should still be plottable on the speed metrics")
+	}
+}
+
+// Offering a metric that plots nothing is worse than not offering it.
+func TestVisualizationHidesMemoryWhenNothingWasMeasured(t *testing.T) {
+	d := BuildVisualization([]BenchmarkRun{vizMemRun("128", 40, nil), vizMemRun("512", 55, nil)})
+	if metricKeys(d)["mem_gpu"] {
+		t.Error("memory is offered although no run measured any")
+	}
+	if !metricKeys(d)["gen"] {
+		t.Error("the speed metrics went missing")
+	}
+}
+
+// The metric list is built per call. Appending to the package-level
+// slice would leak one comparison's memory metrics into the next.
+func TestVisualizationMetricsDoNotLeakBetweenCalls(t *testing.T) {
+	BuildVisualization([]BenchmarkRun{vizMemRun("128", 40, &MemorySnapshot{GPUGiB: 23, Cards: 1})})
+	d := BuildVisualization([]BenchmarkRun{vizMemRun("128", 40, nil)})
+	if metricKeys(d)["mem_gpu"] {
+		t.Error("memory metrics leaked from the previous call")
+	}
+}

--- a/internal/memreport/collector.go
+++ b/internal/memreport/collector.go
@@ -1,0 +1,235 @@
+package memreport
+
+import (
+	"regexp"
+	"sync"
+	"time"
+)
+
+// spawnRE matches the router's announcement that it has started a child
+// process for a model, which is the only line tying an instance back to
+// the model it serves:
+//
+//	0.05.123.456 I srv          load: spawning server instance with name=Qwen3.6-27B on port 46231
+//
+// The router logs this itself rather than through a model instance, at
+// LOG_INF — verbosity 3, llama.cpp's default. The buffer report the
+// instance then prints needs verbosity 4, so a stream can carry the
+// mapping with nothing to map, but never the reverse.
+//
+// The name is matched greedily up to the port so a model whose id
+// contains " on port " still resolves.
+var spawnRE = regexp.MustCompile(`spawning server instance with name=(.+) on port (\d+)\s*$`)
+
+// readyRE matches the line a child writes when it has finished loading
+// and is ready to serve:
+//
+//	[46231] cmd_child_to_router:state:{"state":"ready","payload":{...}}
+//
+// The router forwards every line a child prints before checking whether
+// it is one of these control messages, so it arrives in the log stream
+// like any other. It is the end of the load — and so the moment at which
+// the card counters are worth reading.
+//
+// A model waking from sleep reports ready again without a spawn. That
+// leaves the first ready standing rather than replacing it, which is the
+// honest reading: the load being described is still the one measured.
+var readyRE = regexp.MustCompile(`^\[\s*(\d+)\] cmd_child_to_router:state:.*"state"\s*:\s*"ready"`)
+
+// Measurement is what one model load allocated, as llama.cpp reported it
+// while loading.
+type Measurement struct {
+	// Model is the router's name for the model, which is the registry id:
+	// preset sections are written under it (models.GeneratePresetINI).
+	Model string
+	// Port is the child instance's port, the number the router prefixes
+	// onto every line that instance logs. Instances are what the log
+	// separates; the port is how.
+	Port string
+	// At is when the spawn line was seen; Ready is when the instance
+	// reported itself loaded, zero while it is still loading. Between the
+	// two is the window in which this model, and ideally nothing else,
+	// was claiming memory.
+	At    time.Time
+	Ready time.Time
+	// Note is whatever the caller attached at spawn time — the
+	// configuration in force for this load, in practice. Left to the
+	// caller because what makes two loads comparable is a question about
+	// launch configuration, which this package deliberately knows nothing
+	// about.
+	Note any
+	// Report holds the buffer lines this instance logged, unscaled: a
+	// tensor-parallel load reports per card, and turning that into totals
+	// needs a card count only the caller has (Report.ScaleAggregates).
+	Report Report
+}
+
+// Collector turns the router's combined log stream into one Measurement
+// per model, which is the only way to see what a load really cost rather
+// than what it was predicted to cost.
+//
+// Feed it every line: it picks out the two kinds it needs and ignores the
+// rest. Safe for concurrent use — the reader goroutine writes while
+// request handlers read.
+type Collector struct {
+	mu sync.Mutex
+	// byPort is the in-flight mapping: buffer lines carry a port and
+	// nothing else, so this is what attributes them. Reset by a router
+	// restart, which reallocates ports.
+	byPort map[string]*Measurement
+	// byModel keeps the most recent load per model, including loads whose
+	// instance has since exited. A measurement outlives its instance
+	// because it is still the last thing known about that model.
+	byModel map[string]*Measurement
+	now     func() time.Time
+}
+
+// A nil *Collector is a working no-op: every method below tolerates one.
+// Collection is observation — a server assembled without a collector
+// should still start its router and render its pages, rather than fault
+// on a code path that has nothing to do with memory.
+
+// NewCollector returns an empty collector.
+func NewCollector() *Collector {
+	return &Collector{
+		byPort:  map[string]*Measurement{},
+		byModel: map[string]*Measurement{},
+		now:     time.Now,
+	}
+}
+
+// EventKind is what a log line turned out to mean.
+type EventKind int
+
+const (
+	// EventNone is every line that is not a boundary of a load, buffer
+	// reports included: those are collected, not announced.
+	EventNone EventKind = iota
+	// EventSpawned is a load starting.
+	EventSpawned
+	// EventReady is a load finishing.
+	EventReady
+)
+
+// Event reports a boundary of a model load. Both boundaries matter to a
+// caller measuring from outside — the card counters have to be read
+// before the first allocation and after the last.
+type Event struct {
+	Kind  EventKind
+	Model string
+	Port  string
+}
+
+// Add feeds one log line and reports whether it was the start or the end
+// of a load. Buffer lines in between are collected silently.
+func (c *Collector) Add(line string) Event {
+	if c == nil {
+		return Event{}
+	}
+	if m := spawnRE.FindStringSubmatch(line); m != nil {
+		name, port := m[1], m[2]
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		// A fresh record rather than a reset one: the previous
+		// measurement for this model may still be the answer to a
+		// request being served right now, and callers hold copies.
+		ld := &Measurement{Model: name, Port: port, At: c.now()}
+		c.byPort[port] = ld
+		c.byModel[name] = ld
+		return Event{Kind: EventSpawned, Model: name, Port: port}
+	}
+
+	if m := readyRE.FindStringSubmatch(line); m != nil {
+		port := m[1]
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		ld := c.byPort[port]
+		if ld == nil {
+			return Event{}
+		}
+		if ld.Ready.IsZero() {
+			ld.Ready = c.now()
+		}
+		return Event{Kind: EventReady, Model: ld.Model, Port: port}
+	}
+
+	e, ok := ParseLine(line)
+	if !ok || e.Instance == "" {
+		// An unprefixed buffer line came from the router process itself,
+		// which loads no model. Nothing to attribute it to.
+		return Event{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ld := c.byPort[e.Instance]; ld != nil {
+		ld.Report.Entries = append(ld.Report.Entries, e)
+	}
+	return Event{}
+}
+
+// Annotate attaches the caller's note to the load on a port. Keyed by
+// port rather than by model so a note computed for one load cannot land
+// on a newer load of the same model that started while it was being
+// prepared. A no-op for a port with no load.
+func (c *Collector) Annotate(port string, note any) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ld := c.byPort[port]; ld != nil {
+		ld.Note = note
+	}
+}
+
+// InFlight is how many loads have started and not yet reported ready.
+// More than one means any measurement taken from the card counters
+// covers several models at once.
+func (c *Collector) InFlight() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, ld := range c.byPort {
+		if ld.Ready.IsZero() {
+			n++
+		}
+	}
+	return n
+}
+
+// Latest returns the most recent measurement for a model. The Report in
+// the copy is a snapshot: entries collected after this call don't appear
+// in it, so a load still in progress reads as whatever had been reported
+// by the time it was asked.
+func (c *Collector) Latest(model string) (Measurement, bool) {
+	if c == nil {
+		return Measurement{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ld, ok := c.byModel[model]
+	if !ok {
+		return Measurement{}, false
+	}
+	return *ld, true
+}
+
+// Reset drops the port mapping. Call it when the router is about to
+// start: ports are allocated per instance and reused freely across
+// runs, so a stale entry would quietly collect another model's buffers.
+//
+// Past measurements are kept. They are no longer live — the instances
+// that produced them are gone — but they remain the last thing measured
+// for that model, and whether that still applies is a question about
+// configuration the caller is better placed to answer.
+func (c *Collector) Reset() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byPort = map[string]*Measurement{}
+}

--- a/internal/memreport/collector_test.go
+++ b/internal/memreport/collector_test.go
@@ -1,0 +1,236 @@
+package memreport
+
+import (
+	"strings"
+	"testing"
+)
+
+// twoInstances is the shape the router really produces when a second
+// model is loaded while the first is still allocating: one spawn line per
+// instance from the router itself, and buffer reports from both children
+// interleaved in a single stream, told apart only by the bracketed port.
+const twoInstances = `0.00.100.000 I srv          load: spawning server instance with name=modelA on port 46231
+0.00.200.000 I srv          load: spawning server instance with name=modelB on port 39114
+[46231] 0.14.275.751 I load_tensors:   CPU_Mapped model buffer size =  1024.00 MiB
+[39114] 0.14.300.000 I load_tensors:        ROCm0 model buffer size =  4096.00 MiB
+[46231] 0.14.275.753 I load_tensors:        ROCm0 model buffer size =  8192.00 MiB
+[39114] 0.16.100.000 I llama_kv_cache:      ROCm0 KV buffer size =   512.00 MiB
+[46231] 0.16.162.940 I llama_kv_cache:      ROCm0 KV buffer size =  2048.00 MiB
+[46231] 0.16.260.669 I sched_reserve:   ROCm_Host compute buffer size =   256.00 MiB
+[46231] 0.16.260.662 I sched_reserve:       ROCm0 compute buffer size =  1024.00 MiB`
+
+func feed(c *Collector, log string) {
+	for _, line := range strings.Split(log, "\n") {
+		c.Add(line)
+	}
+}
+
+func TestCollectorAttributesLinesToTheModelThatLoggedThem(t *testing.T) {
+	c := NewCollector()
+	feed(c, twoInstances)
+
+	a, ok := c.Latest("modelA")
+	if !ok {
+		t.Fatal("modelA has no measurement")
+	}
+	if a.Port != "46231" {
+		t.Errorf("modelA port = %q; want 46231", a.Port)
+	}
+	// 8192 weights + 2048 KV + 1024 compute; the host-mapped weights and
+	// the host compute buffer are not on a device.
+	if got := a.Report.GPUMiB(true); got != 11264 {
+		t.Errorf("modelA GPU = %v MiB; want 11264", got)
+	}
+	if got := a.Report.HostMiB(true); got != 1280 {
+		t.Errorf("modelA host = %v MiB; want 1280", got)
+	}
+
+	b, ok := c.Latest("modelB")
+	if !ok {
+		t.Fatal("modelB has no measurement")
+	}
+	if got := b.Report.GPUMiB(true); got != 4608 {
+		t.Errorf("modelB GPU = %v MiB; want 4608 — lines from the other instance leaked in", got)
+	}
+}
+
+func TestCollectorReportsTheBoundariesOfALoad(t *testing.T) {
+	c := NewCollector()
+
+	ev := c.Add("0.00.100.000 I srv          load: spawning server instance with name=modelA on port 46231")
+	if ev.Kind != EventSpawned || ev.Model != "modelA" || ev.Port != "46231" {
+		t.Errorf("spawn line = %+v; want a spawn of modelA on 46231", ev)
+	}
+	if ev := c.Add("[46231] 0.14.275.753 I load_tensors:  ROCm0 model buffer size = 8192.00 MiB"); ev.Kind != EventNone {
+		t.Errorf("buffer line = %+v; want no event — it is collected, not announced", ev)
+	}
+	if ev := c.Add("[46231] 0.14.000.000 I main: server is listening"); ev.Kind != EventNone {
+		t.Errorf("unrelated line = %+v; want no event", ev)
+	}
+
+	ev = c.Add(`[46231] cmd_child_to_router:state:{"state":"ready","payload":{"n_ctx":8192}}`)
+	if ev.Kind != EventReady || ev.Model != "modelA" {
+		t.Errorf("ready line = %+v; want a ready for modelA", ev)
+	}
+	if m, _ := c.Latest("modelA"); m.Ready.IsZero() {
+		t.Error("the measurement does not record when loading finished")
+	}
+}
+
+// A load is in flight from its spawn until it reports ready. It matters
+// because a card-counter reading taken while two models are loading
+// describes both of them.
+func TestCollectorTracksLoadsInFlight(t *testing.T) {
+	c := NewCollector()
+	if got := c.InFlight(); got != 0 {
+		t.Errorf("in flight = %d; want 0", got)
+	}
+	feed(c, twoInstances)
+	if got := c.InFlight(); got != 2 {
+		t.Errorf("in flight = %d; want 2 — both spawned, neither ready", got)
+	}
+	c.Add(`[46231] cmd_child_to_router:state:{"state":"ready","payload":{}}`)
+	if got := c.InFlight(); got != 1 {
+		t.Errorf("in flight = %d; want 1", got)
+	}
+}
+
+// A ready for a port with no load — a leftover from a previous router
+// run, say — must not invent one.
+func TestCollectorIgnoresReadyForAnUnknownPort(t *testing.T) {
+	c := NewCollector()
+	if ev := c.Add(`[59999] cmd_child_to_router:state:{"state":"ready","payload":{}}`); ev.Kind != EventNone {
+		t.Errorf("ready for an unknown port = %+v; want no event", ev)
+	}
+}
+
+// Waking from sleep reports ready again. The load being described is
+// still the one that was measured, so the first time stands.
+func TestCollectorKeepsTheFirstReady(t *testing.T) {
+	c := NewCollector()
+	c.Add("0.00.100.000 I srv          load: spawning server instance with name=modelA on port 46231")
+	c.Add(`[46231] cmd_child_to_router:state:{"state":"ready","payload":{}}`)
+	first, _ := c.Latest("modelA")
+	c.Add(`[46231] cmd_child_to_router:state:{"state":"ready","payload":{}}`)
+	again, _ := c.Latest("modelA")
+	if !again.Ready.Equal(first.Ready) {
+		t.Errorf("ready moved from %v to %v on a wakeup", first.Ready, again.Ready)
+	}
+}
+
+// A model id may contain the words the spawn line uses to delimit it. The
+// port is what ends the line, so the name is whatever precedes it.
+func TestCollectorSpawnLineWithAwkwardName(t *testing.T) {
+	c := NewCollector()
+	const id = "user--Weird on port 1-GGUF--Q4_K_M"
+	ev := c.Add("0.00.100.000 I srv          load: spawning server instance with name=" + id + " on port 46231")
+	if ev.Kind != EventSpawned || ev.Model != id {
+		t.Errorf("event = %+v; want a spawn of %q", ev, id)
+	}
+}
+
+func TestCollectorReloadStartsAFreshReport(t *testing.T) {
+	c := NewCollector()
+	feed(c, `0.00.100.000 I srv          load: spawning server instance with name=modelA on port 46231
+[46231] 0.14.275.753 I load_tensors:  ROCm0 model buffer size = 8192.00 MiB
+0.20.100.000 I srv          load: spawning server instance with name=modelA on port 51002
+[51002] 0.24.275.753 I load_tensors:  ROCm0 model buffer size = 4096.00 MiB`)
+
+	m, ok := c.Latest("modelA")
+	if !ok {
+		t.Fatal("no measurement")
+	}
+	// The second load is a different configuration or a different model
+	// file; adding the two would report a model twice its size.
+	if got := m.Report.GPUMiB(true); got != 4096 {
+		t.Errorf("GPU = %v MiB; want 4096 — a reload must replace, not accumulate", got)
+	}
+	if m.Port != "51002" {
+		t.Errorf("port = %q; want 51002", m.Port)
+	}
+}
+
+func TestCollectorResetDropsPortsButKeepsMeasurements(t *testing.T) {
+	c := NewCollector()
+	feed(c, twoInstances)
+	c.Reset()
+
+	// A new router run reuses the port for something else entirely.
+	c.Add("[46231] 0.14.275.753 I load_tensors:  ROCm0 model buffer size = 99999.00 MiB")
+
+	a, ok := c.Latest("modelA")
+	if !ok {
+		t.Fatal("reset must keep what was already measured")
+	}
+	if got := a.Report.GPUMiB(true); got != 11264 {
+		t.Errorf("GPU = %v MiB; want 11264 — a stale port collected another run's buffers", got)
+	}
+}
+
+func TestCollectorAnnotate(t *testing.T) {
+	c := NewCollector()
+	feed(c, twoInstances)
+
+	c.Annotate("46231", "ctx=8192") // modelA's port
+	c.Annotate("50000", "ctx=4096") // no load there: nothing to attach to
+
+	a, _ := c.Latest("modelA")
+	if a.Note != "ctx=8192" {
+		t.Errorf("note = %v; want ctx=8192", a.Note)
+	}
+	if b, _ := c.Latest("modelB"); b.Note != nil {
+		t.Errorf("modelB note = %v; want nil — annotating one model must not touch another", b.Note)
+	}
+	if _, ok := c.Latest("modelC"); ok {
+		t.Error("annotating an unknown port must not create a measurement")
+	}
+}
+
+// Buffer lines with no port prefix come from the router process, which
+// loads no model of its own. Attributing them to whichever model spawned
+// last would inflate that model.
+func TestCollectorIgnoresUnprefixedBufferLines(t *testing.T) {
+	c := NewCollector()
+	c.Add("0.00.100.000 I srv          load: spawning server instance with name=modelA on port 46231")
+	c.Add("0.14.275.753 I load_tensors:  ROCm0 model buffer size = 8192.00 MiB")
+
+	a, _ := c.Latest("modelA")
+	if got := len(a.Report.Entries); got != 0 {
+		t.Errorf("entries = %d; want 0", got)
+	}
+}
+
+// A tensor-parallel load reports per card against llama.cpp's aggregate
+// device, so the collector's raw figures need scaling by the card count
+// the caller knows. Guards the pairing of the two.
+func TestCollectorReportScalesAggregates(t *testing.T) {
+	c := NewCollector()
+	feed(c, `0.00.100.000 I srv          load: spawning server instance with name=modelA on port 46231
+[46231] 0.14.275.753 I load_tensors:      Meta() model buffer size = 7252.51 MiB
+[46231] 0.16.162.940 I llama_kv_cache:    Meta() KV buffer size = 1024.00 MiB`)
+
+	m, _ := c.Latest("modelA")
+	one := m.Report.GPUMiB(true)
+	four := m.Report.ScaleAggregates(4).GPUMiB(true)
+	if four != one*4 {
+		t.Errorf("scaled = %v; want %v (4x the per-card figures)", four, one*4)
+	}
+}
+
+// The router writes the instance prefix with "[%5d] ", so a port below
+// 10000 arrives padded while the spawn line states it unpadded. Both
+// have to reach the same record, or a load on a low port collects
+// nothing at all.
+func TestCollectorMatchesAPaddedPortPrefix(t *testing.T) {
+	c := NewCollector()
+	feed(c, `0.00.100.000 I srv          load: spawning server instance with name=modelA on port 4623
+[ 4623] 0.14.275.753 I load_tensors:  ROCm0 model buffer size = 8192.00 MiB`)
+
+	m, ok := c.Latest("modelA")
+	if !ok {
+		t.Fatal("no measurement")
+	}
+	if got := m.Report.GPUMiB(true); got != 8192 {
+		t.Errorf("GPU = %v MiB; want 8192", got)
+	}
+}

--- a/internal/memreport/memreport.go
+++ b/internal/memreport/memreport.go
@@ -30,10 +30,13 @@ const (
 
 // Entry is one "<device> <kind> buffer size = N MiB" observation.
 type Entry struct {
-	// Instance is the child process id llama.cpp's router prefixes onto
-	// lines from the model instance that is doing the loading. Empty for
-	// lines the router itself emitted. Reports from concurrently loading
-	// models interleave in one stream, so this is what separates them.
+	// Instance is the port llama.cpp's router prefixes onto lines from
+	// the model instance that is doing the loading — the router logs
+	// "[%5d] " with the child's port, not its pid. Empty for lines the
+	// router itself emitted. Reports from concurrently loading models
+	// interleave in one stream, so this is what separates them. The
+	// router states which model holds a port when it spawns the
+	// instance; Collector reads both and pairs them up.
 	Instance string
 	// Category is the llama.cpp function that logged the line
 	// (load_tensors, llama_kv_cache, sched_reserve, ...). Kept because
@@ -72,18 +75,23 @@ func isHostDevice(device string) bool {
 		strings.HasSuffix(device, "_Host")
 }
 
-// lineRE matches an optional "[pid] " prefix, llama.cpp's timestamp and
+// lineRE matches an optional "[port] " prefix, llama.cpp's timestamp and
 // level, the logging function, and then the buffer report itself. The
 // device name is deliberately \S+ rather than a list: "Meta()" carries
 // parentheses and backend names grow, so an allowlist would silently
 // drop the very numbers this exists to collect.
+//
+// The prefix allows leading spaces because the router writes it with
+// "[%5d] ": a port below 10000 arrives padded, and a prefix that failed
+// to match would drop the line entirely rather than merely lose its
+// instance.
 var lineRE = regexp.MustCompile(
-	`^(?:\[(\d+)\] )?[\d.]+ [A-Z] (\w+):\s+(\S+)\s+(model|KV|compute|output)\s+buffer size\s*=\s*([\d.]+)\s*MiB`)
+	`^(?:\[\s*(\d+)\] )?[\d.]+ [A-Z] (\w+):\s+(\S+)\s+(model|KV|compute|output)\s+buffer size\s*=\s*([\d.]+)\s*MiB`)
 
 // recurrentRE is separate because llama.cpp spells recurrent state "RS"
 // in the buffer line while naming the function llama_memory_recurrent.
 var recurrentRE = regexp.MustCompile(
-	`^(?:\[(\d+)\] )?[\d.]+ [A-Z] (\w+):\s+(\S+)\s+RS\s+buffer size\s*=\s*([\d.]+)\s*MiB`)
+	`^(?:\[\s*(\d+)\] )?[\d.]+ [A-Z] (\w+):\s+(\S+)\s+RS\s+buffer size\s*=\s*([\d.]+)\s*MiB`)
 
 // ParseLine extracts one entry, reporting false for any line that is not
 // a buffer report — which is the overwhelming majority of the stream.
@@ -153,20 +161,21 @@ func (r *Report) Add(line string) bool {
 	return ok
 }
 
-// ForInstance returns the entries a single model instance logged. The
-// router interleaves output from every child, so totals taken without
-// this are the sum of whatever happened to be loading.
-func (r Report) ForInstance(pid string) Report {
+// ForInstance returns the entries a single model instance logged, keyed
+// by the port in Entry.Instance. The router interleaves output from every
+// child, so totals taken without this are the sum of whatever happened to
+// be loading.
+func (r Report) ForInstance(port string) Report {
 	var out Report
 	for _, e := range r.Entries {
-		if e.Instance == pid {
+		if e.Instance == port {
 			out.Entries = append(out.Entries, e)
 		}
 	}
 	return out
 }
 
-// Instances lists the child process ids present, in first-seen order.
+// Instances lists the instance ports present, in first-seen order.
 func (r Report) Instances() []string {
 	seen := map[string]bool{}
 	var out []string

--- a/internal/models/vram.go
+++ b/internal/models/vram.go
@@ -141,11 +141,52 @@ const (
 	vramPerDeviceOverheadGB = 0.85
 )
 
+// VRAMBreakdown is the estimate term by term, in GiB. The terms are named
+// for what llama.cpp reports, so an estimate can be checked against a
+// measured load piece by piece rather than only in total — which is what
+// a total alone cannot do: the estimate this replaced was accurate on one
+// model purely because a 27 GiB over-count of weights cancelled a 20 GiB
+// under-count of everything else.
+//
+// Which measured figure each term answers to:
+//
+//	Weights, Aux    model buffers on a device
+//	KVCache         KV and recurrent-state buffers
+//	IndexerCache    the sparse-attention key cache
+//	Compute         compute and output buffers
+//	IndexerScratch  the rest of the compute buffers on a sparse model
+//	Overhead        nothing — it is the remainder llama.cpp never itemises,
+//	                the gap between its own accounting and the card counters
+type VRAMBreakdown struct {
+	Weights        float64
+	Aux            float64
+	KVCache        float64
+	IndexerCache   float64
+	Compute        float64
+	IndexerScratch float64
+	Overhead       float64
+}
+
+// Total is the figure the UI shows.
+func (b VRAMBreakdown) Total() float64 {
+	return b.Weights + b.Aux + b.KVCache + b.IndexerCache + b.Compute + b.IndexerScratch + b.Overhead
+}
+
+// Reported is the part of the estimate llama.cpp itemises while loading,
+// which is what a measured buffer report can be compared against.
+func (b VRAMBreakdown) Reported() float64 { return b.Total() - b.Overhead }
+
 // VRAMEstimateForConfigOn estimates VRAM for a model spread over devices
 // cards. The count matters because graph scratch and driver overhead are
 // per device, not per model: the same config across four cards costs four
 // times the scratch of one.
 func VRAMEstimateForConfigOn(m *Model, cfg *ModelConfig, cards int) float64 {
+	return VRAMBreakdownForConfigOn(m, cfg, cards).Total()
+}
+
+// VRAMBreakdownForConfigOn is VRAMEstimateForConfigOn with its terms kept
+// apart. Same arithmetic; the split exists so each term can be measured.
+func VRAMBreakdownForConfigOn(m *Model, cfg *ModelConfig, cards int) VRAMBreakdown {
 	if cards < 1 {
 		cards = 1
 	}
@@ -153,6 +194,8 @@ func VRAMEstimateForConfigOn(m *Model, cfg *ModelConfig, cards int) float64 {
 	if ctx == 0 {
 		ctx = m.ContextLength
 	}
+
+	var b VRAMBreakdown
 
 	// Weights, less the parts llama.cpp holds host-mapped rather than on a
 	// device. Two tensors do that on every model measured: the per-layer
@@ -162,14 +205,14 @@ func VRAMEstimateForConfigOn(m *Model, cfg *ModelConfig, cards int) float64 {
 	if resident < 0 {
 		resident = m.SizeBytes
 	}
-	gb := BytesToGiB(resident)
+	b.Weights = BytesToGiB(resident)
 
-	gb += m.KVCacheGB(ctx, cfg.KVCacheQuant)
+	b.KVCache = m.KVCacheGB(ctx, cfg.KVCacheQuant)
 
 	// Graph scratch.
 	ub := cfg.EffectiveUBatchSize()
 	perCard := computeMiBPerUBatchTok*float64(ub) + computeMiBPerCtxTok*float64(ctx)
-	gb += float64(cards) * perCard / 1024
+	b.Compute = float64(cards) * perCard / 1024
 
 	// Sparse attention: a key cache of its own, plus scratch that scales
 	// with context times micro-batch on every device.
@@ -178,13 +221,13 @@ func VRAMEstimateForConfigOn(m *Model, cfg *ModelConfig, cards int) float64 {
 		if layers == 0 {
 			layers = m.NLayers
 		}
-		gb += float64(layers) * float64(ctx) * float64(m.IndexerKeyLength) * 4 / (1024 * 1024 * 1024)
-		gb += float64(cards) * indexerScratchCopies * float64(ctx) * float64(ub) * 4 / (1024 * 1024 * 1024)
+		b.IndexerCache = float64(layers) * float64(ctx) * float64(m.IndexerKeyLength) * 4 / (1024 * 1024 * 1024)
+		b.IndexerScratch = float64(cards) * indexerScratchCopies * float64(ctx) * float64(ub) * 4 / (1024 * 1024 * 1024)
 	}
 
-	gb += AuxFilesVRAMGB(cfg)
-	gb += float64(cards) * vramPerDeviceOverheadGB
-	return gb
+	b.Aux = AuxFilesVRAMGB(cfg)
+	b.Overhead = float64(cards) * vramPerDeviceOverheadGB
+	return b
 }
 
 // PLEAutoMinBytes mirrors auto_lazy_min_size in llama.cpp's model loader:

--- a/internal/models/vram_corpus_test.go
+++ b/internal/models/vram_corpus_test.go
@@ -19,6 +19,30 @@ type corpusPoint struct {
 	cfg      ModelConfig
 	cards    int
 	measured float64 // GiB, summed across cards
+	// reported is the same load as llama.cpp itemised it while
+	// allocating, GPU side only. A total can hide two errors that cancel
+	// — the estimate this corpus replaced did exactly that — so where the
+	// split is known it is recorded, and TestEstimateTermsAgainstTheBufferReport
+	// checks the terms one at a time.
+	//
+	// Nil for points measured before the split was captured. New points
+	// should carry it: /api/models/{id}/vram-corpus prints a filled-in
+	// row for whatever the router last loaded.
+	reported *reportedTerms
+}
+
+// reportedTerms is one load's buffer report, GiB on the accelerators.
+type reportedTerms struct {
+	weights   float64
+	kv        float64
+	recurrent float64
+	compute   float64 // compute and output buffers
+}
+
+// total is what llama.cpp accounts for. Always less than the card
+// counters: context and allocator overhead are not in the report.
+func (r reportedTerms) total() float64 {
+	return r.weights + r.kv + r.recurrent + r.compute
 }
 
 // Sizes are in GiB where written as floats and converted below.
@@ -55,19 +79,45 @@ func corpus() []corpusPoint {
 		SlidingWindow: 512, ContextLength: 131072,
 	}
 	c := func(ctx, ub int) ModelConfig { return ModelConfig{ContextSize: ctx, UBatchSize: ub} }
-	return []corpusPoint{
-		{"Flash-Next ctx32k ub1024", fn(32768, 1024), c(32768, 1024), 4, 84.48},
-		{"Flash-Next ctx128k ub1024", fn(131072, 1024), c(131072, 1024), 4, 95.96},
-		{"Flash-Next ctx262k ub512", fn(262144, 512), c(262144, 512), 4, 98.96},
-		{"27B ctx8k ub512", q27, c(8192, 512), 4, 31.43},
-		{"27B ctx32k ub512", q27, c(32768, 512), 4, 33.01},
-		{"27B ctx128k ub512", q27, c(131072, 512), 4, 39.38},
-		{"27B ctx262k ub512", q27, c(262144, 512), 4, 47.87},
-		{"27B ctx32k ub128", q27, c(32768, 128), 4, 32.61},
-		{"27B ctx32k ub2048", q27, c(32768, 2048), 4, 34.82},
-		{"35B-A3B ctx32k ub512", q35, c(32768, 512), 4, 38.08},
-		{"gemma-4-E4B ctx4k ub512", gem, c(4096, 512), 1, 3.42},
+	// The 27B's weights and recurrent state are the same on every row —
+	// neither depends on context or micro-batch, which is itself part of
+	// what the sweep established.
+	q27terms := func(kv, compute float64) *reportedTerms {
+		return &reportedTerms{weights: 27.51, kv: kv, recurrent: 0.60, compute: compute}
 	}
+	return []corpusPoint{
+		{"Flash-Next ctx32k ub1024", fn(32768, 1024), c(32768, 1024), 4, 84.48, nil},
+		{"Flash-Next ctx128k ub1024", fn(131072, 1024), c(131072, 1024), 4, 95.96, nil},
+		{"Flash-Next ctx262k ub512", fn(262144, 512), c(262144, 512), 4, 98.96, nil},
+		// The one sparse-attention load that was decomposed: its saved
+		// config, quantized KV cache and all. See "The decomposition,
+		// measured" in plan/ple-vram-findings.md.
+		{"Flash-Next ctx262k ub1024 kv-q8_0", fn(262144, 1024),
+			ModelConfig{ContextSize: 262144, UBatchSize: 1024, KVCacheQuant: "q8_0"}, 4, 107.35,
+			&reportedTerms{weights: 76.23, kv: 4.38, recurrent: 0.44, compute: 24.40}},
+		{"27B ctx8k ub512", q27, c(8192, 512), 4, 31.43, q27terms(0.48, 0.52)},
+		{"27B ctx32k ub512", q27, c(32768, 512), 4, 33.01, q27terms(2.00, 0.60)},
+		{"27B ctx128k ub512", q27, c(131072, 512), 4, 39.38, q27terms(8.00, 0.96)},
+		{"27B ctx262k ub512", q27, c(262144, 512), 4, 47.87, q27terms(16.00, 1.48)},
+		{"27B ctx32k ub128", q27, c(32768, 128), 4, 32.61, q27terms(2.00, 0.20)},
+		{"27B ctx32k ub2048", q27, c(32768, 2048), 4, 34.82, q27terms(2.00, 2.40)},
+		{"35B-A3B ctx32k ub512", q35, c(32768, 512), 4, 38.08, nil},
+		{"gemma-4-E4B ctx4k ub512", gem, c(4096, 512), 1, 3.42, nil},
+	}
+}
+
+// point looks a corpus point up by name. Positional access breaks
+// silently when a point is inserted, and inserting points is the whole
+// intent of this file.
+func point(t *testing.T, name string) corpusPoint {
+	t.Helper()
+	for _, p := range corpus() {
+		if p.name == name {
+			return p
+		}
+	}
+	t.Fatalf("no corpus point named %q", name)
+	return corpusPoint{}
 }
 
 // The guardrail. An estimate below what the hardware actually used tells
@@ -111,7 +161,7 @@ func TestEstimateStaysCloseToMeasured(t *testing.T) {
 // across one. A caller that cannot supply the count gets the single-device
 // figure, which is the smaller one — so this must be visible, not silent.
 func TestDeviceCountChangesTheEstimate(t *testing.T) {
-	p := corpus()[3] // 27B, no indexer
+	p := point(t, "27B ctx262k ub512") // no indexer
 	one := VRAMEstimateForConfigOn(&p.model, &p.cfg, 1)
 	four := VRAMEstimateForConfigOn(&p.model, &p.cfg, 4)
 	if four <= one {
@@ -145,7 +195,7 @@ func TestHostMappedWeightsExcluded(t *testing.T) {
 // A sparse-attention model pays for ranking the whole cache. Without that
 // term Flash-Next is under-predicted by tens of GiB at long context.
 func TestIndexerTermOnlyAppliesToRankingModels(t *testing.T) {
-	p := corpus()[2] // Flash-Next ctx262k
+	p := point(t, "Flash-Next ctx262k ub512")
 	with := VRAMEstimateForConfigOn(&p.model, &p.cfg, p.cards)
 
 	plain := p.model
@@ -157,5 +207,109 @@ func TestIndexerTermOnlyAppliesToRankingModels(t *testing.T) {
 	}
 	if without >= p.measured {
 		t.Error("the estimate is adequate without the indexer term; the fixture no longer shows why it exists")
+	}
+}
+
+// The estimate has to be right for the right reasons. A total alone
+// cannot tell a good model from two mistakes that cancel: the estimate
+// this corpus replaced was within 7 GiB on Qwen3.8-Flash-Next while
+// over-counting weights by 27 and under-counting everything else by 20.
+//
+// So each term is checked against what llama.cpp said it allocated, in
+// the same direction as the total: at or above measured, and close.
+func TestEstimateTermsAgainstTheBufferReport(t *testing.T) {
+	const closeEnough = 1.0 // GiB, per term
+
+	checked := 0
+	for _, p := range corpus() {
+		if p.reported == nil {
+			continue
+		}
+		checked++
+		b := VRAMBreakdownForConfigOn(&p.model, &p.cfg, p.cards)
+
+		weights := b.Weights + b.Aux
+		if weights < p.reported.weights {
+			t.Errorf("%s: weights estimated %.2f, measured %.2f — under by %.2f",
+				p.name, weights, p.reported.weights, p.reported.weights-weights)
+		}
+		if weights-p.reported.weights > closeEnough {
+			t.Errorf("%s: weights over by %.2f GiB", p.name, weights-p.reported.weights)
+		}
+
+		// The KV term answers to the attention cache only; recurrent
+		// state is the term below.
+		kv := b.KVCache + b.IndexerCache
+		if kv < p.reported.kv {
+			t.Errorf("%s: KV cache estimated %.2f, measured %.2f — under by %.2f",
+				p.name, kv, p.reported.kv, p.reported.kv-kv)
+		}
+		if kv-p.reported.kv > closeEnough {
+			t.Errorf("%s: KV cache over by %.2f GiB", p.name, kv-p.reported.kv)
+		}
+
+		compute := b.Compute + b.IndexerScratch
+		if compute < p.reported.compute {
+			t.Errorf("%s: compute buffers estimated %.2f, measured %.2f — under by %.2f",
+				p.name, compute, p.reported.compute, p.reported.compute-compute)
+		}
+		if compute-p.reported.compute > closeEnough {
+			t.Errorf("%s: compute buffers over by %.2f GiB", p.name, compute-p.reported.compute)
+		}
+
+		if diff := math.Abs(b.Reported() - p.reported.total()); diff > closeEnough {
+			t.Errorf("%s: llama.cpp accounts for %.2f GiB, the modelled terms for %.2f — off by %.2f",
+				p.name, p.reported.total(), b.Reported(), diff)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no corpus point carries a buffer report; this test proves nothing")
+	}
+	t.Logf("checked %d of %d corpus points term by term", checked, len(corpus()))
+}
+
+// Recurrent state is real and is not modelled: every hybrid in the corpus
+// allocates some, and no term accounts for it. What makes that safe is
+// the per-device overhead, which has to cover both the state and the gap
+// between llama.cpp's accounting and the card counters.
+//
+// If a recurrent term is ever added, this test should be deleted rather
+// than adjusted — it exists to say the omission is deliberate and paid
+// for, not that it is correct.
+func TestUnmodelledRecurrentStateIsCoveredByOverhead(t *testing.T) {
+	for _, p := range corpus() {
+		if p.reported == nil || p.reported.recurrent == 0 {
+			continue
+		}
+		b := VRAMBreakdownForConfigOn(&p.model, &p.cfg, p.cards)
+
+		// Everything the estimate does not itemise: the recurrent state
+		// it has no term for, plus what llama.cpp itself never reports.
+		unaccounted := p.reported.recurrent + (p.measured - p.reported.total())
+		if b.Overhead < unaccounted {
+			t.Errorf("%s: overhead allows %.2f GiB but %.2f is unaccounted for (%.2f recurrent state, %.2f above the buffer report)",
+				p.name, b.Overhead, unaccounted, p.reported.recurrent, p.measured-p.reported.total())
+		}
+	}
+}
+
+// The buffer report is not the whole story: context and allocator
+// overhead never appear in it. Anything reading the report as the
+// footprint — the Available Models tooltip, a corpus row — is reading a
+// figure below what the card will show, and the estimate has to keep
+// covering that difference.
+func TestCardCountersExceedTheBufferReport(t *testing.T) {
+	for _, p := range corpus() {
+		if p.reported == nil {
+			continue
+		}
+		remainder := p.measured - p.reported.total()
+		if remainder <= 0 {
+			t.Errorf("%s: the buffer report (%.2f) is not below the card counters (%.2f) — one of the two figures is wrong",
+				p.name, p.reported.total(), p.measured)
+		}
+		if remainder > 3.0 {
+			t.Errorf("%s: %.2f GiB unreported; the remainder was a near-constant 2.3 across the sweep it was measured on", p.name, remainder)
+		}
 	}
 }

--- a/plan/ple-vram-findings.md
+++ b/plan/ple-vram-findings.md
@@ -408,7 +408,16 @@ step 4 should account for.
 **Step 3 — decompose one load.** Done for Qwen3.8-Flash-Next; see the table
 below. `internal/memreport` parses the report into per-device, per-kind totals.
 
-**Step 2 — build a repeatable harness.** For each (model, context, batch,
+**Step 2 — build a repeatable harness. Partly done.** Every load is now
+measured as it happens: `internal/memreport.Collector` reads the router log
+stream, pairs each instance's buffer report with the model that spawned it, and
+the toolchest brackets the load with GPU-counter readings taken at the spawn
+line and at the child's `ready`. `GET /api/models/{id}/vram-corpus` prints the
+result as a `corpusPoint` literal ready to paste into the corpus, refusing to
+present a card figure taken while a second model was loading. What is still
+missing is the sweep: driving the axes automatically rather than by hand.
+
+**Step 2 (original).** For each (model, context, batch,
 ubatch, kv quant, ngl, ple_mode) point: load, record per-GPU VRAM, host RSS, and
 the per-buffer breakdown. Prerequisite: add `ple_mode` and `extra_flags` as
 benchmark sweep axes (`ConfigOverrides` in `benchmark/job.go:78`, catalogue in

--- a/web/jstest/viz_test.js
+++ b/web/jstest/viz_test.js
@@ -1,0 +1,35 @@
+// Which points a chart may draw. Not every run carries every metric: a
+// run measured before memory was recorded, or under a router below log
+// verbosity 4, has timings and no footprint. Drawing it at zero would
+// claim it used no memory, and Plotly's formatter throws on undefined,
+// so the page has to leave those runs out.
+require('./dom.js');
+const fs = require('fs');
+eval(fs.readFileSync(__dirname + '/viz.js', 'utf8'));
+
+let fails = 0;
+const ok = (c, m) => { if (!c) { console.log('FAIL:', m); fails++; } else console.log('pass:', m); };
+
+DATA = {
+    points: [
+        { run_id: 'a', metrics: { gen: 40, mem_gpu: 23 } },
+        { run_id: 'b', metrics: { gen: 55 } },
+        { run_id: 'c', metrics: { gen: 60, mem_gpu: 0 } }
+    ]
+};
+
+const speed = pointsWith({ key: 'gen' });
+ok(speed.length === 3, 'every run has a speed');
+
+const mem = pointsWith({ key: 'mem_gpu' });
+ok(mem.length === 2, 'the run with no footprint is left out of a memory chart');
+ok(mem.every(p => p.run_id !== 'b'), 'and it is the right one that is left out');
+
+// Zero is a measurement, not an absence — a model whose weights are all
+// on the CPU really does use no GPU memory.
+ok(mem.some(p => p.run_id === 'c'), 'a measured zero is still plotted');
+
+ok(pointsWith(null).length === 3, 'a chart with no metric keeps every point');
+
+console.log(fails === 0 ? 'ALL PASS' : fails + ' FAILURES');
+process.exit(fails === 0 ? 0 : 1);

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -355,8 +355,17 @@
     <ul>
         <li><strong>Detail</strong> — expands the job's cell matrix, with each cell's sweep point and per-run data.</li>
         <li><strong>Compare</strong> — check multiple rows and hit Compare to see them side by side, within or across jobs.</li>
-        <li><strong>Export</strong> — CSV or JSON, including the build's CMake flags and each run's sweep point so rows stay distinguishable outside the UI.</li>
+        <li><strong>Export</strong> — CSV or JSON, including the build's CMake flags, each run's sweep point, and the memory each load used, so rows stay distinguishable outside the UI.</li>
         <li><strong>Retry failed</strong> — re-runs only the cells that failed, keeping completed results.</li>
+    </ul>
+
+    <h3>Memory used</h3>
+    <p>Every benchmark cell loads the model, so every cell records what that load cost: the <strong>VRAM</strong> column in the comparison table, the <em>Memory used</em> block on a run's detail, a set of memory metrics in the visualization, and six columns in the CSV and JSON exports. That is what makes the trade visible — a bigger micro-batch buys prompt-processing speed and spends GPU memory, and a sweep now shows both sides of it on your own hardware instead of one.</p>
+    <p>These are measured figures, read from llama.cpp's own report as it allocates, not the estimate shown on the Models page. Three things to know when reading them:</p>
+    <ul>
+        <li><strong>They only exist at <em>Model loading detail</em> 4</strong> (<a href="/settings">Settings</a>). Below that llama.cpp itemises nothing, and a cell records its speed with no memory figure. Runs from before this was measured show an em-dash rather than a zero.</li>
+        <li><strong>The card total is a little higher</strong> than the sum llama.cpp reports — context and allocator overhead it does not count. Both figures are shown where there is room for both.</li>
+        <li><strong>Capability tests record nothing.</strong> They run with the server stopped, so there is no load to watch.</li>
     </ul>
 
     <div class="callout">

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -129,6 +129,7 @@
         <li>A <strong><span class="inline-icon"><svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><rect x="5" y="5" width="8" height="9" rx="1"/><path d="M3 11V3.5A.5.5 0 0 1 3.5 3H10"/></svg></span> copy</strong> icon — copies the public name to the clipboard.</li>
         <li>A <code>loaded</code> / <code>loading</code> tag when the router has it resident.</li>
     </ul>
+    <p>Hover a row to see what that model <em>actually</em> used the last time it loaded — GPU memory split into weights, KV cache and working buffers, per card, with anything left in system memory — next to the estimate for the current settings. The measured figures are read from llama.cpp's own report as it allocates, so they only exist for models loaded since the server started, and only when <em>Model loading detail</em> is set to 4 or higher on the <a href="/settings">Settings</a> page. The tooltip says which of these you are looking at, and says so plainly when there is nothing measured yet. A card's own reported usage runs a few hundred MiB per GPU above the measured figure, for driver overhead llama.cpp does not count.</p>
 
     <h3>Inventory &amp; API Endpoint cards</h3>
     <p>Build/model counts and the OpenAI-compatible base URL for your clients.</p>

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -140,6 +140,7 @@
                 <th title="Time To First Token in milliseconds, averaged over everything this run measured.">TTFT (ms)</th>
                 {{if .HasEval}}<th title="Capability evaluation score — only capability runs (perplexity / KL-divergence / HellaSwag / Winogrande) produce one; each row shows its own metric (the mode is part of the row identity, so rows of different modes are not compared against each other). PPL: perplexity — lower is better. HellaSwag / Winogrande: accuracy with confidence interval and task count. KLD: deviation from the reference — 0 = identical. Performance runs show an em-dash here.">Score</th>{{end}}
                 <th>Size</th>
+                <th title="GPU memory the load actually used, in GiB, read from llama.cpp's own report as it allocated — not an estimate. Hover a value for the split between weights, KV cache and working buffers. An em-dash means the run recorded none: llama.cpp reports its buffers only at Model loading detail 4, on the Settings page.">VRAM</th>
                 <th>GPUs</th>
                 <th>Context</th>
                 <th title="Batch / micro-batch (-b / -ub). A dash means llama.cpp's default.">Batch b/ub</th>
@@ -175,8 +176,13 @@
             <td>—</td>
             {{if $.HasEval}}<td><strong>{{evalScoreText $run.Eval}}</strong></td>{{end}}
             <td>{{printf "%.1f" $run.SizeGiB}} GiB</td>
+            {{/* A capability run is measured with the router stopped, so
+                 there is no load for the memory reader to watch and this
+                 cell is always an em-dash. Rendered rather than folded
+                 into the span below so the column keeps its tooltip. */}}
+            <td title="{{memDetail $run.Memory}}" style="cursor:help;">{{memText $run.Memory}}</td>
             {{/* GPUs, Context, Batch, KV Quant, Flash Attn, Build — six
-                 columns, which is what the header has after Size. A
+                 columns, which is what the header has after VRAM. A
                  short span here shifts every later column. */}}
             <td colspan="6">—</td>
             {{if $.HasLlamaBench}}<td>—</td>{{end}}
@@ -210,6 +216,7 @@
             <td>{{if evalHas $run.Eval}}{{evalScoreText $run.Eval}}{{else}}—{{end}}</td>
             {{end}}
             <td>{{printf "%.1f" $run.SizeGiB}} GiB</td>
+            <td title="{{memDetail $run.Memory}}" style="cursor:help;">{{memText $run.Memory}}</td>
             <td>{{if $run.Config.GPUAssign}}{{$run.Config.GPUAssign}}{{else}}all{{end}}</td>
             <td>{{$run.Config.ContextSize}}</td>
             <td>{{if or $run.Config.BatchSize $run.Config.UBatchSize}}{{if $run.Config.BatchSize}}{{$run.Config.BatchSize}}{{else}}—{{end}}/{{if $run.Config.UBatchSize}}{{$run.Config.UBatchSize}}{{else}}—{{end}}{{else}}—{{end}}</td>

--- a/web/templates/partials/benchmark_compare.html
+++ b/web/templates/partials/benchmark_compare.html
@@ -18,6 +18,44 @@
 .bench-compare-rank mark { padding:0 0.3rem; font-size:0.7rem; }
 .bench-compare-label { cursor:help; }
 
+/* The details table is wider than the page whenever a comparison varies
+   on much. Overlay scrollbars — the default on most desktops now — draw
+   nothing until the pointer is already moving, so the table looks
+   truncated rather than scrollable. Ask for a bar that stays. */
+.bench-compare-scroll {
+    overflow-x: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--pico-muted-border-color) transparent;
+}
+.bench-compare-scroll::-webkit-scrollbar { height: 10px; }
+.bench-compare-scroll::-webkit-scrollbar-track {
+    background: var(--pico-background-color);
+    border-radius: 5px;
+}
+.bench-compare-scroll::-webkit-scrollbar-thumb {
+    background: var(--pico-muted-border-color);
+    border-radius: 5px;
+}
+.bench-compare-scroll::-webkit-scrollbar-thumb:hover {
+    background: var(--pico-muted-color);
+}
+
+/* Columns every compared run agrees on. Hidden by default and revealed
+   by the toggle, rather than left out of the markup, so "show every
+   column" needs no round trip and the row stays intact. */
+.bench-compare-table.hide-constant .bc-const { display: none; }
+.bench-compare-common {
+    font-size: 0.8rem; color: var(--pico-muted-color);
+    margin: 0 0 0.4rem;
+}
+.bench-compare-common kbd { font-size: 0.75rem; }
+.bench-compare-colbar {
+    display:flex; gap:0.5rem; align-items:center;
+    font-size:0.8rem; margin-bottom:0.4rem; flex-wrap:wrap;
+}
+.bench-compare-colbar label { margin:0; display:flex; gap:0.35rem; align-items:center; }
+.bench-compare-colbar input { margin:0; }
+
 .bench-compare-table th[data-run-id] {
     min-width:160px; max-width:280px;
     overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
@@ -127,26 +165,44 @@
     {{end}}
 
     <small><strong>Details</strong></small>
-    <div style="overflow-x:auto;">
-    <table role="grid" class="bench-compare-table" style="font-size:0.85rem;">
+    {{if .Common}}
+    <p class="bench-compare-common">
+        <strong>The same for every run:</strong>
+        {{range $i, $c := .Common}}{{if $i}} · {{end}}{{$c.Name}} <kbd>{{$c.Value}}</kbd>{{end}}
+    </p>
+    <div class="bench-compare-colbar">
+        <label title="These columns hold the same value in every compared run, so they say nothing about which run won. They are folded into the line above; tick to put them back in the table.">
+            <input type="checkbox" role="switch" class="bench-compare-showall"
+                   onchange="toggleConstantColumns(this)">
+            Show the {{len .Common}} column{{if ne (len .Common) 1}}s{{end}} every run shares
+        </label>
+        <small class="bench-compare-widehint" hidden>The table is wider than the page — scroll it sideways.</small>
+    </div>
+    {{else}}
+    <div class="bench-compare-colbar">
+        <small class="bench-compare-widehint" hidden>The table is wider than the page — scroll it sideways.</small>
+    </div>
+    {{end}}
+    <div class="bench-compare-scroll">
+    <table role="grid" class="bench-compare-table hide-constant" style="font-size:0.85rem;">
         <thead>
             <tr>
                 <th>Model</th>
-                <th>Quant</th>
-                <th title="Which point of a parameter sweep this run measured">Sweep</th>
-                <th title="The prompt lengths this run measured, which is what its averages cover. Prompt speed climbs steeply with prompt length, so two runs are only strictly comparable when this column matches. Hover a value for the breakdown by length.">Prompt sizes</th>
+                <th class="{{constCol .Varies "quant"}}">Quant</th>
+                <th class="{{constCol .Varies "sweep"}}" title="Which point of a parameter sweep this run measured">Sweep</th>
+                <th class="{{constCol .Varies "prompt sizes"}}" title="The prompt lengths this run measured, which is what its averages cover. Prompt speed climbs steeply with prompt length, so two runs are only strictly comparable when this column matches. Hover a value for the breakdown by length.">Prompt sizes</th>
                 <th title="Prompt Processing tokens/sec, averaged over everything this run measured — the same figure as the bar chart above.">PP t/s</th>
                 <th title="Token Generation tokens/sec, averaged over everything this run measured — the same figure as the bar chart above.">TG t/s</th>
                 <th title="Time To First Token in milliseconds, averaged over everything this run measured.">TTFT (ms)</th>
                 {{if .HasEval}}<th title="Capability evaluation score — only capability runs (perplexity / KL-divergence / HellaSwag / Winogrande) produce one; each row shows its own metric (the mode is part of the row identity, so rows of different modes are not compared against each other). PPL: perplexity — lower is better. HellaSwag / Winogrande: accuracy with confidence interval and task count. KLD: deviation from the reference — 0 = identical. Performance runs show an em-dash here.">Score</th>{{end}}
-                <th>Size</th>
+                <th class="{{constCol .Varies "size"}}">Size</th>
                 <th title="GPU memory the load actually used, in GiB, read from llama.cpp's own report as it allocated — not an estimate. Hover a value for the split between weights, KV cache and working buffers. An em-dash means the run recorded none: llama.cpp reports its buffers only at Model loading detail 4, on the Settings page.">VRAM</th>
-                <th>GPUs</th>
-                <th>Context</th>
-                <th title="Batch / micro-batch (-b / -ub). A dash means llama.cpp's default.">Batch b/ub</th>
-                <th>KV Quant</th>
-                <th>Flash Attn</th>
-                <th>Build</th>
+                <th class="{{constCol .Varies "GPUs"}}">GPUs</th>
+                <th class="{{constCol .Varies "context"}}">Context</th>
+                <th class="{{constCol .Varies "batch"}}" title="Batch / micro-batch (-b / -ub). A dash means llama.cpp's default.">Batch b/ub</th>
+                <th class="{{constCol .Varies "KV cache"}}">KV Quant</th>
+                <th class="{{constCol .Varies "flash attention"}}">Flash Attn</th>
+                <th class="{{constCol .Varies "build"}}">Build</th>
                 {{if .HasLlamaBench}}<th title="llama-bench TG t/s (legacy)">lb TG</th>{{end}}
             </tr>
         </thead>
@@ -168,23 +224,28 @@
             data-sort-prompt="0.0000"
             data-sort-score="{{printf "%.4f" (evalScoreValue $run.Eval)}}">
             <td title="{{(index $.Labels $run.ID).Full}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:help;">{{$run.ModelName}}</td>
-            <td><kbd>{{$run.Quant}}</kbd></td>
-            <td>—</td>
-            <td><span title="A capability evaluation reads the model&#39;s own predictions over a fixed text; it measures no speed and no prompt lengths." style="color:var(--pico-muted-color);cursor:help;">not a speed run</span></td>
+            <td class="{{constCol $.Varies "quant"}}"><kbd>{{$run.Quant}}</kbd></td>
+            <td class="{{constCol $.Varies "sweep"}}">—</td>
+            <td class="{{constCol $.Varies "prompt sizes"}}"><span title="A capability evaluation reads the model&#39;s own predictions over a fixed text; it measures no speed and no prompt lengths." style="color:var(--pico-muted-color);cursor:help;">not a speed run</span></td>
             <td>—</td>
             <td>—</td>
             <td>—</td>
             {{if $.HasEval}}<td><strong>{{evalScoreText $run.Eval}}</strong></td>{{end}}
-            <td>{{printf "%.1f" $run.SizeGiB}} GiB</td>
+            <td class="{{constCol $.Varies "size"}}">{{printf "%.1f" $run.SizeGiB}} GiB</td>
             {{/* A capability run is measured with the router stopped, so
                  there is no load for the memory reader to watch and this
-                 cell is always an em-dash. Rendered rather than folded
-                 into the span below so the column keeps its tooltip. */}}
+                 cell is always an em-dash. */}}
             <td title="{{memDetail $run.Memory}}" style="cursor:help;">{{memText $run.Memory}}</td>
-            {{/* GPUs, Context, Batch, KV Quant, Flash Attn, Build — six
-                 columns, which is what the header has after VRAM. A
-                 short span here shifts every later column. */}}
-            <td colspan="6">—</td>
+            {{/* One cell per column rather than a span: a span cannot
+                 carry the per-column class that hides a column every run
+                 agrees on, and would leave the row a different width
+                 from the header the moment one was hidden. */}}
+            <td class="{{constCol $.Varies "GPUs"}}">—</td>
+            <td class="{{constCol $.Varies "context"}}">—</td>
+            <td class="{{constCol $.Varies "batch"}}">—</td>
+            <td class="{{constCol $.Varies "KV cache"}}">—</td>
+            <td class="{{constCol $.Varies "flash attention"}}">—</td>
+            <td class="{{constCol $.Varies "build"}}">—</td>
             {{if $.HasLlamaBench}}<td>—</td>{{end}}
         </tr>
         {{end}}
@@ -203,9 +264,9 @@
             data-sort-prompt="{{printf "%.4f" $s.AvgPromptTokPerSec}}"
             data-sort-score="{{printf "%.4f" (evalScoreValue $run.Eval)}}">
             <td title="{{(index $.Labels $run.ID).Full}}" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:help;">{{if $run.ConfigUnverified}}<span title="Config columns for this run may not reflect what actually ran — its job declared overrides before overrides were applied. Throughput is still valid." style="color:var(--pico-del-color,#b3261e);cursor:help;">&#9888;</span> {{end}}{{$run.ModelName}}</td>
-            <td><kbd>{{$run.Quant}}</kbd></td>
-            <td>{{if $run.SweepValues}}{{range $k, $v := $run.SweepValues}}<kbd>{{$k}}={{$v}}</kbd> {{end}}{{else}}—{{end}}</td>
-            <td title="{{$run.PromptSizesDetail}}" style="cursor:help;">{{with $run.PromptSizesText}}{{.}}{{else}}—{{end}}</td>
+            <td class="{{constCol $.Varies "quant"}}"><kbd>{{$run.Quant}}</kbd></td>
+            <td class="{{constCol $.Varies "sweep"}}">{{if $run.SweepValues}}{{range $k, $v := $run.SweepValues}}<kbd>{{$k}}={{$v}}</kbd> {{end}}{{else}}—{{end}}</td>
+            <td class="{{constCol $.Varies "prompt sizes"}}" title="{{$run.PromptSizesDetail}}" style="cursor:help;">{{with $run.PromptSizesText}}{{.}}{{else}}—{{end}}</td>
             <td>{{printf "%.0f" $s.AvgPromptTokPerSec}}</td>
             <td><strong>{{printf "%.1f" $s.AvgGenTokPerSec}}</strong></td>
             <td>{{printf "%.0f" $s.AvgTTFTMs}}</td>
@@ -215,14 +276,14 @@
                  the same comparison are not compared against each other. */}}
             <td>{{if evalHas $run.Eval}}{{evalScoreText $run.Eval}}{{else}}—{{end}}</td>
             {{end}}
-            <td>{{printf "%.1f" $run.SizeGiB}} GiB</td>
+            <td class="{{constCol $.Varies "size"}}">{{printf "%.1f" $run.SizeGiB}} GiB</td>
             <td title="{{memDetail $run.Memory}}" style="cursor:help;">{{memText $run.Memory}}</td>
-            <td>{{if $run.Config.GPUAssign}}{{$run.Config.GPUAssign}}{{else}}all{{end}}</td>
-            <td>{{$run.Config.ContextSize}}</td>
-            <td>{{if or $run.Config.BatchSize $run.Config.UBatchSize}}{{if $run.Config.BatchSize}}{{$run.Config.BatchSize}}{{else}}—{{end}}/{{if $run.Config.UBatchSize}}{{$run.Config.UBatchSize}}{{else}}—{{end}}{{else}}—{{end}}</td>
-            <td>{{or $run.Config.KVCacheQuant "f16"}}</td>
-            <td>{{if $run.Config.FlashAttention}}yes{{else}}no{{end}}</td>
-            <td title="{{$b.Tag}}{{if $b.GitSHA}} · {{$b.GitSHA}}{{end}}">
+            <td class="{{constCol $.Varies "GPUs"}}">{{if $run.Config.GPUAssign}}{{$run.Config.GPUAssign}}{{else}}all{{end}}</td>
+            <td class="{{constCol $.Varies "context"}}">{{$run.Config.ContextSize}}</td>
+            <td class="{{constCol $.Varies "batch"}}">{{if or $run.Config.BatchSize $run.Config.UBatchSize}}{{if $run.Config.BatchSize}}{{$run.Config.BatchSize}}{{else}}—{{end}}/{{if $run.Config.UBatchSize}}{{$run.Config.UBatchSize}}{{else}}—{{end}}{{else}}—{{end}}</td>
+            <td class="{{constCol $.Varies "KV cache"}}">{{or $run.Config.KVCacheQuant "f16"}}</td>
+            <td class="{{constCol $.Varies "flash attention"}}">{{if $run.Config.FlashAttention}}yes{{else}}no{{end}}</td>
+            <td class="{{constCol $.Varies "build"}}" title="{{$b.Tag}}{{if $b.GitSHA}} · {{$b.GitSHA}}{{end}}">
                 {{if $b.Profile}}{{$b.Profile}}{{end}}{{if $b.GitRef}} · {{$b.GitRef}}{{end}}{{if and (not $b.Profile) (not $b.GitRef)}}—{{end}}
             </td>
             {{if $.HasLlamaBench}}<td>{{if $run.LlamaBench}}{{printf "%.1f" $run.LlamaBench.GenTokPerSec}}{{else}}—{{end}}</td>{{end}}
@@ -238,7 +299,37 @@
 (function() {
     // Initial sort matches the active button (Gen tok/s desc).
     sortBenchCompare(document.querySelector('.bench-sort-bar button.active'));
+    benchCompareWidthHint();
 })();
+
+// toggleConstantColumns puts back the columns every compared run shares.
+// They are in the markup either way, so this needs no round trip — and
+// the width hint is re-checked, since revealing six columns is exactly
+// what makes a table need scrolling.
+function toggleConstantColumns(cb) {
+    var view = cb.closest('#comparison-view') || document;
+    view.querySelectorAll('.bench-compare-table').forEach(function (t) {
+        t.classList.toggle('hide-constant', !cb.checked);
+    });
+    benchCompareWidthHint();
+}
+
+// benchCompareWidthHint says so when the table is wider than its box.
+// A persistent scrollbar is asked for in CSS, but a browser configured
+// for overlay scrollbars can still draw nothing until the pointer moves,
+// and a table that is cut off with no visible bar reads as a table that
+// ends there.
+function benchCompareWidthHint() {
+    document.querySelectorAll('.bench-compare-scroll').forEach(function (box) {
+        var wrap = box.parentElement;
+        if (!wrap) return;
+        var hint = wrap.querySelector('.bench-compare-widehint');
+        if (!hint) return;
+        hint.hidden = box.scrollWidth <= box.clientWidth + 1;
+    });
+}
+
+window.addEventListener('resize', benchCompareWidthHint);
 
 function sortBenchCompare(btn) {
     if (!btn) return;

--- a/web/templates/partials/benchmark_detail.html
+++ b/web/templates/partials/benchmark_detail.html
@@ -32,6 +32,22 @@
             <small>
                 {{range .GPUs}}GPU {{.Index}}: {{.Name}} ({{printf "%.0f" (divf .VRAMTotalMiB 1024.0)}} GiB)<br>{{end}}
             </small>
+            <small><strong>Memory used</strong>
+                <span title="{{memDetail .Memory}}" style="cursor:help;">&#9432;</span>
+            </small><br>
+            <small>
+                {{with .Memory}}
+                {{printf "%.1f" .GPUGiB}} GiB on the GPUs —
+                {{printf "%.1f" .WeightsGiB}} weights,
+                {{printf "%.1f" .KVGiB}} KV cache,
+                {{printf "%.1f" .ComputeGiB}} working buffers
+                {{if ge .HostGiB 0.05}}<br>{{printf "%.1f" .HostGiB}} GiB in system memory{{end}}
+                {{if and (gt .CardDeltaGiB 0.0) (not .Contended)}}<br>Cards reported {{printf "%.1f" .CardDeltaGiB}} GiB, {{printf "%.1f" .Unreported}} above what llama.cpp itemises{{end}}
+                {{if .Contended}}<br>Another model was loading at the same time, so the card total could not be attributed{{end}}
+                {{else}}
+                Not measured — llama.cpp reports what it allocated only at Model loading detail 4, on the <a href="/settings">Settings</a> page.
+                {{end}}
+            </small>
         </div>
     </div>
 

--- a/web/templates/visualize.html
+++ b/web/templates/visualize.html
@@ -127,6 +127,18 @@ main.container { max-width: none; }
                                  : defaultPlotHeight;
     }
 
+    // POINTS is DATA.points restricted to the runs that have a value for
+    // the metric being plotted. Not every run carries every metric: a run
+    // measured before memory was recorded, or under a router below log
+    // verbosity 4, has timings and no footprint. Such a run has to be
+    // left out of a memory chart rather than drawn at zero, which would
+    // claim it used none.
+    var POINTS = DATA.points;
+    function pointsWith(m) {
+        if (!m) return DATA.points;
+        return DATA.points.filter(function (p) { return p.metrics[m.key] !== undefined; });
+    }
+
     function dim(name) {
         return DATA.dimensions.filter(function (d) { return d.name === name; })[0];
     }
@@ -198,7 +210,16 @@ main.container { max-width: none; }
             Plotly.purge('viz-plot');
             return;
         }
-        note('');
+        POINTS = pointsWith(spec.metric ? m : null);
+        if (spec.metric && !POINTS.length) {
+            note('None of these runs recorded ' + m.label.toLowerCase() + '. Memory is measured only when llama.cpp is set to Model loading detail 4, on the Settings page.');
+            Plotly.purge('viz-plot');
+            return;
+        }
+        var dropped = DATA.points.length - POINTS.length;
+        note(dropped ? dropped + (dropped === 1 ? ' run is' : ' runs are') +
+                       ' not shown: no ' + m.label.toLowerCase() + ' was recorded for ' +
+                       (dropped === 1 ? 'it.' : 'them.') : '');
         setPlotHeight(0);
 
         if (chart === 'scatter') return renderScatter(m, x, m.label + ' by ' + x.name);
@@ -210,7 +231,7 @@ main.container { max-width: none; }
     }
 
     function renderScatter(m, x, title) {
-        var pts = DATA.points.filter(function (p) { return p.dims[x.name] !== undefined; });
+        var pts = POINTS.filter(function (p) { return p.dims[x.name] !== undefined; });
         var trace = {
             type: 'scatter', mode: 'markers',
             x: pts.map(function (p) { return coord(x, p.dims[x.name]); }),
@@ -262,7 +283,7 @@ main.container { max-width: none; }
     // Heatmap, 3D surface and 3D scatter all read the same grid: the
     // metric at each (x, y) pair.
     function renderTwoAxis(chart, m, x, y, title) {
-        var grid = buildGrid(DATA.points, m, x, y);
+        var grid = buildGrid(POINTS, m, x, y);
         var z = grid.z;
         if (chart !== 'scatter3d') collisionNote(grid.collisions);
         var xs = x.values.map(function (v) { return coord(x, v); });
@@ -327,7 +348,7 @@ main.container { max-width: none; }
             return;
         }
 
-        var pts = DATA.points.filter(function (p) {
+        var pts = POINTS.filter(function (p) {
             return p.dims[x.name] !== undefined && p.dims[y.name] !== undefined;
         });
         var t3 = {
@@ -361,7 +382,7 @@ main.container { max-width: none; }
         // Ascending for higher-is-better: Plotly draws the first bar of
         // a category axis at the BOTTOM, so ascending puts the winner
         // on top.
-        var pts = DATA.points.slice().sort(function (a, b) {
+        var pts = POINTS.slice().sort(function (a, b) {
             return m.higher_is_better
                 ? a.metrics[m.key] - b.metrics[m.key]
                 : b.metrics[m.key] - a.metrics[m.key];
@@ -476,7 +497,7 @@ main.container { max-width: none; }
         var traces = [], collisions = 0;
         pnl.values.forEach(function (pv, k) {
             var axn = k === 0 ? '' : String(k + 1);
-            var inPanel = DATA.points.filter(function (p) { return p.dims[pnl.name] === pv; });
+            var inPanel = POINTS.filter(function (p) { return p.dims[pnl.name] === pv; });
             var grid = buildGrid(inPanel, m, x, y);
             collisions += grid.collisions;
             var hover = y.values.map(function (yv, j) {
@@ -541,7 +562,7 @@ main.container { max-width: none; }
         // slot instead of a broken line.
         var axes = DATA.dimensions.map(function (d) {
             var missing = false;
-            var vals = DATA.points.map(function (p) {
+            var vals = POINTS.map(function (p) {
                 var i = d.values.indexOf(p.dims[d.name]);
                 if (i < 0) { missing = true; return d.values.length; }
                 return i;
@@ -552,13 +573,17 @@ main.container { max-width: none; }
                      tickvals: ticks.map(function (_, i) { return i; }),
                      ticktext: ticks };
         });
+        // A metric axis needs a value on every line it crosses; one that
+        // some run lacks would break the line rather than gap it, so
+        // such a metric is left off this chart entirely.
         DATA.metrics.forEach(function (mm) {
-            axes.push({ label: mm.label + ' (' + mm.unit + ')',
-                        values: DATA.points.map(function (p) { return p.metrics[mm.key]; }) });
+            var vals = POINTS.map(function (p) { return p.metrics[mm.key]; });
+            if (vals.some(function (v) { return v === undefined; })) return;
+            axes.push({ label: mm.label + ' (' + mm.unit + ')', values: vals });
         });
         var trace = {
             type: 'parcoords', dimensions: axes,
-            line: { color: DATA.points.map(function (p) { return p.metrics[m.key]; }),
+            line: { color: POINTS.map(function (p) { return p.metrics[m.key]; }),
                     colorscale: 'Viridis', reversescale: !m.higher_is_better,
                     showscale: true, colorbar: { title: { text: m.unit } } },
             labelfont: { color: t.font }, tickfont: { color: t.font },


### PR DESCRIPTION
The Models page shows an estimated VRAM figure. This branch adds the measured one — read from llama.cpp's own buffer report as it allocates — and puts it in the two places it changes a decision: the Available Models tooltip, and the benchmark results.

Three commits, each self-contained.

### 1. Measure the load (`feat(memreport)`)

`internal/memreport` was written to calibrate the estimator in #167 and then imported by nothing. This adds the consumer it was missing: a collector reading the router log stream the Server Logs panel already receives — no new process, no polling.

Attribution comes from the router's own `spawning server instance with name=X on port N` line, which it logs at default verbosity, paired with the port prefix on every line an instance emits afterwards. Loads are keyed by port, so two models loading at once cannot contaminate each other and a reload replaces a measurement rather than adding to it.

Also fixes an error in the existing parser: `Entry.Instance` was documented as the child's pid, but it is the port, and the router writes it with `%5d`. A port below 10000 arrives as `[ 4623]`, which the old expression did not match — it would have dropped the whole line, not just the attribution.

The tooltip never presents an estimate as a measurement. Below log verbosity 4 llama.cpp itemises nothing, and it says so and names the setting; a measurement taken under settings that have since changed says which it is; and it states plainly that a card's own reported usage runs a few hundred MiB per GPU higher, for driver overhead llama.cpp does not count.

### 2. Check the estimate term by term (`feat(models)`)

A total cannot tell a good model from two mistakes that cancel — which is exactly what #167 removed. Corpus points now carry the split llama.cpp reported, and the estimate is separable to match (same arithmetic, no behaviour change).

That immediately surfaced a second cancellation: across the 27B sweep the weights term is **0.53 GiB over** on every row and the KV term **0.58–0.60 GiB under** on every row, so the total lands within 0.04 GiB. The shortfall is the recurrent state, which no term models. Two tests record this rather than paper over it, and one says in its comment that it should be deleted, not adjusted, if a recurrent term is added — fixing one half of a cancellation makes the estimate worse.

Adds a twelfth corpus point (the one decomposed sparse-attention load) and `GET /api/models/{id}/vram-corpus`, which prints a paste-ready corpus row so adding evidence costs a copy instead of an afternoon. It refuses to launder a bad row: a contended load, or a record with no parsed GGUF metadata, is marked rather than emitted as numbers.

### 3. Record it per benchmark cell (`feat(benchmarks)`)

A sweep answers what a setting buys and never what it costs. Every cell already loads the model, so the figure is free. It lands as a **VRAM column** in the comparison table, a *Memory used* block on run detail, **five visualization metrics**, **six CSV columns** in both export scopes, and a `memory` block in the JSON export (envelope v3).

Absence is kept distinct from zero everywhere: nil field, empty CSV cells, an em-dash with an explanatory tooltip, and a point dropped from the chart rather than plotted at the origin. This needed handling on the page too — an undefined metric makes Plotly's formatter throw inside a library callback, giving an empty chart and a silent console. That filter is tested through node, the way the job form's controls already are.

## Testing

`go build`, `go vet` and `go test ./...` pass on **each commit individually** (verified in separate worktrees), apart from two pre-existing `internal/builder` failures unrelated to this branch — `git tag` refusing with "no tag message?", a local git config issue.

New coverage: collector attribution across interleaved instances, reloads, resets, padded ports and aggregate scaling; tooltip content for every state; corpus-row rendering including a `go/parser` check that the output compiles; per-term estimate checks; export columns and JSON shape; visualization payload; compare-table and detail-view rendering; a node test for the metric filter; and one end-to-end test that runs a stand-in `llama-server` through the real process manager, so the log subscription itself is covered rather than faked.

**Not yet verified on real hardware** — no router ran during development. The log formats come from the llama.cpp checkout in `~/.local/share/llama-toolchest` and the real-log fixture already in the repo. First real load is the real test: if the tooltip says "not measured" after a load at verbosity 4, the spawn-line wording differs in that build.