### PR TITLE
fix(models): detect MTP drafter heads that share the model's architecture

### DIFF
--- a/internal/api/hf.go
+++ b/internal/api/hf.go
@@ -446,10 +446,11 @@ func (s *Server) onDownloadComplete(source, downloadID, modelID, filename string
 
 	meta, _ := models.ParseGGUFMeta(filePath)
 
-	// MTP drafter heads (e.g. gemma-4's gemma4-assistant) aren't runnable
-	// models — they load via --model-draft. Don't register; auto-associate
-	// with sibling main models like we do for mmproj.
-	if meta != nil && models.IsMTPHeadArch(meta.Architecture) {
+	// MTP drafter heads (gemma-4's gemma4-assistant, unsloth's
+	// Qwen3.8-Flash-Next heads) aren't runnable models — they load via
+	// --model-draft. Don't register; auto-associate with sibling main
+	// models like we do for mmproj.
+	if meta != nil && meta.IsMTPHead() {
 		slog.Info("MTP drafter head downloaded, associating with sibling models", "file", filePath)
 		s.registry.AutoDetectMTP()
 		return

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -227,6 +227,12 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 	if n := s.registry.AutoDetectMMProj(); n > 0 {
 		slog.Info("auto-detected mmproj files", "count", n)
 	}
+	// Runs unconditionally rather than only inside ScanModels: a head the
+	// backfill just dropped leaves its main model with no MtpPath, and a
+	// scan that finds nothing new would not re-attach it.
+	if n := s.registry.AutoDetectMTP(); n > 0 {
+		slog.Info("auto-detected MTP drafter heads", "count", n)
+	}
 	if orphans := s.registry.FindOrphans(); len(orphans) > 0 {
 		for _, m := range orphans {
 			slog.Warn("model file missing", "id", m.ID, "path", m.FilePath)

--- a/internal/models/gguf.go
+++ b/internal/models/gguf.go
@@ -91,6 +91,20 @@ type GGUFMeta struct {
 	// recurrent state.
 	AttnLayers int `json:"attn_layers,omitempty"`
 
+	// NextNPredictLayers is {arch}.nextn_predict_layers: how many MTP /
+	// NextN draft layers the file describes. Non-zero on both flavors of
+	// MTP — a self-speculation model with the head baked into the main
+	// GGUF, and a standalone drafter head — so on its own it does not
+	// tell the two apart. IsMTPHead does.
+	NextNPredictLayers int `json:"nextn_predict_layers,omitempty"`
+	// HasBlockTensors and HasTrunkBlock0 describe the shape of the tensor
+	// table: whether the file carries any blk.N.* tensors at all, and
+	// whether blk.0 is among them. A drafter head declares the full
+	// block_count of the model it drafts for but ships only the trailing
+	// NextN block, so it has blocks without having block 0. See IsMTPHead.
+	HasBlockTensors bool `json:"has_block_tensors,omitempty"`
+	HasTrunkBlock0  bool `json:"has_trunk_block0,omitempty"`
+
 	// BaseModelRepo is the upstream "org/repo" this quant derives from, per
 	// general.base_model.0.repo_url. Used to locate the base model's
 	// generation_config.json when the file has no embedded sampling keys.
@@ -126,6 +140,7 @@ func (meta *GGUFMeta) ApplyTo(m *Model) {
 	m.TokenEmbdBytes = meta.TokenEmbdBytes
 	m.IndexerKeyLength = meta.IndexerKeyLength
 	m.AttnLayers = meta.AttnLayers
+	m.MTPHead = meta.IsMTPHead()
 	if meta.BaseModelRepo != "" {
 		m.BaseModelRepo = meta.BaseModelRepo
 	}
@@ -413,6 +428,11 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 				meta.IndexerKeyLength = v
 				continue
 			}
+		case arch != "" && key == arch+".nextn_predict_layers":
+			if v, ok := readGGUFScalarInt(f, valueType); ok {
+				meta.NextNPredictLayers = v
+				continue
+			}
 		case arch != "" && key == arch+".full_attention_interval":
 			if v, ok := readGGUFScalarInt(f, valueType); ok {
 				fullAttnInterval = v
@@ -449,7 +469,9 @@ func ParseGGUFMetaFrom(f io.ReadSeeker) (*GGUFMeta, error) {
 	// truncated mid-header, or one whose tensor section we can't make sense
 	// of, leaves PLEBytes at zero — the metadata gathered above is still
 	// good, so a failure here must not fail the parse.
-	meta.PLEBytes, meta.TokenEmbdBytes = scanPLETensorBytes(f, tensorCount, alignment)
+	scan := scanTensorBlock(f, tensorCount, alignment)
+	meta.PLEBytes, meta.TokenEmbdBytes = scan.PLEBytes, scan.TokenEmbdBytes
+	meta.HasBlockTensors, meta.HasTrunkBlock0 = scan.HasBlockTensors, scan.HasTrunkBlock0
 
 	// A successful parse means reasoning was evaluated even if no chat template
 	// was present — in which case Reasoning stays the unsupported zero value.
@@ -786,10 +808,31 @@ const pleTensorName = "per_layer_token_embd.weight"
 // quants measured keep it at Q8_0 inside a Q4 model.
 const tokenEmbdTensorName = "token_embd.weight"
 
-// scanPLETensorBytes reads the tensor-info block and returns the size in
-// bytes of the PLE table, or 0 if the file has no such tensor or the block
-// can't be read. The reader must be positioned at the start of the block,
-// which is where the metadata scan leaves it.
+// blockTensorPrefix and trunkBlock0Prefix bound the per-layer tensors.
+// Every architecture names them blk.N.*, so seeing which N are present
+// says whether a file holds a whole model or only some of its layers —
+// without a table of per-architecture tensor names to keep current.
+const (
+	blockTensorPrefix = "blk."
+	trunkBlock0Prefix = "blk.0."
+)
+
+// tensorScan is one pass over the tensor-info block: the two tensor sizes
+// the VRAM estimate needs, plus the block layout IsMTPHead reads. A scan
+// that can't be completed returns the zero value, so an unreadable table
+// classifies nothing.
+type tensorScan struct {
+	PLEBytes        int64
+	TokenEmbdBytes  int64
+	HasBlockTensors bool
+	HasTrunkBlock0  bool
+}
+
+// scanTensorBlock reads the tensor-info block in a single pass, returning
+// the PLE and token-embedding sizes (0 for a file that has no such tensor,
+// or whose block can't be read) along with which per-layer blocks the file
+// carries. The reader must be positioned at the start of the block, which
+// is where the metadata scan leaves it.
 //
 // Sizes come from the gaps between tensor data offsets rather than from
 // each tensor's dimensions and quantization type. Both are correct, but
@@ -798,14 +841,15 @@ const tokenEmbdTensorName = "token_embd.weight"
 // there is a steady supply of new ones. The cost is that a computed size
 // includes any alignment padding that follows the tensor, at most
 // alignment-1 bytes against a table measured in gigabytes.
-func scanPLETensorBytes(f io.ReadSeeker, tensorCount uint64, alignment int64) (pleBytes, embBytes int64) {
+func scanTensorBlock(f io.ReadSeeker, tensorCount uint64, alignment int64) tensorScan {
 	// A malformed count would otherwise have us loop for a very long time
 	// on a file that isn't going to yield anything.
 	const maxTensors = 1 << 20
 	if tensorCount == 0 || tensorCount > maxTensors || alignment <= 0 {
-		return 0, 0
+		return tensorScan{}
 	}
 
+	var scan tensorScan
 	var pleOffset int64 = -1
 	var embOffset int64 = -1
 	offsets := make([]int64, 0, tensorCount)
@@ -813,22 +857,22 @@ func scanPLETensorBytes(f io.ReadSeeker, tensorCount uint64, alignment int64) (p
 	for i := uint64(0); i < tensorCount; i++ {
 		name, err := readGGUFString(f)
 		if err != nil {
-			return 0, 0
+			return tensorScan{}
 		}
 		nDims, err := readUint32(f)
 		if err != nil || nDims > 4 {
-			return 0, 0
+			return tensorScan{}
 		}
 		// Dimensions are read past; the offsets alone give us the size.
 		if _, err := f.Seek(int64(nDims)*8, io.SeekCurrent); err != nil {
-			return 0, 0
+			return tensorScan{}
 		}
 		if _, err := readUint32(f); err != nil { // ggml type
-			return 0, 0
+			return tensorScan{}
 		}
 		var offset uint64
 		if err := binary.Read(f, binary.LittleEndian, &offset); err != nil {
-			return 0, 0
+			return tensorScan{}
 		}
 		offsets = append(offsets, int64(offset))
 		if name == pleTensorName {
@@ -837,21 +881,29 @@ func scanPLETensorBytes(f io.ReadSeeker, tensorCount uint64, alignment int64) (p
 		if name == tokenEmbdTensorName {
 			embOffset = int64(offset)
 		}
+		if strings.HasPrefix(name, blockTensorPrefix) {
+			scan.HasBlockTensors = true
+			if strings.HasPrefix(name, trunkBlock0Prefix) {
+				scan.HasTrunkBlock0 = true
+			}
+		}
 	}
+	// The block layout stands on its own: a file can carry layers while
+	// having neither of the two tensors measured below.
 	if pleOffset < 0 && embOffset < 0 {
-		return 0, 0
+		return scan
 	}
 
 	// The data region starts after the tensor-info block, padded up to the
 	// alignment; every offset above is relative to that point.
 	infoEnd, err := f.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return 0, 0
+		return scan
 	}
 	dataStart := ((infoEnd + alignment - 1) / alignment) * alignment
 	fileSize, err := f.Seek(0, io.SeekEnd)
 	if err != nil || fileSize <= dataStart {
-		return 0, 0
+		return scan
 	}
 
 	// The next offset after a tensor bounds it. Scanning for the smallest
@@ -873,7 +925,9 @@ func scanPLETensorBytes(f io.ReadSeeker, tensorCount uint64, alignment int64) (p
 		}
 		return next - off
 	}
-	return sizeAt(pleOffset), sizeAt(embOffset)
+	scan.PLEBytes = sizeAt(pleOffset)
+	scan.TokenEmbdBytes = sizeAt(embOffset)
+	return scan
 }
 
 // ggufShardPattern matches a split GGUF filename like

--- a/internal/models/gguf_mtp_test.go
+++ b/internal/models/gguf_mtp_test.go
@@ -1,0 +1,184 @@
+package models
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeMTPGGUF builds a minimal GGUF v3 carrying an architecture, an
+// optional {arch}.nextn_predict_layers key, and a tensor-info block with
+// the given tensor names. It is the tensor NAMES that matter here — the
+// dimensions and offsets are filler — because IsMTPHead reads the block
+// layout, not the data.
+func writeMTPGGUF(t *testing.T, arch string, nextn int, tensorNames []string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	writeStr := func(s string) {
+		binary.Write(&buf, binary.LittleEndian, uint64(len(s)))
+		buf.WriteString(s)
+	}
+
+	buf.WriteString("GGUF")
+	binary.Write(&buf, binary.LittleEndian, uint32(3))
+	binary.Write(&buf, binary.LittleEndian, uint64(len(tensorNames)))
+	kvCount := 1
+	if nextn > 0 {
+		kvCount = 2
+	}
+	binary.Write(&buf, binary.LittleEndian, uint64(kvCount))
+
+	writeStr("general.architecture")
+	binary.Write(&buf, binary.LittleEndian, ggufTypeString)
+	writeStr(arch)
+	if nextn > 0 {
+		writeStr(arch + ".nextn_predict_layers")
+		binary.Write(&buf, binary.LittleEndian, ggufTypeUint32)
+		binary.Write(&buf, binary.LittleEndian, uint32(nextn))
+	}
+
+	for i, name := range tensorNames {
+		writeStr(name)
+		binary.Write(&buf, binary.LittleEndian, uint32(2))
+		binary.Write(&buf, binary.LittleEndian, uint64(8))
+		binary.Write(&buf, binary.LittleEndian, uint64(16))
+		binary.Write(&buf, binary.LittleEndian, uint32(0))     // F32
+		binary.Write(&buf, binary.LittleEndian, uint64(i*512)) // offset
+	}
+
+	for buf.Len()%32 != 0 {
+		buf.WriteByte(0)
+	}
+	buf.Write(make([]byte, 512*len(tensorNames)+512))
+
+	path := filepath.Join(t.TempDir(), "model.gguf")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestIsMTPHead covers the shapes that actually ship. The two Qwen3.8
+// cases are the file layouts read off unsloth/Qwen3.8-Flash-Next-GGUF:
+// both declare block_count 49 with nextn_predict_layers 1 and carry only
+// blk.48, differing solely in whether they bring their own token_embd.
+func TestIsMTPHead(t *testing.T) {
+	tests := []struct {
+		name    string
+		arch    string
+		nextn   int
+		tensors []string
+		want    bool
+	}{
+		{
+			name:  "qwen3.8 shared head borrows token_embd from the target",
+			arch:  "qwen4exp",
+			nextn: 1,
+			tensors: []string{
+				"blk.48.attn_q.weight", "blk.48.attn_k.weight",
+				"blk.48.nextn.eh_proj.weight", "blk.48.nextn.enorm.weight",
+			},
+			want: true,
+		},
+		{
+			name:  "qwen3.8 self-contained head carries its own token_embd",
+			arch:  "qwen4exp",
+			nextn: 1,
+			tensors: []string{
+				"token_embd.weight", "output.weight",
+				"blk.48.attn_q.weight", "blk.48.nextn.eh_proj.weight",
+			},
+			want: true,
+		},
+		{
+			name:  "gemma-4 head announces itself by architecture",
+			arch:  "gemma4-assistant",
+			nextn: 0,
+			tensors: []string{
+				"token_embd.weight", "blk.0.attn_q.weight",
+			},
+			want: true,
+		},
+		{
+			// The head is baked into a runnable model: nextn is set, but
+			// the whole trunk is present. Must stay a servable model.
+			name:  "qwen self-speculation model with a baked-in head",
+			arch:  "qwen3moe",
+			nextn: 1,
+			tensors: []string{
+				"token_embd.weight", "blk.0.attn_q.weight",
+				"blk.47.attn_q.weight", "blk.47.nextn.eh_proj.weight",
+			},
+			want: false,
+		},
+		{
+			name:  "ordinary model",
+			arch:  "qwen4exp",
+			nextn: 0,
+			tensors: []string{
+				"token_embd.weight", "blk.0.attn_q.weight", "blk.1.attn_q.weight",
+			},
+			want: false,
+		},
+		{
+			// A split model's first shard holds the metadata and, as
+			// publishers ship them, no tensors at all. Without the
+			// "carries blocks" requirement this would read as a head.
+			name:    "first shard of a split model has metadata but no tensors",
+			arch:    "qwen4exp",
+			nextn:   1,
+			tensors: nil,
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeMTPGGUF(t, tc.arch, tc.nextn, tc.tensors)
+			meta, err := ParseGGUFMeta(path)
+			if err != nil {
+				t.Fatalf("ParseGGUFMeta: %v", err)
+			}
+			if got := meta.IsMTPHead(); got != tc.want {
+				t.Errorf("IsMTPHead() = %v, want %v (arch=%q nextn=%d blocks=%v blk0=%v)",
+					got, tc.want, meta.Architecture, meta.NextNPredictLayers,
+					meta.HasBlockTensors, meta.HasTrunkBlock0)
+			}
+		})
+	}
+}
+
+// TestFindDraftCandidatesSkipsMTPHead is the bug that started this: an
+// MTP head matches its target's architecture exactly and is far under the
+// size bar, so it was offered as a plain draft model — a pairing that
+// fails at load with "tensor 'token_embd.weight' not found".
+func TestFindDraftCandidatesSkipsMTPHead(t *testing.T) {
+	r := &Registry{
+		dataDir:   t.TempDir(),
+		modelsDir: t.TempDir(),
+		data: registryData{
+			Models: map[string]*Model{
+				"target": {
+					ID: "target", Arch: "qwen4exp", SizeBytes: 111 << 30,
+				},
+				"head": {
+					ID: "head", Arch: "qwen4exp", SizeBytes: 3 << 30, MTPHead: true,
+				},
+				"real-draft": {
+					ID: "real-draft", Arch: "qwen4exp", SizeBytes: 2 << 30,
+				},
+			},
+			Configs: map[string]*ModelConfig{},
+		},
+	}
+
+	var got []string
+	for _, c := range r.FindDraftCandidates("target") {
+		got = append(got, c.ID)
+	}
+	if len(got) != 1 || got[0] != "real-draft" {
+		t.Errorf("FindDraftCandidates = %v, want [real-draft] only", got)
+	}
+}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -93,6 +93,11 @@ type Model struct {
 	TokenEmbdBytes   int64 `json:"token_embd_bytes,omitempty"`
 	IndexerKeyLength int   `json:"indexer_key_length,omitempty"`
 	AttnLayers       int   `json:"attn_layers,omitempty"`
+	// MTPHead marks a standalone MTP drafter head that was registered as
+	// an ordinary model by a parser that couldn't recognize it. Records
+	// carrying it are dropped on the next backfill; nothing should serve
+	// one or offer it as a draft candidate. See GGUFMeta.IsMTPHead.
+	MTPHead bool `json:"mtp_head,omitempty"`
 
 	// Architecture parameters parsed from GGUF header.
 	Arch          string `json:"arch,omitempty"`
@@ -636,7 +641,10 @@ func (r *Registry) ListNeedingPresetFetch() []string {
 //	1 — recurrent layers excluded from KV scaling; token-embedding size,
 //	    indexer key length and attention-layer count added for the VRAM
 //	    estimate.
-const GGUFMetaVersion = 1
+//	2 — NextN layer count and block-tensor layout added, so a standalone
+//	    MTP drafter head that reports a runnable architecture is
+//	    recognized as a head. Records for one are dropped by the backfill.
+const GGUFMetaVersion = 2
 
 // BackfillGGUFMeta re-reads GGUF metadata for records written by an older
 // parser, in one pass at startup.
@@ -668,6 +676,18 @@ func (r *Registry) BackfillGGUFMeta() {
 		meta.ApplyTo(m)
 		m.GGUFMetaVersion = GGUFMetaVersion
 		changed = true
+
+		// A head registered by a parser that couldn't tell it from a model.
+		// Drop the record — ScanModels declines to create it now, and
+		// AutoDetectMTP attaches the file to its main model instead. The
+		// file itself is untouched; only the mistaken registration goes.
+		if m.MTPHead {
+			slog.Info("dropping registry entry for MTP drafter head", "model", m.ID,
+				"file", m.FilePath, "arch", meta.Architecture)
+			delete(r.data.Models, m.ID)
+			delete(r.data.Configs, m.ID)
+			continue
+		}
 		slog.Info("re-read GGUF metadata", "model", m.ID, "version", GGUFMetaVersion,
 			"arch", meta.Architecture, "layers", meta.NLayers, "attn_layers", meta.AttnLayers,
 			"kv_full_per_tok", meta.KVFullPerTok, "was", before,
@@ -976,10 +996,11 @@ func (r *Registry) ScanModels() int {
 			meta.ApplyTo(m)
 		}
 
-		// Skip standalone MTP / drafter "assistant" heads (e.g. gemma-4's
-		// gemma4-assistant). They're loaded via --model-draft alongside a main
-		// model, not served on their own — auto-associated by AutoDetectMTP below.
-		if IsMTPHeadArch(m.Arch) {
+		// Skip standalone MTP / drafter heads (gemma-4's gemma4-assistant,
+		// unsloth's Qwen3.8-Flash-Next heads). They're loaded via --model-draft
+		// alongside a main model, not served on their own — auto-associated by
+		// AutoDetectMTP below. Set by ApplyTo from the parsed metadata.
+		if m.MTPHead {
 			return nil
 		}
 
@@ -1115,8 +1136,37 @@ func (r *Registry) AutoDetectMMProj() int {
 // Detection is by architecture, not filename: Qwen's self-speculation MTP
 // models also carry "MTP" in their name but ARE runnable (the head is baked
 // into a normal qwen3 arch), so they must keep registering as ordinary models.
+//
+// This catches only the heads that declare an architecture of their own.
+// Prefer GGUFMeta.IsMTPHead, which also catches the ones that don't.
 func IsMTPHeadArch(arch string) bool {
 	return strings.Contains(strings.ToLower(arch), "assistant")
+}
+
+// IsMTPHead reports whether a GGUF is a standalone MTP / NextN drafter head
+// rather than a runnable model.
+//
+// An architecture name alone is not enough. gemma-4's head announces itself
+// as "gemma4-assistant", but unsloth's Qwen3.8-Flash-Next heads report
+// "qwen4exp" — the same architecture as the 111 GB model they draft for, at
+// the same embedding width. Nothing in the metadata distinguishes them, and
+// treating one as a model makes it a plausible-looking draft candidate for
+// the other, which is a configuration that cannot load.
+//
+// What does distinguish them is the tensor table. A head declares the full
+// block_count of its target but ships only the trailing NextN block: it has
+// blk.N tensors without a blk.0. Requiring that it carry blocks at all keeps
+// the first shard of a split model — which holds the metadata and, as
+// publishers ship them, no tensors — from being mistaken for one.
+//
+// Both flavors of head are covered, whether or not they carry their own
+// copies of token_embd/output: the shared variant borrows those from the
+// target at runtime, and the difference is invisible here.
+func (meta *GGUFMeta) IsMTPHead() bool {
+	if IsMTPHeadArch(meta.Architecture) {
+		return true
+	}
+	return meta.NextNPredictLayers > 0 && meta.HasBlockTensors && !meta.HasTrunkBlock0
 }
 
 // FindMTP looks for a separate MTP drafter-head GGUF associated with the given
@@ -1170,7 +1220,7 @@ func findMTPInDir(dir string) string {
 			continue
 		}
 		path := filepath.Join(dir, name)
-		if meta, err := ParseGGUFMeta(path); err == nil && IsMTPHeadArch(meta.Architecture) {
+		if meta, err := ParseGGUFMeta(path); err == nil && meta.IsMTPHead() {
 			return path
 		}
 	}
@@ -1236,6 +1286,15 @@ func (r *Registry) FindDraftCandidates(id string) []DraftCandidate {
 		}
 		// Skip embedding models
 		if m.IsEmbedding() {
+			continue
+		}
+		// Skip MTP drafter heads. They match on architecture and are far
+		// under the size bar, so they look like ideal draft candidates —
+		// but they carry no trunk and cannot load as a draft model. They
+		// belong on the config's MtpPath under spec_type=draft-mtp, which
+		// AutoDetectMTP sets. Only reaches here for a head registered by
+		// an older parser; the backfill drops those.
+		if m.MTPHead {
 			continue
 		}
 		candidates = append(candidates, DraftCandidate{


### PR DESCRIPTION
## The bug

unsloth's Qwen3.8-Flash-Next MTP heads report `arch: qwen4exp` — the same architecture as the 111 GB model they draft for, at the same embedding width (`n_embd 2560`). `IsMTPHeadArch` tests for the substring `"assistant"`, which catches gemma-4's `gemma4-assistant` head but sees nothing to flag here.

So the head registered as an ordinary servable model. Then `FindDraftCandidates`, which filters on matching architecture and a size under 40% of the target, offered it as an ideal-looking draft model. Selecting it produces a config that cannot load:

```
llama_model_load: error loading model: check_tensor_dims: tensor 'token_embd.weight' not found
common_speculative_init_result: failed to load draft model
srv    load_model: failed to load draft model
srv  llama_server: exiting due to model loading error
```

The `shared-` heads omit `token_embd.weight` and `output.weight` by design — they borrow both from the target at runtime.

## The fix

Detect by tensor layout rather than architecture name. Read off the two shipped variants:

| file | tensors | `token_embd.weight` | blocks present |
|---|---|---|---|
| `mtp-…-shared-Q8_0.gguf` | 32 | ✗ | `blk.48` only |
| `mtp-…-Q8_0.gguf` | 34 | ✓ | `blk.48` only |

Both declare `block_count 49` and `nextn_predict_layers 1` while carrying only the trailing NextN block — layers without a layer 0. That is the test:

```go
func (meta *GGUFMeta) IsMTPHead() bool {
	if IsMTPHeadArch(meta.Architecture) {
		return true
	}
	return meta.NextNPredictLayers > 0 && meta.HasBlockTensors && !meta.HasTrunkBlock0
}
```

`IsMTPHeadArch` stays as the gemma-4 signal and keeps its test. The `HasBlockTensors` requirement is load-bearing: a split model's first shard holds the metadata and, as publishers ship them, no tensors — without it that reads as a head.

The parser gained `{arch}.nextn_predict_layers` and block-layout tracking, folded into the existing tensor pass (`scanPLETensorBytes` → `scanTensorBlock`, returning a struct). No extra I/O.

## Consequences

- Heads are skipped at scan and at download.
- `FindDraftCandidates` excludes them — the pairing that caused this.
- `GGUFMetaVersion` 1 → 2, and the backfill drops registry records for heads a previous parser registered. The files themselves are untouched.
- `AutoDetectMTP()` runs at startup beside `AutoDetectMMProj`. It previously ran only inside `ScanModels` when a scan found something new, so a head the backfill just dropped would have left its main model with no `MtpPath`.

## Not included

Existing configs aren't migrated. A model already pointing at a head via `spec_type: "draft"` + `draft_model_path` keeps that config and still fails to load; the sensible target is `draft-mtp` + `MtpPath` + `MtpDisabled`, but silently rewriting a user's spec config seemed worth deciding separately.

## Testing

`go test ./...` green. New `TestIsMTPHead` covers six layouts: both Qwen3.8 variants, the gemma-4 arch path, a Qwen self-speculation model with a baked-in head (must stay servable), an ordinary model, and a split first shard. `TestFindDraftCandidatesSkipsMTPHead` covers the pairing itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnQbuY8TXS84a1yFxfCiMe