### PR TITLE
feat(spec): run a draft method and an n-gram assist together

### DIFF
--- a/internal/api/bench_about.go
+++ b/internal/api/bench_about.go
@@ -12,6 +12,7 @@ type AboutBenchmarks struct {
 	InternalPrompt struct {
 		Text             string `json:"text"`
 		RepetitionPrefix string `json:"repetition_prefix"`
+		EchoPrefix       string `json:"echo_prefix"`
 		CharsPerToken    int    `json:"chars_per_token"`
 	} `json:"internal_prompt"`
 	Presets        []benchmark.Preset     `json:"presets"`
@@ -39,6 +40,7 @@ func (s *Server) handleBenchmarksAbout(w http.ResponseWriter, r *http.Request) {
 	}
 	about.InternalPrompt.Text = benchmark.BenchPromptText
 	about.InternalPrompt.RepetitionPrefix = benchmark.BenchPromptPrefixTemplate
+	about.InternalPrompt.EchoPrefix = benchmark.BenchPromptEchoPrefixTemplate
 	about.InternalPrompt.CharsPerToken = benchmark.BenchPromptCharsPerToken
 
 	for _, p := range about.Presets {

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -384,6 +384,7 @@ func (e *jobEnv) modelInfoBundle(m *models.Model) (benchmark.ModelInfo, error) {
 		FilePath:    m.FilePath,
 		DisplayName: shortenModelName(m.ModelID),
 		RouterName:  e.s.registry.RouterName(m.ID),
+		Reasoning:   reasoningControl(m, cfg),
 		Config: benchmark.ConfigSnapshot{
 			GPULayers:      cfg.GPULayers,
 			ContextSize:    cfg.ContextSize,
@@ -833,4 +834,17 @@ func configDiff(base, merged models.ModelConfig) []string {
 		return []string{"none"}
 	}
 	return out
+}
+
+// reasoningControl translates the model's detected reasoning capability
+// into the shape the benchmark runner uses. Only the recall workload acts
+// on it: a reasoning model asked to reproduce a passage will otherwise
+// spend its whole generation budget deliberating, which is new prose and
+// measures nothing an n-gram method can accelerate.
+func reasoningControl(m *models.Model, cfg *models.ModelConfig) benchmark.ReasoningControl {
+	r := m.EffectiveReasoning(cfg)
+	if !r.Supported {
+		return benchmark.ReasoningControl{Toggle: models.ReasoningToggleNone}
+	}
+	return benchmark.ReasoningControl{Toggle: r.Toggle, Kwarg: r.Kwarg}
 }

--- a/internal/api/jobs_env.go
+++ b/internal/api/jobs_env.go
@@ -400,6 +400,13 @@ func (e *jobEnv) modelInfoBundle(m *models.Model) (benchmark.ModelInfo, error) {
 			DraftMax:       cfg.DraftMax,
 			DraftMin:       cfg.DraftMin,
 			DraftPMin:      cfg.DraftPMin,
+			SpecAssist:     cfg.SpecAssist,
+			AssistNMax:     cfg.AssistNMax,
+			AssistNMin:     cfg.AssistNMin,
+			AssistNMatch:   cfg.AssistNMatch,
+			AssistSizeN:    cfg.AssistSizeN,
+			AssistSizeM:    cfg.AssistSizeM,
+			AssistMinHits:  cfg.AssistMinHits,
 			NgramSizeN:     cfg.NgramSizeN,
 			NgramSizeM:     cfg.NgramSizeM,
 			PLEMode:        cfg.PLEMode,
@@ -671,6 +678,13 @@ func applySnapshotToConfig(base models.ModelConfig, snap benchmark.ConfigSnapsho
 	out.DraftMax = snap.DraftMax
 	out.DraftMin = snap.DraftMin
 	out.DraftPMin = snap.DraftPMin
+	out.SpecAssist = snap.SpecAssist
+	out.AssistNMax = snap.AssistNMax
+	out.AssistNMin = snap.AssistNMin
+	out.AssistNMatch = snap.AssistNMatch
+	out.AssistSizeN = snap.AssistSizeN
+	out.AssistSizeM = snap.AssistSizeM
+	out.AssistMinHits = snap.AssistMinHits
 	out.NgramSizeN = snap.NgramSizeN
 	out.NgramSizeM = snap.NgramSizeM
 	out.FlashAttention = snap.FlashAttention
@@ -806,6 +820,13 @@ func configDiff(base, merged models.ModelConfig) []string {
 	add("draft-max", base.DraftMax, merged.DraftMax)
 	add("draft-min", base.DraftMin, merged.DraftMin)
 	add("draft-p-min", base.DraftPMin, merged.DraftPMin)
+	add("spec-assist", base.SpecAssist, merged.SpecAssist)
+	add("ngram-mod-n-max", base.AssistNMax, merged.AssistNMax)
+	add("ngram-mod-n-min", base.AssistNMin, merged.AssistNMin)
+	add("ngram-mod-n-match", base.AssistNMatch, merged.AssistNMatch)
+	add("size-n", base.AssistSizeN, merged.AssistSizeN)
+	add("size-m", base.AssistSizeM, merged.AssistSizeM)
+	add("min-hits", base.AssistMinHits, merged.AssistMinHits)
 	add("ngram-size-n", base.NgramSizeN, merged.NgramSizeN)
 	add("ngram-size-m", base.NgramSizeM, merged.NgramSizeM)
 	if len(out) == 0 {

--- a/internal/api/js_params_test.go
+++ b/internal/api/js_params_test.go
@@ -49,6 +49,7 @@ func TestParameterControlsJS(t *testing.T) {
 		"paramRows", "paramValues", "onParamInheritToggle", "onParamValueToggle",
 		"addParamCustom", "addParamValue", "syncParamRow", "readParams",
 		"numEq", "fillUbatchLadder", "updateMatrixCount", "prefillJobForm",
+		"updateSpecValue",
 	}
 	extracted, missing := extractFunctions(js.String(), wanted)
 	if len(missing) > 0 {

--- a/internal/api/memory_measured.go
+++ b/internal/api/memory_measured.go
@@ -195,13 +195,15 @@ func memoryFingerprint(cfg *models.ModelConfig) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"ctx=%d par=%d b=%d ub=%d kv=%s fa=%t ngl=%d gpus=%s split=%s/%s main=%d ple=%s mmproj=%s/%t spec=%s draft=%s mtp=%s/%t dctx=%d dngl=%d ddev=%s dmoe=%d dkv=%s extra=%s",
+		"ctx=%d par=%d b=%d ub=%d kv=%s fa=%t ngl=%d gpus=%s split=%s/%s main=%d ple=%s mmproj=%s/%t spec=%s draft=%s mtp=%s/%t dctx=%d dngl=%d ddev=%s dmoe=%d dkv=%s assist=%s/%d/%d/%d/%d/%d/%d extra=%s",
 		cfg.ContextSize, cfg.Parallel, cfg.EffectiveBatchSize(), cfg.EffectiveUBatchSize(),
 		cfg.KVCacheQuant, cfg.FlashAttention, cfg.GPULayers, cfg.GPUAssign,
 		cfg.SplitMode, cfg.TensorSplit, cfg.MainGPU, cfg.PLEMode,
 		cfg.MmprojPath, cfg.MmprojDisabled,
 		cfg.SpecType, cfg.DraftModelPath, cfg.MtpPath, cfg.MtpDisabled,
 		cfg.DraftCtxSize, cfg.DraftGPULayers, cfg.DraftDevice, cfg.DraftCPUMoE, cfg.DraftKVCacheQuant,
+		cfg.SpecAssist, cfg.AssistNMax, cfg.AssistNMin, cfg.AssistNMatch,
+		cfg.AssistSizeN, cfg.AssistSizeM, cfg.AssistMinHits,
 		cfg.ExtraFlags,
 	)
 }

--- a/internal/api/ple_render_test.go
+++ b/internal/api/ple_render_test.go
@@ -27,9 +27,15 @@ func renderModelConfig(t *testing.T, cfg *models.ModelConfig, hasPLE bool, sizeL
 		EffectiveFlags      string
 		MaxContext          int
 		HasMMProj           bool
+		HasMTP              bool
 		HasBuiltinVision    bool
 		IsEmbedding         bool
 		DraftCandidates     []models.DraftCandidate
+		DraftModes          []models.SpecMode
+		AssistModes         []models.SpecMode
+		DraftParams         []models.SpecModeParam
+		AssistParams        []models.SpecModeParam
+		EffectiveSpecType   string
 		GPUOptions          []models.GPUOption
 		NumGPUs             int
 		SamplingPresets     []models.SamplingPreset
@@ -40,8 +46,15 @@ func renderModelConfig(t *testing.T, cfg *models.ModelConfig, hasPLE bool, sizeL
 	}{
 		ModelID:      "test-id",
 		Config:       cfg,
-		HasPLE:       hasPLE,
-		PLESizeLabel: sizeLabel,
+		DraftModes:   models.DraftModes(),
+		AssistModes:  models.AssistModes(),
+		DraftParams:  models.SpecDraftParams(cfg.SpecType),
+		AssistParams: models.SpecAssistParams(cfg.SpecAssist),
+		HasMTP:       cfg.MtpPath != "",
+
+		EffectiveSpecType: cfg.EffectiveSpecType(),
+		HasPLE:            hasPLE,
+		PLESizeLabel:      sizeLabel,
 	}
 	var buf bytes.Buffer
 	if err := base.ExecuteTemplate(&buf, "model_config", data); err != nil {

--- a/internal/api/sampling_presets_render_test.go
+++ b/internal/api/sampling_presets_render_test.go
@@ -60,9 +60,15 @@ func TestSamplingPresetsPartialRenders(t *testing.T) {
 		EffectiveFlags      string
 		MaxContext          int
 		HasMMProj           bool
+		HasMTP              bool
 		HasBuiltinVision    bool
 		IsEmbedding         bool
 		DraftCandidates     []models.DraftCandidate
+		DraftModes          []models.SpecMode
+		AssistModes         []models.SpecMode
+		DraftParams         []models.SpecModeParam
+		AssistParams        []models.SpecModeParam
+		EffectiveSpecType   string
 		GPUOptions          []models.GPUOption
 		NumGPUs             int
 		SamplingPresets     []models.SamplingPreset
@@ -124,9 +130,15 @@ func TestSamplingPresetsPartialHidden(t *testing.T) {
 		EffectiveFlags      string
 		MaxContext          int
 		HasMMProj           bool
+		HasMTP              bool
 		HasBuiltinVision    bool
 		IsEmbedding         bool
 		DraftCandidates     []models.DraftCandidate
+		DraftModes          []models.SpecMode
+		AssistModes         []models.SpecMode
+		DraftParams         []models.SpecModeParam
+		AssistParams        []models.SpecModeParam
+		EffectiveSpecType   string
 		GPUOptions          []models.GPUOption
 		NumGPUs             int
 		SamplingPresets     []models.SamplingPreset

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -215,6 +215,9 @@ func NewServer(cfg *config.Config, configPath string) *Server {
 		Token: cfg.MSToken,
 	})
 	s.registry.BackfillGGUFMeta()
+	if n := s.registry.BackfillSpecAssist(); n > 0 {
+		slog.Info("migrated draftless speculative configs", "configs", n)
+	}
 	if n := s.registry.DeduplicateModels(); n > 0 {
 		slog.Info("removed duplicate model entries", "count", n)
 	}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -814,6 +814,11 @@ func (s *Server) handleGetModelConfig(w http.ResponseWriter, r *http.Request) {
 			HasBuiltinVision    bool
 			IsEmbedding         bool
 			DraftCandidates     []models.DraftCandidate
+			DraftModes          []models.SpecMode
+			AssistModes         []models.SpecMode
+			DraftParams         []models.SpecModeParam
+			AssistParams        []models.SpecModeParam
+			EffectiveSpecType   string
 			GPUOptions          []models.GPUOption
 			GPUAssignWarning    string
 			NumGPUs             int
@@ -832,6 +837,11 @@ func (s *Server) handleGetModelConfig(w http.ResponseWriter, r *http.Request) {
 			HasBuiltinVision:    hasBuiltinVision,
 			IsEmbedding:         isEmbedding,
 			DraftCandidates:     draftCandidates,
+			DraftModes:          models.DraftModes(),
+			AssistModes:         models.AssistModes(),
+			DraftParams:         models.SpecDraftParams(cfg.SpecType),
+			AssistParams:        models.SpecAssistParams(cfg.SpecAssist),
+			EffectiveSpecType:   cfg.EffectiveSpecType(),
 			GPUOptions:          gpuOptions,
 			GPUAssignWarning:    s.gpuAssignWarning(cfg, metrics.GPU),
 			NumGPUs:             numGPUs,
@@ -950,11 +960,8 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		// Speculative decoding. Capture the previous mode of each slot so
 		// we can tell whether the user just switched modes vs. is saving
 		// an existing one — the applyDefaults functions wipe user-tuned
-		// values, so we only want to run them on a mode change.
-		//
-		// The form is still the pre-split single picker, so a draftless
-		// choice arrives in spec_type with its settings in the legacy
-		// fields; NormalizeSpec below routes both into the assist slot.
+		// values, so we only want to run them on a mode change. Splitting
+		// them per slot is what stops a change to one wiping the other.
 		prevSpecType, prevSpecAssist := cfg.SpecType, cfg.SpecAssist
 		cfg.SpecType = r.FormValue("spec_type")
 		if r.Form.Has("draft_model_path") {
@@ -971,16 +978,23 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 			cfg.DraftMin = 0
 		}
 		cfg.DraftPMin = r.FormValue("draft_p_min")
-		if v, err := strconv.Atoi(r.FormValue("ngram_size_n")); err == nil && v > 0 {
-			cfg.NgramSizeN = v
-		} else {
-			cfg.NgramSizeN = 0
+		cfg.SpecAssist = r.FormValue("spec_assist")
+		atoiField := func(name string) int {
+			if v, err := strconv.Atoi(r.FormValue(name)); err == nil && v > 0 {
+				return v
+			}
+			return 0
 		}
-		if v, err := strconv.Atoi(r.FormValue("ngram_size_m")); err == nil && v > 0 {
-			cfg.NgramSizeM = v
-		} else {
-			cfg.NgramSizeM = 0
-		}
+		cfg.AssistNMax = atoiField("assist_n_max")
+		cfg.AssistNMin = atoiField("assist_n_min")
+		cfg.AssistNMatch = atoiField("assist_n_match")
+		cfg.AssistSizeN = atoiField("assist_size_n")
+		cfg.AssistSizeM = atoiField("assist_size_m")
+		cfg.AssistMinHits = atoiField("assist_min_hits")
+		// The legacy n-gram inputs are gone from the form; clear any value
+		// a config still carries so nothing reads them again.
+		cfg.NgramSizeN = 0
+		cfg.NgramSizeM = 0
 
 		// Draft model resource overrides (spec_type=draft only).
 		if v, err := strconv.Atoi(r.FormValue("draft_ctx_size")); err == nil && v > 0 {
@@ -1001,12 +1015,6 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		}
 		cfg.DraftKVCacheQuant = r.FormValue("draft_kv_cache_quant")
 
-		// Route a draftless selection into the assist slot before the
-		// comparisons below, so both see the normalised slots — otherwise
-		// choosing an n-gram mode would clear SpecType and apply no
-		// defaults at all.
-		models.NormalizeSpec(cfg)
-
 		// Populate recommended defaults only when the user actually switched
 		// modes — preserves any custom values they tuned within an existing
 		// mode (e.g. lowering ngram-mod's n-min from 48 to 12).
@@ -1025,6 +1033,13 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	if err := cfg.ValidateFlashAttention(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	// The two pickers cannot put a mode in the wrong slot, but a crafted
+	// POST or a hand-edited registry can, and llama-server treats an
+	// unknown --spec-type name as a fatal startup error.
+	if err := cfg.ValidateSpec(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -749,7 +749,7 @@ func (s *Server) handleGetModelConfig(w http.ResponseWriter, r *http.Request) {
 			detectedMTP = models.FindMTP(model.FilePath)
 			isEmbedding = model.IsEmbedding()
 			if !isEmbedding {
-				draftCandidates = s.registry.FindDraftCandidates(id)
+				draftCandidates = s.registry.FindDraftCandidates(id, cfg.SpecType)
 			}
 		}
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -16,20 +16,24 @@ import (
 	"github.com/tmac1973/llama-toolchest/internal/process"
 )
 
-// applySpecDefaults resets speculative decoding parameters to recommended
-// values for the selected mode. Call this only on a mode *change* — calling
-// it on every save would clobber user-tuned values within an existing mode
-// (the form parser already loaded them from the request into cfg).
-func applySpecDefaults(cfg *models.ModelConfig) {
-	// Zero everything, then apply the mode's recommended defaults from
-	// the shared table — the same one the benchmark job form renders, so
-	// the two surfaces cannot disagree.
+// applyDraftDefaults resets the draft-method parameters to the recommended
+// values for the selected draft mode. Call this only on a mode *change* —
+// calling it on every save would clobber user-tuned values within an
+// existing mode (the form parser already loaded them from the request
+// into cfg).
+//
+// It touches only the draft slot, and applyAssistDefaults only the assist
+// slot: with two independent slots, one function resetting everything
+// would wipe a tuned draft depth the moment the user changed the n-gram
+// assist.
+func applyDraftDefaults(cfg *models.ModelConfig) {
+	// Zero everything in the slot, then apply the mode's recommended
+	// defaults from the shared table — the same one the benchmark job
+	// form renders, so the two surfaces cannot disagree.
 	cfg.DraftMax = 0
 	cfg.DraftMin = 0
 	cfg.DraftPMin = ""
-	cfg.NgramSizeN = 0
-	cfg.NgramSizeM = 0
-	for _, p := range models.SpecModeParams(cfg.SpecType) {
+	for _, p := range models.SpecDraftParams(cfg.SpecType) {
 		switch p.Key {
 		case "draft_max":
 			cfg.DraftMax, _ = strconv.Atoi(p.Default)
@@ -37,10 +41,34 @@ func applySpecDefaults(cfg *models.ModelConfig) {
 			cfg.DraftMin, _ = strconv.Atoi(p.Default)
 		case "draft_p_min":
 			cfg.DraftPMin = p.Default
-		case "ngram_size_n":
-			cfg.NgramSizeN, _ = strconv.Atoi(p.Default)
-		case "ngram_size_m":
-			cfg.NgramSizeM, _ = strconv.Atoi(p.Default)
+		}
+	}
+}
+
+// applyAssistDefaults resets the n-gram assist parameters to the
+// recommended values for the selected assist mode. Same rule as
+// applyDraftDefaults: only on a mode change.
+func applyAssistDefaults(cfg *models.ModelConfig) {
+	cfg.AssistNMax = 0
+	cfg.AssistNMin = 0
+	cfg.AssistNMatch = 0
+	cfg.AssistSizeN = 0
+	cfg.AssistSizeM = 0
+	cfg.AssistMinHits = 0
+	for _, p := range models.SpecAssistParams(cfg.SpecAssist) {
+		switch p.Key {
+		case "assist_n_max":
+			cfg.AssistNMax, _ = strconv.Atoi(p.Default)
+		case "assist_n_min":
+			cfg.AssistNMin, _ = strconv.Atoi(p.Default)
+		case "assist_n_match":
+			cfg.AssistNMatch, _ = strconv.Atoi(p.Default)
+		case "assist_size_n":
+			cfg.AssistSizeN, _ = strconv.Atoi(p.Default)
+		case "assist_size_m":
+			cfg.AssistSizeM, _ = strconv.Atoi(p.Default)
+		case "assist_min_hits":
+			cfg.AssistMinHits, _ = strconv.Atoi(p.Default)
 		}
 	}
 }
@@ -919,11 +947,15 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 			cfg.Aliases = nil
 		}
 
-		// Speculative decoding. Capture the previous SpecType so we can tell
-		// whether the user just switched modes vs. is saving an existing one
-		// — applySpecDefaults wipes user-tuned values, so we only want to
-		// run it on a mode change.
-		prevSpecType := cfg.SpecType
+		// Speculative decoding. Capture the previous mode of each slot so
+		// we can tell whether the user just switched modes vs. is saving
+		// an existing one — the applyDefaults functions wipe user-tuned
+		// values, so we only want to run them on a mode change.
+		//
+		// The form is still the pre-split single picker, so a draftless
+		// choice arrives in spec_type with its settings in the legacy
+		// fields; NormalizeSpec below routes both into the assist slot.
+		prevSpecType, prevSpecAssist := cfg.SpecType, cfg.SpecAssist
 		cfg.SpecType = r.FormValue("spec_type")
 		if r.Form.Has("draft_model_path") {
 			cfg.DraftModelPath = r.FormValue("draft_model_path")
@@ -969,11 +1001,20 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		}
 		cfg.DraftKVCacheQuant = r.FormValue("draft_kv_cache_quant")
 
+		// Route a draftless selection into the assist slot before the
+		// comparisons below, so both see the normalised slots — otherwise
+		// choosing an n-gram mode would clear SpecType and apply no
+		// defaults at all.
+		models.NormalizeSpec(cfg)
+
 		// Populate recommended defaults only when the user actually switched
 		// modes — preserves any custom values they tuned within an existing
-		// mode (e.g. lowering ngram-mod's draft_min from 48 to 12).
+		// mode (e.g. lowering ngram-mod's n-min from 48 to 12).
 		if cfg.SpecType != prevSpecType {
-			applySpecDefaults(cfg)
+			applyDraftDefaults(cfg)
+		}
+		if cfg.SpecAssist != prevSpecAssist {
+			applyAssistDefaults(cfg)
 		}
 	}
 

--- a/internal/api/spec_form_test.go
+++ b/internal/api/spec_form_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/models"
+)
+
+// The two default functions are split per slot precisely so that changing
+// one picker cannot wipe the other's tuned values. A single function that
+// reset everything — which is what existed before there were two slots —
+// would silently discard a tuned draft depth the moment the user picked
+// an n-gram assist.
+func TestApplyDefaultsTouchOnlyTheirOwnSlot(t *testing.T) {
+	cfg := &models.ModelConfig{
+		SpecType: "draft-mtp", DraftMax: 3, DraftMin: 1, DraftPMin: "0.5",
+		SpecAssist: "ngram-mod", AssistNMax: 99, AssistNMin: 7, AssistNMatch: 5,
+	}
+
+	applyAssistDefaults(cfg)
+	if cfg.DraftMax != 3 || cfg.DraftMin != 1 || cfg.DraftPMin != "0.5" {
+		t.Errorf("assist defaults clobbered the draft slot: %+v", cfg)
+	}
+	if cfg.AssistNMax != 64 || cfg.AssistNMin != 48 || cfg.AssistNMatch != 24 {
+		t.Errorf("assist defaults not applied: %+v", cfg)
+	}
+
+	cfg.DraftMax, cfg.DraftMin, cfg.DraftPMin = 3, 1, "0.5"
+	applyDraftDefaults(cfg)
+	if cfg.AssistNMax != 64 || cfg.AssistNMin != 48 || cfg.AssistNMatch != 24 {
+		t.Errorf("draft defaults clobbered the assist slot: %+v", cfg)
+	}
+	if cfg.DraftMax != 6 || cfg.DraftMin != 0 || cfg.DraftPMin != "" {
+		t.Errorf("draft defaults not applied: %+v", cfg)
+	}
+}
+
+// The three new draft methods carry no recommended values, so selecting
+// one must leave the fields empty rather than inventing a number.
+func TestApplyDraftDefaultsLeavesHeadModesBlank(t *testing.T) {
+	for _, mode := range []string{"draft-eagle3", "draft-dflash", "draft-dspark"} {
+		cfg := &models.ModelConfig{SpecType: mode, DraftMax: 16, DraftMin: 2, DraftPMin: "0.9"}
+		applyDraftDefaults(cfg)
+		if cfg.DraftMax != 0 || cfg.DraftMin != 0 || cfg.DraftPMin != "" {
+			t.Errorf("%s should apply no defaults, got %+v", mode, cfg)
+		}
+	}
+}
+
+// ngram-cache takes no settings, so switching to it must clear whatever
+// the previous assist mode left behind.
+func TestApplyAssistDefaultsClearsForSettinglessMode(t *testing.T) {
+	cfg := &models.ModelConfig{SpecAssist: "ngram-cache", AssistNMax: 64, AssistSizeN: 12}
+	applyAssistDefaults(cfg)
+	if cfg.AssistNMax != 0 || cfg.AssistSizeN != 0 {
+		t.Errorf("ngram-cache should carry no settings, got %+v", cfg)
+	}
+}
+
+func TestConfigFormShowsBothPickers(t *testing.T) {
+	out := renderModelConfig(t, &models.ModelConfig{
+		SpecType: "draft-mtp", DraftMax: 3,
+		SpecAssist: "ngram-mod", AssistNMax: 64, AssistNMin: 48, AssistNMatch: 24,
+	}, false, "")
+
+	for _, want := range []string{
+		`name="spec_type"`, `name="spec_assist"`,
+		"Draft method", "N-gram assist",
+		`name="draft_max"`, `name="assist_n_max"`, `name="assist_n_match"`,
+		// Every draft method reachable, including the three that were
+		// merged upstream but offered nowhere here.
+		`value="draft-eagle3"`, `value="draft-dflash"`, `value="draft-dspark"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("config form missing %q", want)
+		}
+	}
+	// ngram-mod has no m-gram size; the old form offered one anyway.
+	if strings.Contains(out, `name="assist_size_m"`) || strings.Contains(out, `name="ngram_size_m"`) {
+		t.Errorf("ngram-mod must not be offered an m-gram size:\n%s", out)
+	}
+	// Two draft methods cannot be selected, because they share one picker.
+	if n := strings.Count(out, `name="spec_type"`); n != 1 {
+		t.Errorf("want exactly one draft-method picker, got %d", n)
+	}
+}
+
+func TestConfigFormShowsEffectiveSpecType(t *testing.T) {
+	combined := renderModelConfig(t, &models.ModelConfig{
+		SpecType: "draft-mtp", SpecAssist: "ngram-mod",
+	}, false, "")
+	if !strings.Contains(combined, "draft-mtp,ngram-mod") {
+		t.Errorf("effective --spec-type not shown:\n%s", combined)
+	}
+
+	off := renderModelConfig(t, &models.ModelConfig{}, false, "")
+	if !strings.Contains(off, "speculative decoding is off") {
+		t.Errorf("off state should say so, not print a value:\n%s", off)
+	}
+	// "none" is a real llama.cpp value that discards every other mode in a
+	// list. The launch never emits it, so the form must never show it.
+	if strings.Contains(off, "<code>none</code>") {
+		t.Errorf("form must not display none as an effective value")
+	}
+}
+
+func TestConfigFormOffersHeadPickerForHeadModes(t *testing.T) {
+	for _, mode := range []string{"draft-eagle3", "draft-dflash", "draft-dspark"} {
+		out := renderModelConfig(t, &models.ModelConfig{SpecType: mode}, false, "")
+		if !strings.Contains(out, "Drafter Head") {
+			t.Errorf("%s should offer a head picker", mode)
+		}
+		if !strings.Contains(out, `name="draft_model_path"`) {
+			t.Errorf("%s head picker should post draft_model_path", mode)
+		}
+	}
+}

--- a/internal/api/vram_corpus.go
+++ b/internal/api/vram_corpus.go
@@ -181,7 +181,10 @@ func configLiteral(cfg *models.ModelConfig) string {
 	if cfg.MtpPath != "" && !cfg.MtpDisabled {
 		f = append(f, fmt.Sprintf("MtpPath: %q", cfg.MtpPath))
 	}
-	if cfg.SpecType == "draft" && cfg.DraftModelPath != "" {
+	// Any draft method that loads a drafter from DraftModelPath, not just
+	// "draft" — the head-based methods load one too, and a corpus entry
+	// captured under one of them must record it.
+	if models.IsDraftMode(cfg.SpecType) && cfg.DraftModelPath != "" {
 		f = append(f, fmt.Sprintf("SpecType: %q, DraftModelPath: %q", cfg.SpecType, cfg.DraftModelPath))
 	}
 	return "ModelConfig{" + strings.Join(f, ", ") + "}"

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -323,6 +323,11 @@ type Preset struct {
 	Repetitions  int
 	Concurrency  []int // benchy only; defaults to [1] if empty
 
+	// PromptStyle selects the instruction wrapped around the passage.
+	// Zero value is PromptStyleAnalyze, so an existing preset keeps the
+	// workload it has always had and no stored result is invalidated.
+	PromptStyle PromptStyle
+
 	// Capability presets only (Source == PresetSourceCapability).
 	// EvalMode names the evaluation the cell runs; EvalTasks and
 	// EvalChunks are the run limits (0 = full run). Performance presets
@@ -356,6 +361,14 @@ func Presets() []Preset {
 			Description:  "Three repetitions of end-to-end requests at 128, 512, and 2048-token prompts (128 gen tokens each).",
 			Source:       PresetSourceInternal,
 			PromptTokens: []int{128, 512, 2048}, GenTokens: 128, Repetitions: 3,
+		},
+		{
+			Name:         "internal-echo",
+			Label:        "internal-echo — 3 reps × 2048-token prompt, 512 gen, recall workload (~2 min)",
+			Description:  "Three repetitions of a 2048-token prompt asking the model to reproduce the passage verbatim, with 512 generated tokens. Generation is recall of text already in the context rather than new prose, which is the workload where n-gram speculative decoding pays off: a file being rewritten, a structured response, a tool-call loop. Compare against internal-standard, whose prompts ask for new text, to see what a speculative setting costs on one workload and earns on the other.",
+			Source:       PresetSourceInternal,
+			PromptTokens: []int{2048}, GenTokens: 512, Repetitions: 3,
+			PromptStyle: PromptStyleEcho,
 		},
 		{
 			Name:         "internal-thorough",

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -150,13 +150,24 @@ type ConfigSnapshot struct {
 	Threads        int    `json:"threads"`
 	BatchSize      int    `json:"batch_size,omitempty"`
 	UBatchSize     int    `json:"ubatch_size,omitempty"`
+	// Speculative decoding runs in two slots: a draft method and a
+	// draftless n-gram assist, either of which may be empty. Runs
+	// recorded before the split carry a draftless mode in SpecType and
+	// its settings in NgramSizeN/M; models.NormalizeSpec reads those.
 	SpecType       string `json:"spec_type,omitempty"`
 	DraftModelPath string `json:"draft_model_path,omitempty"`
 	DraftMax       int    `json:"draft_max,omitempty"`
 	DraftMin       int    `json:"draft_min,omitempty"`
 	DraftPMin      string `json:"draft_p_min,omitempty"`
-	NgramSizeN     int    `json:"ngram_size_n,omitempty"`
-	NgramSizeM     int    `json:"ngram_size_m,omitempty"`
+	SpecAssist     string `json:"spec_assist,omitempty"`
+	AssistNMax     int    `json:"assist_n_max,omitempty"`
+	AssistNMin     int    `json:"assist_n_min,omitempty"`
+	AssistNMatch   int    `json:"assist_n_match,omitempty"`
+	AssistSizeN    int    `json:"assist_size_n,omitempty"`
+	AssistSizeM    int    `json:"assist_size_m,omitempty"`
+	AssistMinHits  int    `json:"assist_min_hits,omitempty"`
+	NgramSizeN     int    `json:"ngram_size_n,omitempty"` // legacy; migrated by models.NormalizeSpec
+	NgramSizeM     int    `json:"ngram_size_m,omitempty"` // legacy; migrated by models.NormalizeSpec
 
 	// PLEMode and ExtraFlags reach llama-server through the preset INI
 	// (tensor-read-lazy, and the raw flag text appended verbatim). Both

--- a/internal/benchmark/compare_labels.go
+++ b/internal/benchmark/compare_labels.go
@@ -97,7 +97,7 @@ func comparisonDimensions(runs []BenchmarkRun) []runDimension {
 		{Name: "GPUs", Value: func(r BenchmarkRun) string { return r.Config.GPUAssign }},
 		{Name: "tensor split", Value: func(r BenchmarkRun) string { return r.Config.TensorSplit }},
 		{Name: "threads", Value: func(r BenchmarkRun) string { return itoaOrEmpty(r.Config.Threads) }},
-		{Name: "speculative decoding", Value: func(r BenchmarkRun) string { return r.Config.SpecType }},
+		{Name: "speculative decoding", Value: func(r BenchmarkRun) string { return specLabel(r.Config) }},
 	}
 	for _, d := range cfg {
 		if swept[configFieldForDimension(d.Name)] {
@@ -423,4 +423,25 @@ func (r BenchmarkRun) PromptSizesDetail() string {
 		}
 	}
 	return b.String()
+}
+
+// specLabel renders a run's speculative configuration for the comparison
+// table: both slots when both ran, otherwise whichever one did.
+//
+// The separator is " + " rather than the comma llama.cpp's own flag uses,
+// because this is a table cell read at a glance, and it matches the "+"
+// the sweep encoding joins two modes with.
+//
+// Runs recorded before speculative decoding had two slots carry a
+// draftless mode in SpecType and nothing in SpecAssist, so they keep
+// rendering exactly as they always did.
+func specLabel(c ConfigSnapshot) string {
+	switch {
+	case c.SpecType != "" && c.SpecAssist != "":
+		return c.SpecType + " + " + c.SpecAssist
+	case c.SpecType != "":
+		return c.SpecType
+	default:
+		return c.SpecAssist
+	}
 }

--- a/internal/benchmark/job.go
+++ b/internal/benchmark/job.go
@@ -76,30 +76,40 @@ type BenchmarkJob struct {
 // ConfigOverrides applies on top of each model's saved ModelConfig for
 // every cell. Pointer fields so nil = "use the model's saved value".
 type ConfigOverrides struct {
-	GPULayers      *int     `json:"gpu_layers,omitempty"`
-	ContextSize    *int     `json:"context_size,omitempty"`
-	Threads        *int     `json:"threads,omitempty"`
-	BatchSize      *int     `json:"batch_size,omitempty"`
-	UBatchSize     *int     `json:"ubatch_size,omitempty"`
-	FlashAttention *bool    `json:"flash_attention,omitempty"`
-	KVCacheQuant   *string  `json:"kv_cache_quant,omitempty"`
-	DirectIO       *bool    `json:"direct_io,omitempty"`
-	PLEMode        *string  `json:"ple_mode,omitempty"`
-	ExtraFlags     *string  `json:"extra_flags,omitempty"`
-	GPUAssign      *string  `json:"gpu_assign,omitempty"`
-	TensorSplit    *string  `json:"tensor_split,omitempty"`
-	SpecType       *string  `json:"spec_type,omitempty"`
-	DraftModelPath *string  `json:"draft_model_path,omitempty"`
-	DraftMax       *int     `json:"draft_max,omitempty"`
-	DraftMin       *int     `json:"draft_min,omitempty"`
-	DraftPMin      *string  `json:"draft_p_min,omitempty"`
-	NgramSizeN     *int     `json:"ngram_size_n,omitempty"`
-	NgramSizeM     *int     `json:"ngram_size_m,omitempty"`
-	Temperature    *float64 `json:"temperature,omitempty"`
-	TopP           *float64 `json:"top_p,omitempty"`
-	TopK           *int     `json:"top_k,omitempty"`
-	MinP           *float64 `json:"min_p,omitempty"`
-	RepeatPenalty  *float64 `json:"repeat_penalty,omitempty"`
+	GPULayers      *int    `json:"gpu_layers,omitempty"`
+	ContextSize    *int    `json:"context_size,omitempty"`
+	Threads        *int    `json:"threads,omitempty"`
+	BatchSize      *int    `json:"batch_size,omitempty"`
+	UBatchSize     *int    `json:"ubatch_size,omitempty"`
+	FlashAttention *bool   `json:"flash_attention,omitempty"`
+	KVCacheQuant   *string `json:"kv_cache_quant,omitempty"`
+	DirectIO       *bool   `json:"direct_io,omitempty"`
+	PLEMode        *string `json:"ple_mode,omitempty"`
+	ExtraFlags     *string `json:"extra_flags,omitempty"`
+	GPUAssign      *string `json:"gpu_assign,omitempty"`
+	TensorSplit    *string `json:"tensor_split,omitempty"`
+	SpecType       *string `json:"spec_type,omitempty"`
+	DraftModelPath *string `json:"draft_model_path,omitempty"`
+	DraftMax       *int    `json:"draft_max,omitempty"`
+	DraftMin       *int    `json:"draft_min,omitempty"`
+	DraftPMin      *string `json:"draft_p_min,omitempty"`
+	SpecAssist     *string `json:"spec_assist,omitempty"`
+	AssistNMax     *int    `json:"assist_n_max,omitempty"`
+	AssistNMin     *int    `json:"assist_n_min,omitempty"`
+	AssistNMatch   *int    `json:"assist_n_match,omitempty"`
+	AssistSizeN    *int    `json:"assist_size_n,omitempty"`
+	AssistSizeM    *int    `json:"assist_size_m,omitempty"`
+	AssistMinHits  *int    `json:"assist_min_hits,omitempty"`
+	// Legacy speculative fields. Jobs stored before speculative decoding
+	// had two slots still carry these, so the merge keeps honouring them
+	// and models.NormalizeSpec moves them onto the assist slot.
+	NgramSizeN    *int     `json:"ngram_size_n,omitempty"`
+	NgramSizeM    *int     `json:"ngram_size_m,omitempty"`
+	Temperature   *float64 `json:"temperature,omitempty"`
+	TopP          *float64 `json:"top_p,omitempty"`
+	TopK          *int     `json:"top_k,omitempty"`
+	MinP          *float64 `json:"min_p,omitempty"`
+	RepeatPenalty *float64 `json:"repeat_penalty,omitempty"`
 }
 
 // JobCell is one (model, build, preset) point in the matrix. The cell

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -158,6 +158,10 @@ type ModelInfo struct {
 	DisplayName string         // short, human-readable name for the run
 	RouterName  string         // identifier the router responds to
 	Config      ConfigSnapshot // saved baseline; ConfigOverrides overlay on this
+	// Reasoning is how this model's thinking mode is turned off, detected
+	// from its chat template. The recall workload needs it; nothing else
+	// does.
+	Reasoning ReasoningControl
 }
 
 // JobQueue serializes job execution: only one job runs at a time. Submit
@@ -500,6 +504,7 @@ func (q *JobQueue) runCell(ctx context.Context, job *BenchmarkJob, cell *JobCell
 		HFToken:    q.env.HFToken(),
 		HFHome:     q.env.HFCacheDir(),
 		Sampling:   samplingFromOverrides(cellOv),
+		Reasoning:  modelInfo.Reasoning,
 		Memory:     q.env.MeasuredMemory,
 	}, nil)
 

--- a/internal/benchmark/job_runner.go
+++ b/internal/benchmark/job_runner.go
@@ -866,12 +866,39 @@ func applyOverrides(base ConfigSnapshot, overrides *ConfigOverrides) ConfigSnaps
 	if overrides.NgramSizeM != nil {
 		out.NgramSizeM = *overrides.NgramSizeM
 	}
+	if overrides.SpecAssist != nil {
+		out.SpecAssist = *overrides.SpecAssist
+	}
+	if overrides.AssistNMax != nil {
+		out.AssistNMax = *overrides.AssistNMax
+	}
+	if overrides.AssistNMin != nil {
+		out.AssistNMin = *overrides.AssistNMin
+	}
+	if overrides.AssistNMatch != nil {
+		out.AssistNMatch = *overrides.AssistNMatch
+	}
+	if overrides.AssistSizeN != nil {
+		out.AssistSizeN = *overrides.AssistSizeN
+	}
+	if overrides.AssistSizeM != nil {
+		out.AssistSizeM = *overrides.AssistSizeM
+	}
+	if overrides.AssistMinHits != nil {
+		out.AssistMinHits = *overrides.AssistMinHits
+	}
 	if overrides.PLEMode != nil {
 		out.PLEMode = *overrides.PLEMode
 	}
 	if overrides.ExtraFlags != nil {
 		out.ExtraFlags = *overrides.ExtraFlags
 	}
+	// Not normalised here: a job stored before speculative decoding had
+	// two slots carries a draftless mode in SpecType with its settings in
+	// the legacy fields, and the snapshot keeps that shape verbatim —
+	// it is a record of what was requested. models.NormalizeSpec runs on
+	// the launch path (specDecodingParams), so such a job launches
+	// exactly as it always did without its stored history being rewritten.
 	return out
 }
 

--- a/internal/benchmark/overrides_test.go
+++ b/internal/benchmark/overrides_test.go
@@ -120,3 +120,69 @@ func TestSamplingOmitsUnsetFields(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyOverridesCarriesBothSpeculativeSlots(t *testing.T) {
+	// A job built after the split names both slots. applySpecValue always
+	// writes both pointers — clearing the one the value does not name —
+	// so a cell that selects a mode runs that mode and nothing else.
+	st, sa := "draft-mtp", "ngram-mod"
+	dmax, nmax, nmin, nmatch := 3, 64, 48, 24
+
+	got := applyOverrides(ConfigSnapshot{}, &ConfigOverrides{
+		SpecType: &st, DraftMax: &dmax,
+		SpecAssist: &sa, AssistNMax: &nmax, AssistNMin: &nmin, AssistNMatch: &nmatch,
+	})
+
+	want := ConfigSnapshot{
+		SpecType: st, DraftMax: dmax,
+		SpecAssist: sa, AssistNMax: nmax, AssistNMin: nmin, AssistNMatch: nmatch,
+	}
+	if got != want {
+		t.Errorf("applyOverrides dropped a speculative field:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+func TestApplyOverridesKeepsLegacySpecShapeVerbatim(t *testing.T) {
+	// The shape a job stored before speculative decoding had two slots
+	// holds. The snapshot is a record of what was *requested*, so it must
+	// come through unchanged — models.NormalizeSpec runs on the launch
+	// path, which is what makes such a job launch as it always did
+	// without its stored history being rewritten.
+	st := "ngram-mod"
+	dmax, dmin, nsn := 64, 48, 24
+
+	got := applyOverrides(ConfigSnapshot{}, &ConfigOverrides{
+		SpecType: &st, DraftMax: &dmax, DraftMin: &dmin, NgramSizeN: &nsn,
+	})
+
+	want := ConfigSnapshot{SpecType: st, DraftMax: dmax, DraftMin: dmin, NgramSizeN: nsn}
+	if got != want {
+		t.Errorf("legacy job shape was altered:\ngot  %+v\nwant %+v", got, want)
+	}
+	if got.SpecAssist != "" {
+		t.Errorf("snapshot should not be normalised here, got SpecAssist=%q", got.SpecAssist)
+	}
+}
+
+func TestSpecLabelJoinsBothSlots(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ConfigSnapshot
+		want string
+	}{
+		{"both", ConfigSnapshot{SpecType: "draft-mtp", SpecAssist: "ngram-mod"}, "draft-mtp + ngram-mod"},
+		{"draft only", ConfigSnapshot{SpecType: "draft-mtp"}, "draft-mtp"},
+		{"assist only", ConfigSnapshot{SpecAssist: "ngram-mod"}, "ngram-mod"},
+		{"off", ConfigSnapshot{}, ""},
+		// A run recorded before the split carries a draftless name in
+		// SpecType and must keep rendering exactly as it did.
+		{"legacy draftless", ConfigSnapshot{SpecType: "ngram-mod"}, "ngram-mod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := specLabel(tc.cfg); got != tc.want {
+				t.Errorf("specLabel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/benchmark/runner.go
+++ b/internal/benchmark/runner.go
@@ -233,7 +233,7 @@ func (r *Runner) Run(ctx context.Context, cfg RunConfig, progress chan<- Progres
 
 			// run.ID is unique per cell, so no two cells can send the
 			// same prompt and hit each other's cache.
-			result, err := r.runOneTest(ctx, cfg.RouterURL, cfg.RouterName, promptTokens, cfg.Preset.GenTokens, rep, cfg.Sampling, run.ID)
+			result, err := r.runOneTest(ctx, cfg.RouterURL, cfg.RouterName, promptTokens, cfg.Preset.GenTokens, rep, cfg.Sampling, run.ID, cfg.Preset.PromptStyle)
 			if err != nil {
 				lastErr = err
 				slog.Error("benchmark test failed", "prompt_tokens", promptTokens, "rep", rep, "error", err)
@@ -376,6 +376,35 @@ const BenchPromptPrefixTemplate = "This is benchmark repetition number %d. Pleas
 // ~4 chars/token under most BPE tokenizers).
 const BenchPromptCharsPerToken = 4
 
+// PromptStyle selects the instruction wrapped around the benchmark
+// passage. The two styles produce opposite generation workloads, and that
+// is the point: an n-gram speculative method measures exactly baseline on
+// PromptStyleAnalyze, which asks for new prose, and several times
+// baseline on PromptStyleEcho, where generation is recall of text already
+// in the context.
+type PromptStyle string
+
+const (
+	// PromptStyleAnalyze asks the model to respond to the passage. It is
+	// the zero value, so every preset that does not say otherwise keeps
+	// the behaviour it has always had.
+	PromptStyleAnalyze PromptStyle = ""
+	PromptStyleEcho    PromptStyle = "echo"
+)
+
+// BenchPromptEchoPrefixTemplate asks the model to reproduce the passage
+// rather than respond to it. Exposed so the About modal can show the
+// actual template, the same as the analysis prefix.
+const BenchPromptEchoPrefixTemplate = "This is benchmark repetition number %d. Reproduce the following text exactly, character for character, with no commentary and no introduction.\n\n"
+
+// promptPrefixTemplate returns the per-repetition prefix for a style.
+func promptPrefixTemplate(style PromptStyle) string {
+	if style == PromptStyleEcho {
+		return BenchPromptEchoPrefixTemplate
+	}
+	return BenchPromptPrefixTemplate
+}
+
 // buildPrompt constructs a prompt of approximately the target token count
 // by repeating the benchmark text. The repetition parameter varies the
 // prompt to defeat llama.cpp's prompt cache.
@@ -392,7 +421,7 @@ const BenchPromptCharsPerToken = 4
 // prompt_n collapsing from 213 to 4 and prompt-processing throughput
 // reported as ~90 t/s instead of ~1380: a meaningless number presented
 // as a measurement.
-func buildPromptFor(nonce string, targetTokens int, repetition int) string {
+func buildPromptFor(nonce string, targetTokens int, repetition int, style PromptStyle) string {
 	targetChars := targetTokens * BenchPromptCharsPerToken
 	var b strings.Builder
 	// Everything that distinguishes this request goes first, before the
@@ -406,9 +435,18 @@ func buildPromptFor(nonce string, targetTokens int, repetition int) string {
 	// prompt_n of 6309/6795/13070/25630, which sum to the real sizes, and
 	// its throughput figures measured incremental prefill at increasing
 	// depth rather than the full prefill each row claimed.
-	b.WriteString(fmt.Sprintf("Benchmark %s, target %d tokens, repetition %d.\n\n",
-		nonce, targetTokens, repetition))
-	b.WriteString(fmt.Sprintf(BenchPromptPrefixTemplate, repetition))
+	// The style belongs on this line too: both prefixes below open with
+	// "This is benchmark repetition number N", so two prompts that differ
+	// only in style would otherwise share their first ~80 characters. It
+	// is appended only when non-default, so an analysis prompt stays
+	// byte-identical to what every existing preset has always sent.
+	styleMark := ""
+	if style != PromptStyleAnalyze {
+		styleMark = ", style " + string(style)
+	}
+	b.WriteString(fmt.Sprintf("Benchmark %s, target %d tokens, repetition %d%s.\n\n",
+		nonce, targetTokens, repetition, styleMark))
+	b.WriteString(fmt.Sprintf(promptPrefixTemplate(style), repetition))
 	for b.Len() < targetChars {
 		b.WriteString(BenchPromptText)
 	}
@@ -422,14 +460,14 @@ func buildPromptFor(nonce string, targetTokens int, repetition int) string {
 // buildPrompt is the nonce-free form, kept for callers that don't need
 // cache isolation (warmup).
 func buildPrompt(targetTokens int, repetition int) string {
-	return buildPromptFor("", targetTokens, repetition)
+	return buildPromptFor("", targetTokens, repetition, PromptStyleAnalyze)
 }
 
 // sendCompletion sends a chat completion and returns the timings.
 func (r *Runner) sendCompletion(ctx context.Context, routerURL, model string, promptTokens, genTokens int) error {
 	// Warmup only needs the model resident; sampling settings are
 	// irrelevant to that and are left at server defaults.
-	_, err := r.sendCompletionWithTimings(ctx, routerURL, model, promptTokens, genTokens, 0, SamplingParams{}, "")
+	_, err := r.sendCompletionWithTimings(ctx, routerURL, model, promptTokens, genTokens, 0, SamplingParams{}, "", PromptStyleAnalyze)
 	return err
 }
 
@@ -443,8 +481,8 @@ type timingsResponse struct {
 	PredictedPerSec float64 `json:"predicted_per_second"`
 }
 
-func (r *Runner) sendCompletionWithTimings(ctx context.Context, routerURL, model string, promptTokens, genTokens, repetition int, sampling SamplingParams, nonce string) (*timingsResponse, error) {
-	prompt := buildPromptFor(nonce, promptTokens, repetition)
+func (r *Runner) sendCompletionWithTimings(ctx context.Context, routerURL, model string, promptTokens, genTokens, repetition int, sampling SamplingParams, nonce string, style PromptStyle) (*timingsResponse, error) {
+	prompt := buildPromptFor(nonce, promptTokens, repetition, style)
 	reqPayload := map[string]any{
 		"model":      model,
 		"max_tokens": genTokens,
@@ -492,8 +530,8 @@ func (r *Runner) sendCompletionWithTimings(ctx context.Context, routerURL, model
 }
 
 // runOneTest runs a single benchmark test point.
-func (r *Runner) runOneTest(ctx context.Context, routerURL, model string, promptTokens, genTokens, rep int, sampling SamplingParams, nonce string) (*BenchmarkResult, error) {
-	timings, err := r.sendCompletionWithTimings(ctx, routerURL, model, promptTokens, genTokens, rep, sampling, nonce)
+func (r *Runner) runOneTest(ctx context.Context, routerURL, model string, promptTokens, genTokens, rep int, sampling SamplingParams, nonce string, style PromptStyle) (*BenchmarkResult, error) {
+	timings, err := r.sendCompletionWithTimings(ctx, routerURL, model, promptTokens, genTokens, rep, sampling, nonce, style)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/benchmark/runner.go
+++ b/internal/benchmark/runner.go
@@ -22,6 +22,10 @@ type RunConfig struct {
 	HFToken    string // forwarded as HF_TOKEN to llama-benchy (avoids HF rate limiting)
 	HFHome     string // forwarded as HF_HOME so the tokenizer cache persists across runs
 	Sampling   SamplingParams
+	// Reasoning is how this model's thinking mode is turned off, used by
+	// the recall workload so its generation is recall rather than
+	// deliberation.
+	Reasoning ReasoningControl
 
 	// Memory returns what the model's current load allocated, once it is
 	// loaded. Nil, or a false second return, when nothing was measured —
@@ -233,7 +237,10 @@ func (r *Runner) Run(ctx context.Context, cfg RunConfig, progress chan<- Progres
 
 			// run.ID is unique per cell, so no two cells can send the
 			// same prompt and hit each other's cache.
-			result, err := r.runOneTest(ctx, cfg.RouterURL, cfg.RouterName, promptTokens, cfg.Preset.GenTokens, rep, cfg.Sampling, run.ID, cfg.Preset.PromptStyle)
+			result, err := r.runOneTest(ctx, cfg.RouterURL, cfg.RouterName, promptTokens, cfg.Preset.GenTokens, rep, cfg.Sampling, run.ID, promptOptions{
+				Style:     cfg.Preset.PromptStyle,
+				Reasoning: cfg.Reasoning,
+			})
 			if err != nil {
 				lastErr = err
 				slog.Error("benchmark test failed", "prompt_tokens", promptTokens, "rep", rep, "error", err)
@@ -397,6 +404,43 @@ const (
 // actual template, the same as the analysis prefix.
 const BenchPromptEchoPrefixTemplate = "This is benchmark repetition number %d. Reproduce the following text exactly, character for character, with no commentary and no introduction.\n\n"
 
+// ReasoningControl describes how to turn a model's thinking mode off, in
+// whichever way that model exposes. Detected from the chat template and
+// carried through ModelInfo so this package needs no dependency on the
+// models package.
+type ReasoningControl struct {
+	Toggle string // "chat_template_kwargs" | "reasoning_effort" | "none"
+	Kwarg  string // kwarg key when Toggle is chat_template_kwargs
+}
+
+// applyThinkingOff adds whatever the model needs to skip its reasoning
+// pass. It is used for the recall workload and nothing else.
+//
+// Without it a reasoning model spends the whole generation budget
+// deliberating about how to reproduce the passage — novel prose, which is
+// the opposite of what internal-echo is for. The measured symptom is an
+// echo preset that reads almost exactly like the analysis preset, because
+// that is what it is running.
+func (rc ReasoningControl) applyThinkingOff(payload map[string]any) {
+	switch rc.Toggle {
+	case "chat_template_kwargs":
+		if rc.Kwarg == "" {
+			return
+		}
+		payload["chat_template_kwargs"] = map[string]any{rc.Kwarg: false}
+	case "reasoning_effort":
+		payload["reasoning_effort"] = "none"
+	}
+	// "none", or a model with no reasoning mode: nothing to turn off.
+}
+
+// promptOptions bundle what the prompt and the request need beyond the
+// sizing arguments, so the two travel together and cannot disagree.
+type promptOptions struct {
+	Style     PromptStyle
+	Reasoning ReasoningControl
+}
+
 // promptPrefixTemplate returns the per-repetition prefix for a style.
 func promptPrefixTemplate(style PromptStyle) string {
 	if style == PromptStyleEcho {
@@ -467,7 +511,7 @@ func buildPrompt(targetTokens int, repetition int) string {
 func (r *Runner) sendCompletion(ctx context.Context, routerURL, model string, promptTokens, genTokens int) error {
 	// Warmup only needs the model resident; sampling settings are
 	// irrelevant to that and are left at server defaults.
-	_, err := r.sendCompletionWithTimings(ctx, routerURL, model, promptTokens, genTokens, 0, SamplingParams{}, "", PromptStyleAnalyze)
+	_, err := r.sendCompletionWithTimings(ctx, routerURL, model, promptTokens, genTokens, 0, SamplingParams{}, "", promptOptions{})
 	return err
 }
 
@@ -481,8 +525,8 @@ type timingsResponse struct {
 	PredictedPerSec float64 `json:"predicted_per_second"`
 }
 
-func (r *Runner) sendCompletionWithTimings(ctx context.Context, routerURL, model string, promptTokens, genTokens, repetition int, sampling SamplingParams, nonce string, style PromptStyle) (*timingsResponse, error) {
-	prompt := buildPromptFor(nonce, promptTokens, repetition, style)
+func (r *Runner) sendCompletionWithTimings(ctx context.Context, routerURL, model string, promptTokens, genTokens, repetition int, sampling SamplingParams, nonce string, opts promptOptions) (*timingsResponse, error) {
+	prompt := buildPromptFor(nonce, promptTokens, repetition, opts.Style)
 	reqPayload := map[string]any{
 		"model":      model,
 		"max_tokens": genTokens,
@@ -490,6 +534,11 @@ func (r *Runner) sendCompletionWithTimings(ctx context.Context, routerURL, model
 		"messages": []map[string]string{
 			{"role": "user", "content": prompt},
 		},
+	}
+	if opts.Style == PromptStyleEcho {
+		// Recall only works if the model actually reproduces the passage
+		// rather than reasoning about how to.
+		opts.Reasoning.applyThinkingOff(reqPayload)
 	}
 	sampling.applyTo(reqPayload)
 	reqBody, _ := json.Marshal(reqPayload)
@@ -530,8 +579,8 @@ func (r *Runner) sendCompletionWithTimings(ctx context.Context, routerURL, model
 }
 
 // runOneTest runs a single benchmark test point.
-func (r *Runner) runOneTest(ctx context.Context, routerURL, model string, promptTokens, genTokens, rep int, sampling SamplingParams, nonce string, style PromptStyle) (*BenchmarkResult, error) {
-	timings, err := r.sendCompletionWithTimings(ctx, routerURL, model, promptTokens, genTokens, rep, sampling, nonce, style)
+func (r *Runner) runOneTest(ctx context.Context, routerURL, model string, promptTokens, genTokens, rep int, sampling SamplingParams, nonce string, opts promptOptions) (*BenchmarkResult, error) {
+	timings, err := r.sendCompletionWithTimings(ctx, routerURL, model, promptTokens, genTokens, rep, sampling, nonce, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/benchmark/split_params_test.go
+++ b/internal/benchmark/split_params_test.go
@@ -646,3 +646,32 @@ func TestInternalEchoPresetUsesTheRecallStyle(t *testing.T) {
 		}
 	}
 }
+
+// A reasoning model asked to reproduce a passage will spend its whole
+// generation budget deliberating about how to, which is new prose — so
+// internal-echo would measure the same workload as internal-standard and
+// the recall case would silently not be tested. Turning thinking off for
+// the echo style is what makes the preset mean what it says.
+func TestEchoStyleTurnsThinkingOff(t *testing.T) {
+	cases := []struct {
+		name string
+		rc   ReasoningControl
+		want map[string]any
+	}{
+		{"qwen-style kwarg", ReasoningControl{Toggle: "chat_template_kwargs", Kwarg: "enable_thinking"},
+			map[string]any{"chat_template_kwargs": map[string]any{"enable_thinking": false}}},
+		{"openai-style effort", ReasoningControl{Toggle: "reasoning_effort"},
+			map[string]any{"reasoning_effort": "none"}},
+		{"no reasoning mode", ReasoningControl{Toggle: "none"}, map[string]any{}},
+		{"kwarg mechanism with no key", ReasoningControl{Toggle: "chat_template_kwargs"}, map[string]any{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := map[string]any{}
+			tc.rc.applyThinkingOff(got)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("applyThinkingOff = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/benchmark/split_params_test.go
+++ b/internal/benchmark/split_params_test.go
@@ -423,20 +423,20 @@ func TestValidateSamplingSupportAllowsConfigSweepWithBenchy(t *testing.T) {
 // prompt-processing rate is cache-lookup overhead reported as a
 // measurement.
 func TestPromptsDifferPerCell(t *testing.T) {
-	a := buildPromptFor("bench-1-1-1", 256, 1)
-	b := buildPromptFor("bench-2-2-1", 256, 1)
+	a := buildPromptFor("bench-1-1-1", 256, 1, PromptStyleAnalyze)
+	b := buildPromptFor("bench-2-2-1", 256, 1, PromptStyleAnalyze)
 	if a == b {
 		t.Error("two cells produced identical prompts; the second would hit the prompt cache")
 	}
 	// Same nonce and repetition must still be reproducible.
-	if buildPromptFor("bench-1-1-1", 256, 1) != a {
+	if buildPromptFor("bench-1-1-1", 256, 1, PromptStyleAnalyze) != a {
 		t.Error("prompt generation must be deterministic for a given cell")
 	}
 }
 
 // The existing per-repetition variation must survive.
 func TestPromptsDifferPerRepetition(t *testing.T) {
-	if buildPromptFor("x", 256, 1) == buildPromptFor("x", 256, 2) {
+	if buildPromptFor("x", 256, 1, PromptStyleAnalyze) == buildPromptFor("x", 256, 2, PromptStyleAnalyze) {
 		t.Error("repetitions must differ")
 	}
 }
@@ -445,7 +445,7 @@ func TestPromptsDifferPerRepetition(t *testing.T) {
 func TestPromptSizeUnaffectedByNonce(t *testing.T) {
 	want := 256 * BenchPromptCharsPerToken
 	for _, n := range []string{"", "bench-1784407486983-1-1"} {
-		if got := len(buildPromptFor(n, 256, 1)); got != want {
+		if got := len(buildPromptFor(n, 256, 1, PromptStyleAnalyze)); got != want {
 			t.Errorf("nonce %q: prompt is %d chars, want %d", n, got, want)
 		}
 	}
@@ -456,8 +456,8 @@ func TestPromptSizeUnaffectedByNonce(t *testing.T) {
 // every size after the first measured incremental prefill while
 // reporting only the newly-processed token count.
 func TestPromptsOfDifferentSizesDoNotSharePrefix(t *testing.T) {
-	short := buildPromptFor("cell-1", 256, 1)
-	long := buildPromptFor("cell-1", 512, 1)
+	short := buildPromptFor("cell-1", 256, 1, PromptStyleAnalyze)
+	long := buildPromptFor("cell-1", 512, 1, PromptStyleAnalyze)
 
 	n := len(short)
 	if len(long) < n {
@@ -568,5 +568,81 @@ func TestSpecValueParsingAndCanonical(t *testing.T) {
 	}
 	if len(axes) != 0 {
 		t.Errorf("equivalent values should dedup to a fixed override, got axes %+v", axes)
+	}
+}
+
+// The two prompt styles must ask for opposite work — that is the whole
+// reason internal-echo exists. An n-gram speculative method measures
+// exactly baseline on the analysis prompt, so without a recall prompt the
+// benefit of combining modes cannot be measured here at all.
+func TestPromptStylesAskForOppositeWork(t *testing.T) {
+	analyze := buildPromptFor("n", 2048, 1, PromptStyleAnalyze)
+	echo := buildPromptFor("n", 2048, 1, PromptStyleEcho)
+
+	if !strings.Contains(analyze, "analyze the following text") {
+		t.Errorf("analysis prompt lost its instruction:\n%s", analyze[:200])
+	}
+	if strings.Contains(analyze, "Reproduce the following text") {
+		t.Errorf("analysis prompt should not ask for reproduction")
+	}
+	if !strings.Contains(echo, "Reproduce the following text exactly") {
+		t.Errorf("echo prompt lost its instruction:\n%s", echo[:200])
+	}
+	if strings.Contains(echo, "analyze the following text") {
+		t.Errorf("echo prompt should not ask for analysis")
+	}
+	// Both are sized the same way, so a comparison between them is a
+	// comparison of workload and nothing else.
+	if len(analyze) != len(echo) {
+		t.Errorf("styles produced different lengths: %d vs %d", len(analyze), len(echo))
+	}
+	if want := 2048 * BenchPromptCharsPerToken; len(echo) != want {
+		t.Errorf("echo prompt length = %d, want %d", len(echo), want)
+	}
+}
+
+// An echo prompt is by construction the most cacheable thing the
+// benchmark sends, so the cache-defeating discipline matters more here,
+// not less: a cached prefill would report a meaningless number.
+func TestEchoPromptsStillDefeatTheCache(t *testing.T) {
+	const head = 80
+	cases := []struct{ name, a, b string }{
+		{"style", buildPromptFor("n", 256, 1, PromptStyleAnalyze), buildPromptFor("n", 256, 1, PromptStyleEcho)},
+		{"nonce", buildPromptFor("a", 256, 1, PromptStyleEcho), buildPromptFor("b", 256, 1, PromptStyleEcho)},
+		{"repetition", buildPromptFor("n", 256, 1, PromptStyleEcho), buildPromptFor("n", 256, 2, PromptStyleEcho)},
+		{"size", buildPromptFor("n", 256, 1, PromptStyleEcho), buildPromptFor("n", 512, 1, PromptStyleEcho)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.a[:head] == tc.b[:head] {
+				t.Errorf("prompts differing by %s share their first %d chars:\n%s", tc.name, head, tc.a[:head])
+			}
+		})
+	}
+}
+
+func TestInternalEchoPresetUsesTheRecallStyle(t *testing.T) {
+	p := GetPreset("internal-echo")
+	if p.Name != "internal-echo" {
+		t.Fatalf("internal-echo not registered; GetPreset fell back to %q", p.Name)
+	}
+	if p.PromptStyle != PromptStyleEcho {
+		t.Errorf("internal-echo style = %q, want %q", p.PromptStyle, PromptStyleEcho)
+	}
+	// 512 generated tokens has to fit inside the passage being echoed, or
+	// the model runs out of source text and drifts into invention.
+	if p.GenTokens >= p.PromptTokens[0] {
+		t.Errorf("gen tokens %d should be well inside the %d-token passage", p.GenTokens, p.PromptTokens[0])
+	}
+
+	// Every other preset keeps the workload it has always had, so no
+	// stored result is invalidated.
+	for _, other := range Presets() {
+		if other.Name == "internal-echo" {
+			continue
+		}
+		if other.PromptStyle != PromptStyleAnalyze {
+			t.Errorf("%s changed prompt style to %q", other.Name, other.PromptStyle)
+		}
 	}
 }

--- a/internal/benchmark/sweep.go
+++ b/internal/benchmark/sweep.go
@@ -43,6 +43,15 @@ type SweepChoice struct {
 	// name the encoded Value starts with.
 	Params []models.SpecModeParam
 	Mode   string
+	// Slot is "draft" or "assist" for a speculative mode choice, "" for
+	// everything else. A draft choice also carries AssistModes and
+	// AssistParamsByMode, so its expandable section can offer an n-gram
+	// assist alongside its own settings: that is what reaches all
+	// twenty-five combinations from eleven checkboxes, on a field that
+	// has no custom-entry box to fall back on.
+	Slot               string
+	AssistModes        []models.SpecMode
+	AssistParamsByMode map[string][]models.SpecModeParam
 }
 
 // SweepField describes one sweepable parameter. The set function is the
@@ -179,34 +188,79 @@ func specModeParams(mode string) []models.SpecModeParam {
 	return models.SpecAssistParams(mode)
 }
 
-// specValue is a parsed spec_type sweep value: a mode plus any
-// parameter settings from the mode's expandable section.
-type specValue struct {
-	mode   string
-	params map[string]string // key -> raw value, keys from models.SpecModeParams
+// nonEmpty returns the non-empty arguments, for naming whichever slots a
+// value actually uses in an error message.
+func nonEmpty(vals ...string) []string {
+	var out []string
+	for _, v := range vals {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
-// parseSpecValue parses the three accepted shapes: "none", a bare mode
-// name, or "mode:key=value,key=value". Keys must belong to the mode
-// (per models.SpecModeParams) and integer parameters must parse.
+// specValue is a parsed spec_type sweep value: up to one draft method,
+// up to one n-gram assist, and any parameter settings from their
+// expandable sections.
+type specValue struct {
+	mode   string            // draft method, "" if none
+	assist string            // n-gram assist, "" if none
+	params map[string]string // draft_* and assist_* keys
+}
+
+// parseSpecValue parses the accepted shapes: "none", a bare mode name,
+// "mode:key=value,key=value", and either of those with the two modes
+// joined by "+" — "draft-mtp+ngram-mod:draft_max=3,assist_n_max=64".
+//
+// "+" joins the modes rather than the "," llama.cpp's own flag uses,
+// because "," already separates the parameters inside a value. (The
+// field's own value separator is ";" for the same reason.) The parameter
+// keys are disjoint across the two slots, so one flat key=value list
+// still covers both.
 func parseSpecValue(raw string) (specValue, error) {
 	v := strings.TrimSpace(raw)
 	out := specValue{params: map[string]string{}}
 	if v == "none" {
-		return out, nil // mode "" = speculative decoding off
+		// The off entry, and never a mode name — the validation below
+		// must not see it. llama.cpp treats "none" inside a real list as
+		// poison, discarding every other mode, so it is never emitted
+		// as a list member either.
+		return out, nil
 	}
-	mode, rest, hasParams := strings.Cut(v, ":")
-	mode = strings.TrimSpace(mode)
-	// Validity is membership in one of the two mode lists, not "has
-	// settings": ngram-cache is a real mode that takes no settings.
-	if !models.IsDraftMode(mode) && !models.IsAssistMode(mode) {
-		return out, fmt.Errorf("%q is not a speculative decoding mode", mode)
+	modes, rest, hasParams := strings.Cut(v, ":")
+
+	segments := strings.Split(modes, "+")
+	if len(segments) > 2 {
+		return out, fmt.Errorf("%q names %d speculative modes; at most one draft method and one n-gram method can run together", modes, len(segments))
 	}
-	allowed := specModeParams(mode)
-	out.mode = mode
+	for _, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		switch {
+		case models.IsDraftMode(seg):
+			if out.mode != "" {
+				return out, fmt.Errorf("%q and %q are both draft methods; only one can run at a time", out.mode, seg)
+			}
+			out.mode = seg
+		case models.IsAssistMode(seg):
+			// Validity is membership in the mode lists, not "has
+			// settings": ngram-cache is a real mode that takes none.
+			if out.assist != "" {
+				return out, fmt.Errorf("%q and %q are both n-gram methods; only one can run at a time", out.assist, seg)
+			}
+			out.assist = seg
+		default:
+			return out, fmt.Errorf("%q is not a speculative decoding mode", seg)
+		}
+	}
+
 	if !hasParams {
 		return out, nil
 	}
+	// Keys are allowed only for a slot this value actually uses, so
+	// "draft-mtp:assist_n_max=64" is caught here rather than silently
+	// dropped when the value is applied.
+	allowed := append(models.SpecDraftParams(out.mode), models.SpecAssistParams(out.assist)...)
 	allowedKeys := map[string]bool{}
 	for _, p := range allowed {
 		allowedKeys[p.Key] = true
@@ -222,7 +276,7 @@ func parseSpecValue(raw string) (specValue, error) {
 			return out, fmt.Errorf("%q is not a key=value setting", pair)
 		}
 		if !allowedKeys[k] {
-			return out, fmt.Errorf("%q is not a setting of the %s mode", k, mode)
+			return out, fmt.Errorf("%q is not a setting of %s", k, strings.Join(nonEmpty(out.mode, out.assist), " + "))
 		}
 		if k == "draft_p_min" {
 			if _, err := strconv.ParseFloat(val, 64); err != nil {
@@ -247,16 +301,12 @@ func applySpecValue(o *ConfigOverrides, raw string) error {
 	if err != nil {
 		return err
 	}
-	// A value names one mode, which belongs to one slot; the other slot
-	// is explicitly cleared rather than left to inherit, so a cell that
-	// selects a mode runs that mode and nothing else.
-	var draft, assist string
-	if models.IsDraftMode(sv.mode) {
-		draft = sv.mode
-	} else {
-		assist = sv.mode
-	}
-	o.SpecType, o.SpecAssist = &draft, &assist
+	// Both slots are written, including when one is empty: an empty slot
+	// in a swept value means "off for this cell", not "inherit the
+	// model's saved mode". Parameters the value doesn't mention are left
+	// nil, which does inherit — the same rule as every other parameter.
+	mode, assist := sv.mode, sv.assist
+	o.SpecType, o.SpecAssist = &mode, &assist
 	for k, val := range sv.params {
 		switch k {
 		case "draft_max":
@@ -291,20 +341,32 @@ func applySpecValue(o *ConfigOverrides, raw string) error {
 	return nil
 }
 
-// encodeSpecValue renders a mode with its parameters' current values in
-// the encoded form the parser accepts, skipping empty values (empty =
-// inherit the model's saved setting). Bare mode when nothing is set.
-func encodeSpecValue(mode string, params []models.SpecModeParam) string {
+// encodeSpecValue renders one or both slots with their parameters'
+// current values in the encoded form the parser accepts, skipping empty
+// values (empty = inherit the model's saved setting). Bare mode names
+// when nothing is set.
+func encodeSpecValue(mode, assist string, params []models.SpecModeParam) string {
+	var names []string
+	if mode != "" {
+		names = append(names, mode)
+	}
+	if assist != "" {
+		names = append(names, assist)
+	}
+	if len(names) == 0 {
+		return "none"
+	}
 	var pairs []string
 	for _, p := range params {
 		if p.Default != "" {
 			pairs = append(pairs, p.Key+"="+p.Default)
 		}
 	}
+	out := strings.Join(names, "+")
 	if len(pairs) == 0 {
-		return mode
+		return out
 	}
-	return mode + ":" + strings.Join(pairs, ",")
+	return out + ":" + strings.Join(pairs, ",")
 }
 
 // canonicalSpecValue renders a spec value in its parsed, sorted form so
@@ -316,11 +378,22 @@ func canonicalSpecValue(raw string) string {
 	if err != nil {
 		return strings.TrimSpace(raw)
 	}
-	if sv.mode == "" {
+	if sv.mode == "" && sv.assist == "" {
 		return "none"
 	}
+	var names []string
+	if sv.mode != "" {
+		names = append(names, sv.mode)
+	}
+	if sv.assist != "" {
+		names = append(names, sv.assist)
+	}
+	// The draft method always sorts first, so "ngram-mod+draft-mtp" and
+	// "draft-mtp+ngram-mod" dedup to one cell — the modes are a set, not
+	// an order: common_speculative_init walks a fixed priority regardless.
+	out := strings.Join(names, "+")
 	if len(sv.params) == 0 {
-		return sv.mode
+		return out
 	}
 	keys := make([]string, 0, len(sv.params))
 	for k := range sv.params {
@@ -331,7 +404,7 @@ func canonicalSpecValue(raw string) string {
 	for i, k := range keys {
 		pairs[i] = k + "=" + sv.params[k]
 	}
-	return sv.mode + ":" + strings.Join(pairs, ",")
+	return out + ":" + strings.Join(pairs, ",")
 }
 
 func floatField(name, label, help, example string, apply func(*ConfigOverrides, *float64)) SweepField {
@@ -684,13 +757,17 @@ func init() {
 	))
 	// "none" (not an empty value, which would be dropped as unset) is the
 	// explicit off entry; the field's set function maps it to "".
-	set("spec_type", false, choices(
-		"none", "Off (no speculative decoding)",
-		"draft", "Draft Model", "draft-mtp", "MTP (self-speculation)",
-		"ngram-simple", "N-gram Simple", "ngram-cache", "N-gram Cache",
-		"ngram-map-k", "N-gram Map-K", "ngram-map-k4v", "N-gram Map-K4V",
-		"ngram-mod", "N-gram Mod",
-	))
+	// Eleven entries: five draft methods, five n-gram methods, and off.
+	// Built from the shared mode tables so the labels cannot drift from
+	// the model config form's two pickers.
+	specChoicePairs := []string{"none", "Off (no speculative decoding)"}
+	for _, m := range models.DraftModes() {
+		specChoicePairs = append(specChoicePairs, m.Name, m.Label)
+	}
+	for _, m := range models.AssistModes() {
+		specChoicePairs = append(specChoicePairs, m.Name, m.Label)
+	}
+	set("spec_type", false, choices(specChoicePairs...))
 	set("temperature", true, choices("0", "0 (greedy)", "0.7", "0.7", "1.0", "1.0"))
 	set("top_p", true, choices("0.9", "0.9", "0.95", "0.95", "1.0", "1.0 (off)"))
 	set("top_k", true, choices("20", "20", "40", "40", "0", "0 (disabled)"))
@@ -716,13 +793,33 @@ func init() {
 	// selecting a mode in a job then behaves exactly like selecting it
 	// on the model config form, and what the inputs show is what
 	// submits. Editing an input re-encodes the value in the browser.
+	// A draft choice additionally carries the n-gram assist dropdown and
+	// every assist mode's settings, rendered hidden and revealed by that
+	// dropdown, so a combination is built without leaving the checkbox.
+	assistParamsByMode := map[string][]models.SpecModeParam{}
+	for _, m := range models.AssistModes() {
+		assistParamsByMode[m.Name] = models.SpecAssistParams(m.Name)
+	}
+
 	st := sweepFields["spec_type"]
 	for i := range st.Choices {
 		mode := st.Choices[i].Value
-		st.Choices[i].Params = specModeParams(mode)
-		if len(st.Choices[i].Params) > 0 {
-			st.Choices[i].Mode = mode
-			st.Choices[i].Value = encodeSpecValue(mode, st.Choices[i].Params)
+		switch {
+		case models.IsDraftMode(mode):
+			st.Choices[i].Slot = "draft"
+			st.Choices[i].Params = models.SpecDraftParams(mode)
+			st.Choices[i].AssistModes = models.AssistModes()
+			st.Choices[i].AssistParamsByMode = assistParamsByMode
+		case models.IsAssistMode(mode):
+			st.Choices[i].Slot = "assist"
+			st.Choices[i].Params = models.SpecAssistParams(mode)
+		default:
+			continue // the "none" entry
+		}
+		st.Choices[i].Mode = mode
+		st.Choices[i].Value = encodeSpecValue(mode, "", st.Choices[i].Params)
+		if st.Choices[i].Slot == "assist" {
+			st.Choices[i].Value = encodeSpecValue("", mode, st.Choices[i].Params)
 		}
 	}
 	sweepFields["spec_type"] = st

--- a/internal/benchmark/sweep.go
+++ b/internal/benchmark/sweep.go
@@ -169,6 +169,16 @@ func boolField(name, label, help string, apply func(*ConfigOverrides, *bool)) Sw
 	}
 }
 
+// specModeParams returns whichever slot's parameter table the mode
+// belongs to. A sweep value still names a single mode; the draft and
+// assist key namespaces are disjoint, so one lookup is unambiguous.
+func specModeParams(mode string) []models.SpecModeParam {
+	if models.IsDraftMode(mode) {
+		return models.SpecDraftParams(mode)
+	}
+	return models.SpecAssistParams(mode)
+}
+
 // specValue is a parsed spec_type sweep value: a mode plus any
 // parameter settings from the mode's expandable section.
 type specValue struct {
@@ -187,10 +197,12 @@ func parseSpecValue(raw string) (specValue, error) {
 	}
 	mode, rest, hasParams := strings.Cut(v, ":")
 	mode = strings.TrimSpace(mode)
-	allowed := models.SpecModeParams(mode)
-	if len(allowed) == 0 {
+	// Validity is membership in one of the two mode lists, not "has
+	// settings": ngram-cache is a real mode that takes no settings.
+	if !models.IsDraftMode(mode) && !models.IsAssistMode(mode) {
 		return out, fmt.Errorf("%q is not a speculative decoding mode", mode)
 	}
+	allowed := specModeParams(mode)
 	out.mode = mode
 	if !hasParams {
 		return out, nil
@@ -235,8 +247,16 @@ func applySpecValue(o *ConfigOverrides, raw string) error {
 	if err != nil {
 		return err
 	}
-	mode := sv.mode
-	o.SpecType = &mode
+	// A value names one mode, which belongs to one slot; the other slot
+	// is explicitly cleared rather than left to inherit, so a cell that
+	// selects a mode runs that mode and nothing else.
+	var draft, assist string
+	if models.IsDraftMode(sv.mode) {
+		draft = sv.mode
+	} else {
+		assist = sv.mode
+	}
+	o.SpecType, o.SpecAssist = &draft, &assist
 	for k, val := range sv.params {
 		switch k {
 		case "draft_max":
@@ -248,12 +268,24 @@ func applySpecValue(o *ConfigOverrides, raw string) error {
 		case "draft_p_min":
 			v := val
 			o.DraftPMin = &v
-		case "ngram_size_n":
+		case "assist_n_max":
 			n, _ := strconv.Atoi(val)
-			o.NgramSizeN = &n
-		case "ngram_size_m":
+			o.AssistNMax = &n
+		case "assist_n_min":
 			n, _ := strconv.Atoi(val)
-			o.NgramSizeM = &n
+			o.AssistNMin = &n
+		case "assist_n_match":
+			n, _ := strconv.Atoi(val)
+			o.AssistNMatch = &n
+		case "assist_size_n":
+			n, _ := strconv.Atoi(val)
+			o.AssistSizeN = &n
+		case "assist_size_m":
+			n, _ := strconv.Atoi(val)
+			o.AssistSizeM = &n
+		case "assist_min_hits":
+			n, _ := strconv.Atoi(val)
+			o.AssistMinHits = &n
 		}
 	}
 	return nil
@@ -687,7 +719,7 @@ func init() {
 	st := sweepFields["spec_type"]
 	for i := range st.Choices {
 		mode := st.Choices[i].Value
-		st.Choices[i].Params = models.SpecModeParams(mode)
+		st.Choices[i].Params = specModeParams(mode)
 		if len(st.Choices[i].Params) > 0 {
 			st.Choices[i].Mode = mode
 			st.Choices[i].Value = encodeSpecValue(mode, st.Choices[i].Params)
@@ -782,9 +814,15 @@ func MergeOverrides(base, derived *ConfigOverrides) *ConfigOverrides {
 
 // specParamTags are ConfigOverrides fields expressible through
 // spec_type's encoded values rather than registry entries of their own.
+// Both slots are in here: applySpecValue writes spec_assist and the
+// assist parameters from the same encoded value it writes spec_type from,
+// so params own all of them.
 var specParamTags = map[string]bool{
 	"draft_max": true, "draft_min": true, "draft_p_min": true,
-	"ngram_size_n": true, "ngram_size_m": true,
+	"spec_assist": true, "assist_n_max": true, "assist_n_min": true,
+	"assist_n_match": true, "assist_size_n": true, "assist_size_m": true,
+	"assist_min_hits": true,
+	"ngram_size_n":    true, "ngram_size_m": true,
 }
 
 // IsSweepable reports whether a parameter has a form control, i.e.

--- a/internal/benchmark/sweep_test.go
+++ b/internal/benchmark/sweep_test.go
@@ -2,7 +2,10 @@ package benchmark
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/tmac1973/llama-toolchest/internal/models"
 )
 
 func TestSweepCombinationsCartesianProduct(t *testing.T) {
@@ -244,5 +247,177 @@ func TestCellIdentityUnsweptCellsMatch(t *testing.T) {
 	b := JobCell{ModelID: "m", BuildID: "b", Preset: "p"}
 	if identify(a) != identify(b) {
 		t.Error("identical unswept cells must share an identity")
+	}
+}
+
+func TestSpecValueRoundTripsBothSlots(t *testing.T) {
+	cases := []struct {
+		raw          string
+		mode, assist string
+		params       map[string]string
+	}{
+		{"none", "", "", map[string]string{}},
+		{"draft-mtp", "draft-mtp", "", map[string]string{}},
+		{"draft-mtp:draft_max=3", "draft-mtp", "", map[string]string{"draft_max": "3"}},
+		{"ngram-mod:assist_n_max=64", "", "ngram-mod", map[string]string{"assist_n_max": "64"}},
+		{"draft-mtp+ngram-mod", "draft-mtp", "ngram-mod", map[string]string{}},
+		{
+			"draft-mtp+ngram-mod:draft_max=3,assist_n_max=64,assist_n_match=24",
+			"draft-mtp", "ngram-mod",
+			map[string]string{"draft_max": "3", "assist_n_max": "64", "assist_n_match": "24"},
+		},
+		{
+			"draft+ngram-simple:draft_p_min=0.75,assist_size_n=12,assist_min_hits=1",
+			"draft", "ngram-simple",
+			map[string]string{"draft_p_min": "0.75", "assist_size_n": "12", "assist_min_hits": "1"},
+		},
+		// ngram-cache takes no settings but is still a real mode.
+		{"draft-eagle3+ngram-cache", "draft-eagle3", "ngram-cache", map[string]string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			sv, err := parseSpecValue(tc.raw)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.raw, err)
+			}
+			if sv.mode != tc.mode || sv.assist != tc.assist {
+				t.Errorf("slots = %q/%q, want %q/%q", sv.mode, sv.assist, tc.mode, tc.assist)
+			}
+			if !reflect.DeepEqual(sv.params, tc.params) {
+				t.Errorf("params = %v, want %v", sv.params, tc.params)
+			}
+			// Canonicalising is idempotent, so dedup is stable.
+			c1 := canonicalSpecValue(tc.raw)
+			if c2 := canonicalSpecValue(c1); c1 != c2 {
+				t.Errorf("canonical not idempotent: %q then %q", c1, c2)
+			}
+		})
+	}
+}
+
+func TestCanonicalSpecValueDedupsOrderAndSpacing(t *testing.T) {
+	// The modes are a set, not an order: common_speculative_init builds a
+	// bitmask and walks a fixed priority, so these are the same cell.
+	a := canonicalSpecValue("draft-mtp+ngram-mod:assist_n_max=64,draft_max=3")
+	b := canonicalSpecValue(" ngram-mod + draft-mtp : draft_max=3 , assist_n_max=64 ")
+	if a != b {
+		t.Errorf("values differing only in order/spacing did not dedup:\n%q\n%q", a, b)
+	}
+	if !strings.HasPrefix(a, "draft-mtp+ngram-mod:") {
+		t.Errorf("canonical form should put the draft method first, got %q", a)
+	}
+}
+
+func TestParseSpecValueRejections(t *testing.T) {
+	cases := []struct{ raw, wantSubstr string }{
+		{"draft+draft-mtp", "both draft methods"},
+		{"ngram-mod+ngram-simple", "both n-gram methods"},
+		{"draft-mtp+ngram-mod+ngram-simple", "at most one draft method"},
+		{"draft-mtp:assist_n_max=64", "is not a setting"},
+		{"ngram-mod:draft_p_min=0.5", "is not a setting"},
+		{"draft-mtp:draft_max=abc", "is not an integer"},
+		{"draft:draft_p_min=nope", "is not a number"},
+		{"nonsense", "is not a speculative decoding mode"},
+		// "none" is a real llama.cpp value that poisons a list; it is only
+		// ever the standalone off entry, never a list member.
+		{"none+ngram-mod", "is not a speculative decoding mode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			_, err := parseSpecValue(tc.raw)
+			if err == nil {
+				t.Fatalf("parse %q: want an error", tc.raw)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("error = %q, want it to mention %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestApplySpecValueWritesBothSlots(t *testing.T) {
+	var o ConfigOverrides
+	if err := applySpecValue(&o, "draft-mtp+ngram-mod:draft_max=3,assist_n_max=64"); err != nil {
+		t.Fatal(err)
+	}
+	if o.SpecType == nil || *o.SpecType != "draft-mtp" {
+		t.Errorf("SpecType = %v, want draft-mtp", o.SpecType)
+	}
+	if o.SpecAssist == nil || *o.SpecAssist != "ngram-mod" {
+		t.Errorf("SpecAssist = %v, want ngram-mod", o.SpecAssist)
+	}
+	if o.DraftMax == nil || *o.DraftMax != 3 || o.AssistNMax == nil || *o.AssistNMax != 64 {
+		t.Errorf("parameters not applied: %+v", o)
+	}
+
+	// A value naming one mode must clear the other slot, not inherit it:
+	// "MTP alone" has to actually mean alone, even on a model whose saved
+	// config has an assist.
+	var solo ConfigOverrides
+	if err := applySpecValue(&solo, "draft-mtp:draft_max=3"); err != nil {
+		t.Fatal(err)
+	}
+	if solo.SpecAssist == nil || *solo.SpecAssist != "" {
+		t.Errorf("SpecAssist = %v, want an explicit empty string", solo.SpecAssist)
+	}
+
+	var off ConfigOverrides
+	if err := applySpecValue(&off, "none"); err != nil {
+		t.Fatal(err)
+	}
+	if off.SpecType == nil || *off.SpecType != "" || off.SpecAssist == nil || *off.SpecAssist != "" {
+		t.Errorf("none should clear both slots, got %+v", off)
+	}
+}
+
+func TestSpecChoicesCoverEveryMode(t *testing.T) {
+	got := map[string]string{}
+	for _, c := range sweepFields["spec_type"].Choices {
+		got[c.Mode] = c.Slot
+	}
+	// Eleven entries: five draft, five n-gram, and off (which has no mode).
+	if n := len(sweepFields["spec_type"].Choices); n != 11 {
+		t.Errorf("want 11 spec_type choices, got %d", n)
+	}
+	for _, m := range models.DraftModes() {
+		if got[m.Name] != "draft" {
+			t.Errorf("%s slot = %q, want draft", m.Name, got[m.Name])
+		}
+	}
+	for _, m := range models.AssistModes() {
+		if got[m.Name] != "assist" {
+			t.Errorf("%s slot = %q, want assist", m.Name, got[m.Name])
+		}
+	}
+	// Only a draft choice carries the assist dropdown, which is what makes
+	// two draft methods unreachable from the form.
+	for _, c := range sweepFields["spec_type"].Choices {
+		if (len(c.AssistModes) > 0) != (c.Slot == "draft") {
+			t.Errorf("%q: AssistModes present = %v, slot = %q", c.Value, len(c.AssistModes) > 0, c.Slot)
+		}
+	}
+	// Every encoded choice value must parse.
+	for _, c := range sweepFields["spec_type"].Choices {
+		if _, err := parseSpecValue(c.Value); err != nil {
+			t.Errorf("choice %q does not parse: %v", c.Value, err)
+		}
+	}
+}
+
+// spec_type's value separator is ";" — it already had to be, because an
+// encoded value's parameters are comma-separated. "+" appears only inside
+// a single value, so the form's live cell-count estimate, which splits on
+// the separator, keeps counting correctly.
+func TestSpecTypeSeparatorUnchanged(t *testing.T) {
+	if sep := sweepFields["spec_type"].Separator; sep != ";" {
+		t.Errorf("spec_type separator = %q, want %q", sep, ";")
+	}
+	// A combined value must survive a split on the separator intact.
+	raw := "draft-mtp+ngram-mod:draft_max=3,assist_n_max=64"
+	if parts := strings.Split(raw, ";"); len(parts) != 1 {
+		t.Errorf("combined value split into %d parts on the separator", len(parts))
+	}
+	if _, err := parseSpecValue(raw); err != nil {
+		t.Errorf("combined value does not parse: %v", err)
 	}
 }

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -174,9 +174,11 @@ type SnapshotSubset struct {
 //     SplitMode / MainGPU); they reach the command line only as the
 //     resolved PlacementFlags.
 //   - SpecType, DraftModelPath, DraftMax, DraftMin, DraftPMin,
-//     NgramSizeN, NgramSizeM: speculative decoding — scoring is a fixed
-//     greedy next-token pass over a fixed corpus, there is nothing for
-//     a drafter to accelerate.
+//     SpecAssist, AssistNMax, AssistNMin, AssistNMatch, AssistSizeN,
+//     AssistSizeM, AssistMinHits, NgramSizeN, NgramSizeM: speculative
+//     decoding, in both the draft-method and n-gram assist slots —
+//     scoring is a fixed greedy next-token pass over a fixed corpus,
+//     there is nothing for a drafter to accelerate.
 //   - PLEMode, ExtraFlags: load-time settings. --tensor-read-lazy
 //     governs host residency during load and ExtraFlags is arbitrary
 //     user text; neither changes a deterministic greedy scoring pass,

--- a/internal/models/gguf_mtp_test.go
+++ b/internal/models/gguf_mtp_test.go
@@ -175,10 +175,49 @@ func TestFindDraftCandidatesSkipsMTPHead(t *testing.T) {
 	}
 
 	var got []string
-	for _, c := range r.FindDraftCandidates("target") {
+	for _, c := range r.FindDraftCandidates("target", "draft") {
 		got = append(got, c.ID)
 	}
 	if len(got) != 1 || got[0] != "real-draft" {
 		t.Errorf("FindDraftCandidates = %v, want [real-draft] only", got)
+	}
+}
+
+// A converted EAGLE-3 / DFlash / DSpark head is a trained extra layer in
+// its own GGUF, so it matches neither the architecture filter nor the
+// size bar that make the draft-model picker safe. Applying them would
+// leave the picker empty for exactly the modes that need it.
+func TestFindDraftCandidatesRelaxedForHeadBasedModes(t *testing.T) {
+	r := &Registry{
+		dataDir:   t.TempDir(),
+		modelsDir: t.TempDir(),
+		data: registryData{
+			Models: map[string]*Model{
+				"target": {ID: "target", Arch: "qwen4exp", SizeBytes: 100 << 30},
+				// Wrong architecture and far too large for the 40% bar.
+				"eagle-head": {ID: "eagle-head", Arch: "eagle3", SizeBytes: 90 << 30},
+				// Excluded whatever the mode: it cannot load as a drafter.
+				"mtp-head": {ID: "mtp-head", Arch: "qwen4exp", SizeBytes: 3 << 30, MTPHead: true},
+			},
+			Configs: map[string]*ModelConfig{},
+		},
+	}
+
+	ids := func(mode string) []string {
+		var got []string
+		for _, c := range r.FindDraftCandidates("target", mode) {
+			got = append(got, c.ID)
+		}
+		return got
+	}
+
+	if got := ids("draft"); len(got) != 0 {
+		t.Errorf("draft mode should still filter by arch and size, got %v", got)
+	}
+	for _, mode := range []string{"draft-eagle3", "draft-dflash", "draft-dspark"} {
+		got := ids(mode)
+		if len(got) != 1 || got[0] != "eagle-head" {
+			t.Errorf("%s candidates = %v, want [eagle-head] only", mode, got)
+		}
 	}
 }

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -1305,14 +1305,29 @@ type DraftCandidate struct {
 	Arch     string
 }
 
-// FindDraftCandidates returns models that could serve as draft models for
-// the given model: same architecture family, significantly smaller.
-func (r *Registry) FindDraftCandidates(id string) []DraftCandidate {
+// FindDraftCandidates returns models that could serve as the drafter for
+// the given model under the given speculative mode: same architecture
+// family and significantly smaller, which is what makes a draft model
+// usable at all.
+//
+// The head-based methods (draft-eagle3, draft-dflash, draft-dspark) skip
+// both of those checks. Their drafter is not a smaller model of the same
+// family, it is a trained extra layer converted to its own GGUF, so it
+// matches neither filter — applying them would leave the picker empty for
+// exactly the modes that need it.
+func (r *Registry) FindDraftCandidates(id, mode string) []DraftCandidate {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	headBased := IsHeadBasedDraftMode(mode)
+
 	target, ok := r.data.Models[id]
-	if !ok || target.Arch == "" {
+	if !ok {
+		return nil
+	}
+	// A target with no recorded architecture can still take a converted
+	// head; it just cannot be matched against a draft model.
+	if target.Arch == "" && !headBased {
 		return nil
 	}
 
@@ -1321,13 +1336,15 @@ func (r *Registry) FindDraftCandidates(id string) []DraftCandidate {
 		if m.ID == id {
 			continue
 		}
-		// Same architecture family
-		if m.Arch != target.Arch {
-			continue
-		}
-		// Must be significantly smaller (< 40% of target size)
-		if m.SizeBytes >= target.SizeBytes*4/10 {
-			continue
+		if !headBased {
+			// Same architecture family
+			if m.Arch != target.Arch {
+				continue
+			}
+			// Must be significantly smaller (< 40% of target size)
+			if m.SizeBytes >= target.SizeBytes*4/10 {
+				continue
+			}
 		}
 		// Skip embedding models
 		if m.IsEmbedding() {

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -175,14 +175,31 @@ type ModelConfig struct {
 	MtpPath        string `json:"mtp_path,omitempty"`        // path to a separate MTP drafter-head GGUF (gemma-4 style); loaded via --model-draft under spec_type=draft-mtp. Empty for self-speculation MTP (Qwen3.6/DeepSeek-V3) where the head is baked into the main GGUF.
 	MtpDisabled    bool   `json:"mtp_disabled,omitempty"`    // skip the separate --model-draft MTP head at launch even when MtpPath is set; preserves the path so it can be re-enabled
 
-	// Speculative decoding
-	SpecType       string `json:"spec_type,omitempty"`        // "", "draft", "draft-mtp", "ngram-simple", "ngram-cache", etc.
-	DraftModelPath string `json:"draft_model_path,omitempty"` // path to draft model (when spec_type="draft")
+	// Speculative decoding, draft-method slot. See specmodes.go for why
+	// there are two slots and specDecodingParams for what each emits.
+	SpecType       string `json:"spec_type,omitempty"`        // "", "draft", "draft-mtp", "draft-eagle3", "draft-dflash", "draft-dspark" — draft methods only; the draftless mode lives in SpecAssist
+	DraftModelPath string `json:"draft_model_path,omitempty"` // path to the draft model or converted head (every draft method except self-speculation draft-mtp, which uses MtpPath)
 	DraftMax       int    `json:"draft_max,omitempty"`        // max draft tokens per step
 	DraftMin       int    `json:"draft_min,omitempty"`        // min draft tokens per step
 	DraftPMin      string `json:"draft_p_min,omitempty"`      // min probability threshold (string to allow empty=default)
-	NgramSizeN     int    `json:"ngram_size_n,omitempty"`     // n-gram lookup length
-	NgramSizeM     int    `json:"ngram_size_m,omitempty"`     // n-gram draft length
+
+	// Speculative decoding, draftless n-gram assist slot. Runs alongside
+	// the draft method above: llama.cpp accepts a comma-separated
+	// --spec-type list mixing one draft method with one draftless one,
+	// and the two do not share a draft length.
+	SpecAssist    string `json:"spec_assist,omitempty"`     // "", "ngram-mod", "ngram-simple", "ngram-cache", "ngram-map-k", "ngram-map-k4v"
+	AssistNMax    int    `json:"assist_n_max,omitempty"`    // --spec-ngram-mod-n-max
+	AssistNMin    int    `json:"assist_n_min,omitempty"`    // --spec-ngram-mod-n-min
+	AssistNMatch  int    `json:"assist_n_match,omitempty"`  // --spec-ngram-mod-n-match
+	AssistSizeN   int    `json:"assist_size_n,omitempty"`   // --spec-<mode>-size-n
+	AssistSizeM   int    `json:"assist_size_m,omitempty"`   // --spec-<mode>-size-m
+	AssistMinHits int    `json:"assist_min_hits,omitempty"` // --spec-<mode>-min-hits
+
+	// Legacy: the config form still posts these until the two-picker
+	// rework lands, and NormalizeSpec migrates them into the Assist*
+	// fields above. Nothing else reads them.
+	NgramSizeN int `json:"ngram_size_n,omitempty"`
+	NgramSizeM int `json:"ngram_size_m,omitempty"`
 
 	// Draft model resource overrides. Apply to spec_type="draft" and to
 	// gemma-4-style draft-mtp (separate head loaded via --model-draft). Not
@@ -1230,6 +1247,34 @@ func findMTPInDir(dir string) string {
 // AutoDetectMTP scans all registered models and sets MtpPath on configs where a
 // separate MTP drafter head exists in or near the model directory but isn't
 // configured yet.
+// BackfillSpecAssist migrates configs written before speculative decoding
+// had two slots, where a draftless mode sat in SpecType and its settings
+// in the draft-length fields. Runs once at startup; NormalizeSpec is
+// idempotent, so a second run finds nothing and saves nothing.
+//
+// Read paths tolerate the old shape anyway (specDecodingParams and the
+// benchmark override merge both normalise), which is what keeps stored
+// benchmark history working without being rewritten. This exists so the
+// registry on disk converges on one shape rather than staying mixed
+// indefinitely.
+func (r *Registry) BackfillSpecAssist() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	migrated := 0
+	for _, cfg := range r.data.Configs {
+		if cfg == nil || !IsAssistMode(cfg.SpecType) {
+			continue
+		}
+		NormalizeSpec(cfg)
+		migrated++
+	}
+	if migrated > 0 {
+		r.save()
+	}
+	return migrated
+}
+
 func (r *Registry) AutoDetectMTP() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/models/spec_smoke_test.go
+++ b/internal/models/spec_smoke_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -137,5 +138,238 @@ func TestSpecMTPPresetINI(t *testing.T) {
 	}
 	if strings.Contains(out, "model-draft") {
 		t.Errorf("MTP preset should not emit model-draft, got:\n%s", out)
+	}
+}
+
+func TestSpecCombinedFlags(t *testing.T) {
+	// The configuration the whole two-slot design exists for: MTP drafting
+	// 3 tokens while ngram-mod drafts up to 64. Before the split this was
+	// not merely unsupported, it was inexpressible — DraftMax had to be
+	// either --spec-draft-n-max or --spec-ngram-mod-n-max, not both.
+	cfg := &ModelConfig{
+		GPULayers:    99,
+		ContextSize:  8192,
+		Threads:      8,
+		SpecType:     "draft-mtp",
+		DraftMax:     3,
+		SpecAssist:   "ngram-mod",
+		AssistNMax:   64,
+		AssistNMin:   48,
+		AssistNMatch: 24,
+	}
+	got := cfg.EffectiveFlags()
+	for _, want := range []string{
+		"--spec-type draft-mtp,ngram-mod",
+		"--spec-draft-n-max 3",
+		"--spec-ngram-mod-n-max 64",
+		"--spec-ngram-mod-n-min 48",
+		"--spec-ngram-mod-n-match 24",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("combined flags missing %q in: %s", want, got)
+		}
+	}
+	// "none" anywhere in the list makes llama.cpp discard every other mode.
+	if strings.Contains(got, "none") {
+		t.Errorf("combined flags must never contain %q, got: %s", "none", got)
+	}
+	if n := strings.Count(got, "--spec-type"); n != 1 {
+		t.Errorf("want exactly one --spec-type, got %d in: %s", n, got)
+	}
+}
+
+func TestSpecCombinedPresetINISingleSpecTypeLine(t *testing.T) {
+	// common/preset.cpp parses an INI section into a map, so a repeated
+	// "spec-type =" line silently keeps only the last value. The modes
+	// must arrive comma-joined on one line.
+	cfg := &ModelConfig{
+		Enabled:     true,
+		GPULayers:   99,
+		ContextSize: 8192,
+		Threads:     8,
+		SpecType:    "draft-mtp",
+		DraftMax:    3,
+		SpecAssist:  "ngram-mod",
+		AssistNMax:  64,
+	}
+	var b strings.Builder
+	writeConfigParams(&b, cfg, false, "")
+
+	var specLines []string
+	for _, line := range strings.Split(b.String(), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "spec-type") {
+			specLines = append(specLines, strings.TrimSpace(line))
+		}
+	}
+	if len(specLines) != 1 {
+		t.Fatalf("want exactly one spec-type line, got %d: %v", len(specLines), specLines)
+	}
+	if want := "spec-type = draft-mtp,ngram-mod"; specLines[0] != want {
+		t.Errorf("spec-type line = %q, want %q", specLines[0], want)
+	}
+}
+
+func TestSpecNgramModMatchEmitted(t *testing.T) {
+	// The form stored this value and specDecodingParams never emitted it,
+	// so tuning it did nothing.
+	cfg := &ModelConfig{
+		GPULayers:    99,
+		ContextSize:  8192,
+		Threads:      8,
+		SpecAssist:   "ngram-mod",
+		AssistNMatch: 32,
+	}
+	if got := cfg.EffectiveFlags(); !strings.Contains(got, "--spec-ngram-mod-n-match 32") {
+		t.Errorf("ngram-mod match length not emitted in: %s", got)
+	}
+}
+
+func TestSpecMinHitsEmitted(t *testing.T) {
+	// Offered as a default in no table and emitted by no branch before the
+	// assist slot existed.
+	for _, mode := range []string{"ngram-simple", "ngram-map-k", "ngram-map-k4v"} {
+		cfg := &ModelConfig{
+			GPULayers:     99,
+			ContextSize:   8192,
+			Threads:       8,
+			SpecAssist:    mode,
+			AssistSizeN:   12,
+			AssistSizeM:   48,
+			AssistMinHits: 2,
+		}
+		got := cfg.EffectiveFlags()
+		for _, want := range []string{
+			"--spec-type " + mode,
+			"--spec-" + mode + "-size-n 12",
+			"--spec-" + mode + "-size-m 48",
+			"--spec-" + mode + "-min-hits 2",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("%s flags missing %q in: %s", mode, want, got)
+			}
+		}
+	}
+}
+
+func TestSpecNewDraftModes(t *testing.T) {
+	// Merged upstream, documented, in the build we ship, and reachable
+	// from nowhere in the toolchest until now.
+	for _, mode := range []string{"draft-eagle3", "draft-dflash", "draft-dspark"} {
+		cfg := &ModelConfig{
+			GPULayers:      99,
+			ContextSize:    8192,
+			Threads:        8,
+			SpecType:       mode,
+			DraftModelPath: "/models/head.gguf",
+		}
+		got := cfg.EffectiveFlags()
+		for _, want := range []string{
+			"--spec-type " + mode,
+			"--model-draft /models/head.gguf",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("%s flags missing %q in: %s", mode, want, got)
+			}
+		}
+		// Blank defaults: nothing is emitted unless the user sets it.
+		if strings.Contains(got, "--spec-draft-n-max") {
+			t.Errorf("%s should emit no draft length by default, got: %s", mode, got)
+		}
+	}
+}
+
+func TestSpecLegacyDraftlessConfig(t *testing.T) {
+	// The shape a registry written before the split holds. It must launch
+	// as it always did, with the one deliberate addition of the n-match
+	// flag the form was already storing.
+	legacy := &ModelConfig{
+		GPULayers:   99,
+		ContextSize: 8192,
+		Threads:     8,
+		SpecType:    "ngram-mod",
+		DraftMax:    64,
+		DraftMin:    48,
+		NgramSizeN:  24,
+		NgramSizeM:  48,
+	}
+	got := legacy.EffectiveFlags()
+	for _, want := range []string{
+		"--spec-type ngram-mod",
+		"--spec-ngram-mod-n-max 64",
+		"--spec-ngram-mod-n-min 48",
+		"--spec-ngram-mod-n-match 24",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("legacy ngram-mod flags missing %q in: %s", want, got)
+		}
+	}
+	// ngram-mod has no m-gram size; the form offered one and it meant
+	// nothing, so it must not reach the command line under any name.
+	if strings.Contains(got, "size-m") {
+		t.Errorf("ngram-mod must not emit an m-gram size, got: %s", got)
+	}
+	// Reading must not rewrite the caller's config.
+	if legacy.SpecType != "ngram-mod" || legacy.DraftMax != 64 {
+		t.Errorf("EffectiveFlags mutated the config: %+v", legacy)
+	}
+
+	// The migrated shape emits exactly the same thing.
+	migrated := *legacy
+	NormalizeSpec(&migrated)
+	if migrated.SpecType != "" || migrated.SpecAssist != "ngram-mod" {
+		t.Fatalf("NormalizeSpec left slots wrong: type=%q assist=%q", migrated.SpecType, migrated.SpecAssist)
+	}
+	if migrated.AssistNMax != 64 || migrated.AssistNMin != 48 || migrated.AssistNMatch != 24 {
+		t.Errorf("NormalizeSpec lost parameters: %+v", migrated)
+	}
+	if migrated.NgramSizeM != 0 || migrated.AssistSizeM != 0 {
+		t.Errorf("ngram-mod m-gram size should be dropped, got %+v", migrated)
+	}
+	if migrated.EffectiveFlags() != got {
+		t.Errorf("migrated config emits different flags:\n legacy:   %s\n migrated: %s", got, migrated.EffectiveFlags())
+	}
+
+	// Idempotent: the startup backfill runs on every boot.
+	twice := migrated
+	NormalizeSpec(&twice)
+	if !reflect.DeepEqual(twice, migrated) {
+		t.Errorf("NormalizeSpec is not idempotent: %+v vs %+v", twice, migrated)
+	}
+}
+
+func TestSpecLegacyDraftlessSizeModes(t *testing.T) {
+	// The size-n/size-m family migrates onto different fields than
+	// ngram-mod does, since "N-gram size N" meant lookup size there.
+	legacy := &ModelConfig{
+		GPULayers:   99,
+		ContextSize: 8192,
+		Threads:     8,
+		SpecType:    "ngram-simple",
+		NgramSizeN:  12,
+		NgramSizeM:  48,
+	}
+	got := legacy.EffectiveFlags()
+	for _, want := range []string{
+		"--spec-type ngram-simple",
+		"--spec-ngram-simple-size-n 12",
+		"--spec-ngram-simple-size-m 48",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("legacy ngram-simple flags missing %q in: %s", want, got)
+		}
+	}
+	// No legacy field feeds min-hits, so a migrated config emits none —
+	// llama.cpp's own default is the 1 the form now offers, so nothing
+	// changes for it.
+	if strings.Contains(got, "min-hits") {
+		t.Errorf("a migrated config should emit no min-hits, got: %s", got)
+	}
+}
+
+func TestSpecOffEmitsNothing(t *testing.T) {
+	cfg := &ModelConfig{GPULayers: 99, ContextSize: 8192, Threads: 8}
+	got := cfg.EffectiveFlags()
+	if strings.Contains(got, "--spec-type") {
+		t.Errorf("speculative decoding off should emit no --spec-type, got: %s", got)
 	}
 }

--- a/internal/models/spec_smoke_test.go
+++ b/internal/models/spec_smoke_test.go
@@ -373,3 +373,52 @@ func TestSpecOffEmitsNothing(t *testing.T) {
 		t.Errorf("speculative decoding off should emit no --spec-type, got: %s", got)
 	}
 }
+
+func TestValidateSpecRejectsWrongSlot(t *testing.T) {
+	// The two pickers cannot produce these, but a hand-edited registry or
+	// a crafted POST can, and llama-server treats an unknown --spec-type
+	// name as a fatal startup error.
+	cases := []struct {
+		name    string
+		cfg     ModelConfig
+		wantErr bool
+	}{
+		{"empty is fine", ModelConfig{}, false},
+		{"draft in draft slot", ModelConfig{SpecType: "draft-mtp"}, false},
+		{"assist in assist slot", ModelConfig{SpecAssist: "ngram-mod"}, false},
+		{"both slots filled", ModelConfig{SpecType: "draft-mtp", SpecAssist: "ngram-mod"}, false},
+		{"assist in draft slot", ModelConfig{SpecType: "ngram-mod"}, true},
+		{"draft in assist slot", ModelConfig{SpecAssist: "draft-mtp"}, true},
+		{"unknown draft name", ModelConfig{SpecType: "draft-mtp-adaptive"}, true},
+		{"unknown assist name", ModelConfig{SpecAssist: "ngram-whatever"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.ValidateSpec()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateSpec() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEffectiveSpecType(t *testing.T) {
+	cases := []struct {
+		cfg  ModelConfig
+		want string
+	}{
+		{ModelConfig{}, ""},
+		{ModelConfig{SpecType: "draft-mtp"}, "draft-mtp"},
+		{ModelConfig{SpecType: "draft"}, "draft-simple"},
+		{ModelConfig{SpecAssist: "ngram-mod"}, "ngram-mod"},
+		{ModelConfig{SpecType: "draft-mtp", SpecAssist: "ngram-mod"}, "draft-mtp,ngram-mod"},
+		// A config still in the pre-split shape reads the same as its
+		// migrated equivalent.
+		{ModelConfig{SpecType: "ngram-mod"}, "ngram-mod"},
+	}
+	for _, tc := range cases {
+		if got := tc.cfg.EffectiveSpecType(); got != tc.want {
+			t.Errorf("EffectiveSpecType(%+v) = %q, want %q", tc.cfg, got, tc.want)
+		}
+	}
+}

--- a/internal/models/specflags.go
+++ b/internal/models/specflags.go
@@ -1,6 +1,9 @@
 package models
 
-import "strconv"
+import (
+	"strconv"
+	"strings"
+)
 
 // specParam is a launch parameter name (without the "--" prefix) and its
 // value. Callers format params as CLI flags (EffectiveFlagsFor) or INI
@@ -50,58 +53,106 @@ func appendDraftSamplingParams(params []specParam, c *ModelConfig) []specParam {
 	return params
 }
 
-// specDecodingParams returns the speculative-decoding launch parameters for
-// the config. llama.cpp split the legacy mode-agnostic flags (--draft-max,
-// --draft-min, --spec-ngram-size-n/m) into mode-specific flags; emit the
-// right name based on SpecType.
-func specDecodingParams(c *ModelConfig) []specParam {
-	var params []specParam
-	switch c.SpecType {
-	case "draft":
-		// Internal value is still "draft" (legacy config compat) but
-		// llama.cpp renamed the spec-type enum value to "draft-simple"
-		// alongside the introduction of "draft-mtp" and "draft-eagle3".
-		// Without --spec-type, the draft model loads but isn't used —
-		// the default is "none".
-		params = append(params, specParam{"spec-type", "draft-simple"})
-		if c.DraftModelPath != "" {
-			params = append(params, specParam{"model-draft", c.DraftModelPath})
-		}
-		params = appendDraftSamplingParams(params, c)
-		params = appendDraftResourceParams(params, c)
-	case "draft-mtp":
-		// Two MTP flavors share this spec-type:
-		//   • Self-speculation (Qwen3.6, DeepSeek-V3): the MTP head is baked
-		//     into the main GGUF, so MtpPath is empty — no --model-draft and
-		//     the draft-resource flags don't apply. Only the sampling knobs do.
-		//   • Separate drafter (gemma-4's "gemma4-assistant" head): the head
-		//     ships as its own GGUF in MtpPath, loaded via --model-draft just
-		//     like a draft-simple model, including the draft-resource overrides.
-		params = append(params, specParam{"spec-type", "draft-mtp"})
+// draftTypeName maps a config's draft mode onto llama.cpp's own
+// --spec-type value. Only "draft" differs: llama.cpp renamed that enum
+// value to "draft-simple" alongside the introduction of "draft-mtp" and
+// "draft-eagle3", after configs had already been saved with the old one.
+func draftTypeName(mode string) string {
+	if mode == "draft" {
+		return "draft-simple"
+	}
+	return mode
+}
+
+// appendDraftParams appends the flags of the draft-method slot: the
+// drafter to load, its resource overrides, and its sampling knobs.
+func appendDraftParams(params []specParam, c *ModelConfig) []specParam {
+	// Where the drafter comes from depends on the mode:
+	//   • Self-speculation MTP (Qwen3.5/3.6, DeepSeek-V3): the head is
+	//     baked into the main GGUF, so MtpPath is empty — no
+	//     --model-draft, and the draft-resource flags don't apply.
+	//   • Separate MTP drafter (gemma-4's "gemma4-assistant" head): the
+	//     head ships as its own GGUF in MtpPath.
+	//   • Every other draft method: DraftModelPath, whether that is a
+	//     smaller model of the same family (draft) or a converted head
+	//     (draft-eagle3, draft-dflash, draft-dspark).
+	drafter := c.DraftModelPath
+	if c.SpecType == "draft-mtp" {
+		drafter = ""
 		if c.MtpPath != "" && !c.MtpDisabled {
-			params = append(params, specParam{"model-draft", c.MtpPath})
-			params = appendDraftResourceParams(params, c)
+			drafter = c.MtpPath
 		}
-		params = appendDraftSamplingParams(params, c)
+	}
+	if drafter != "" {
+		params = append(params, specParam{"model-draft", drafter})
+		params = appendDraftResourceParams(params, c)
+	}
+	return appendDraftSamplingParams(params, c)
+}
+
+// appendAssistParams appends the flags of the draftless n-gram slot.
+// The modes do not share a parameter set: ngram-mod is tuned by draft
+// lengths and a match length, the map/simple family by lookup and draft
+// sizes and a hit threshold, and ngram-cache takes nothing at all.
+func appendAssistParams(params []specParam, c *ModelConfig) []specParam {
+	switch c.SpecAssist {
 	case "ngram-mod":
-		params = append(params, specParam{"spec-type", c.SpecType})
-		if c.DraftMax > 0 {
-			params = append(params, specParam{"spec-ngram-mod-n-max", strconv.Itoa(c.DraftMax)})
+		if c.AssistNMax > 0 {
+			params = append(params, specParam{"spec-ngram-mod-n-max", strconv.Itoa(c.AssistNMax)})
 		}
-		if c.DraftMin > 0 {
-			params = append(params, specParam{"spec-ngram-mod-n-min", strconv.Itoa(c.DraftMin)})
+		if c.AssistNMin > 0 {
+			params = append(params, specParam{"spec-ngram-mod-n-min", strconv.Itoa(c.AssistNMin)})
+		}
+		if c.AssistNMatch > 0 {
+			params = append(params, specParam{"spec-ngram-mod-n-match", strconv.Itoa(c.AssistNMatch)})
 		}
 	case "ngram-simple", "ngram-map-k", "ngram-map-k4v":
-		params = append(params, specParam{"spec-type", c.SpecType})
-		prefix := "spec-" + c.SpecType
-		if c.NgramSizeN > 0 {
-			params = append(params, specParam{prefix + "-size-n", strconv.Itoa(c.NgramSizeN)})
+		prefix := "spec-" + c.SpecAssist
+		if c.AssistSizeN > 0 {
+			params = append(params, specParam{prefix + "-size-n", strconv.Itoa(c.AssistSizeN)})
 		}
-		if c.NgramSizeM > 0 {
-			params = append(params, specParam{prefix + "-size-m", strconv.Itoa(c.NgramSizeM)})
+		if c.AssistSizeM > 0 {
+			params = append(params, specParam{prefix + "-size-m", strconv.Itoa(c.AssistSizeM)})
 		}
-	case "ngram-cache":
-		params = append(params, specParam{"spec-type", c.SpecType})
+		if c.AssistMinHits > 0 {
+			params = append(params, specParam{prefix + "-min-hits", strconv.Itoa(c.AssistMinHits)})
+		}
 	}
 	return params
+}
+
+// specDecodingParams returns the speculative-decoding launch parameters for
+// the config: one --spec-type carrying the comma-separated list of active
+// modes, then each slot's own flags. llama.cpp split the legacy
+// mode-agnostic flags (--draft-max, --draft-min, --spec-ngram-size-n/m)
+// into per-mode ones, so the two slots' draft lengths coexist —
+// common_speculative_n_max takes the maximum over whatever is enabled.
+//
+// The list is written as one value rather than a repeated flag on
+// purpose: common/preset.cpp parses an INI section into a map, so a
+// second "spec-type =" line would silently replace the first.
+func specDecodingParams(c *ModelConfig) []specParam {
+	// Copied, not mutated in place: this runs on the registry's own
+	// struct, and normalising a config that still holds the pre-split
+	// shape must not write back to it.
+	cfg := *c
+	NormalizeSpec(&cfg)
+
+	var modes []string
+	var params []specParam
+	if IsDraftMode(cfg.SpecType) {
+		modes = append(modes, draftTypeName(cfg.SpecType))
+		params = appendDraftParams(params, &cfg)
+	}
+	if IsAssistMode(cfg.SpecAssist) {
+		modes = append(modes, cfg.SpecAssist)
+		params = appendAssistParams(params, &cfg)
+	}
+	if len(modes) == 0 {
+		// Nothing, not "none": common_speculative_types_from_names
+		// discards every other entry in a list the moment it sees
+		// "none", so an empty slot must contribute no name at all.
+		return nil
+	}
+	return append([]specParam{{"spec-type", strings.Join(modes, ",")}}, params...)
 }

--- a/internal/models/specmodes.go
+++ b/internal/models/specmodes.go
@@ -1,5 +1,7 @@
 package models
 
+import "fmt"
+
 // Speculative decoding has two independent slots. llama.cpp accepts a
 // comma-separated --spec-type list and its docs sanction exactly one
 // shape of combination:
@@ -152,4 +154,39 @@ func NormalizeSpec(c *ModelConfig) {
 	// DraftPMin is left alone: it is a draft-method knob, and a draftless
 	// config that carries one was never emitting it anyway.
 	c.DraftPMin = ""
+}
+
+// EffectiveSpecType returns the comma-separated --spec-type value this
+// config launches with, or "" when speculative decoding is off.
+//
+// The config form shows it verbatim so the list a user has built is
+// visible without reading the whole flag line, and so a launch failure
+// can be quoted straight off the form.
+func (c *ModelConfig) EffectiveSpecType() string {
+	for _, p := range specDecodingParams(c) {
+		if p.Name == "spec-type" {
+			return p.Value
+		}
+	}
+	return ""
+}
+
+// ValidateSpec rejects a mode name in the wrong slot. The two-picker form
+// cannot produce one, but a hand-edited registry or a crafted POST can,
+// and llama-server treats an unknown --spec-type name as a fatal startup
+// error whose message a user would not connect back to this form.
+func (c *ModelConfig) ValidateSpec() error {
+	if c.SpecType != "" && !IsDraftMode(c.SpecType) {
+		if IsAssistMode(c.SpecType) {
+			return fmt.Errorf("%q is an n-gram method — it belongs in the n-gram assist, not the draft method", c.SpecType)
+		}
+		return fmt.Errorf("%q is not a draft method", c.SpecType)
+	}
+	if c.SpecAssist != "" && !IsAssistMode(c.SpecAssist) {
+		if IsDraftMode(c.SpecAssist) {
+			return fmt.Errorf("%q is a draft method — it belongs in the draft method, not the n-gram assist", c.SpecAssist)
+		}
+		return fmt.Errorf("%q is not an n-gram method", c.SpecAssist)
+	}
+	return nil
 }

--- a/internal/models/specmodes.go
+++ b/internal/models/specmodes.go
@@ -1,0 +1,155 @@
+package models
+
+// Speculative decoding has two independent slots. llama.cpp accepts a
+// comma-separated --spec-type list and its docs sanction exactly one
+// shape of combination:
+//
+//	An implementation with draft model can be mixed with an
+//	implementation without draft model.
+//
+// So SpecType holds the draft method and SpecAssist the draftless one,
+// each with its own draft-length flags. Two draft methods in one list
+// crash llama-server at startup (upstream issue #27897), which the two
+// separate lists below make unreachable rather than something to
+// validate against.
+//
+// Ordering inside the list is not exposed because it does not exist:
+// common_speculative_init turns the names into a bitmask and walks a
+// fixed priority order, so "draft-mtp,ngram-mod" and "ngram-mod,draft-mtp"
+// behave identically.
+
+// SpecMode is one speculative decoding mode and the label every surface
+// shows for it. Sharing the labels is what stops the model config form,
+// the benchmark job form and the sweep choices from drifting apart.
+//
+// There is deliberately no entry for "no mode selected": it reads
+// differently in each place ("Disabled" in the draft picker, "None" in
+// the assist picker, "Off (no speculative decoding)" in the sweep
+// choices), so each surface writes its own.
+type SpecMode struct {
+	Name  string
+	Label string
+}
+
+// draftModes are the modes that speculate with a drafter — a smaller
+// model of the same family, or a trained head loaded through
+// --model-draft, or one baked into the main GGUF. At most one can run.
+//
+// "draft" is the internal name for llama.cpp's "draft-simple"; the
+// rename happened after configs were already saved with the old value,
+// so the config keeps it and specDecodingParams translates on the way
+// out.
+var draftModes = []SpecMode{
+	{"draft", "Draft Model"},
+	{"draft-mtp", "MTP (self-speculation)"},
+	{"draft-eagle3", "EAGLE-3"},
+	{"draft-dflash", "DFlash"},
+	{"draft-dspark", "DSpark"},
+}
+
+// assistModes are the draftless n-gram methods. They propose tokens by
+// matching text already in the prompt and the generation so far, so they
+// load no extra file and cost no extra memory.
+var assistModes = []SpecMode{
+	{"ngram-mod", "N-gram Mod"},
+	{"ngram-simple", "N-gram Simple"},
+	{"ngram-cache", "N-gram Cache"},
+	{"ngram-map-k", "N-gram Map-K"},
+	{"ngram-map-k4v", "N-gram Map-K4V"},
+}
+
+// headBasedDraftModes are the draft methods whose --model-draft target is
+// a converted head rather than a smaller model of the same family. It
+// matters for the draft-model picker: a head matches neither the
+// architecture nor the size filter that makes the picker safe for
+// "draft".
+var headBasedDraftModes = map[string]bool{
+	"draft-eagle3": true,
+	"draft-dflash": true,
+	"draft-dspark": true,
+}
+
+// DraftModes returns the draft methods in display order.
+func DraftModes() []SpecMode { return draftModes }
+
+// AssistModes returns the draftless n-gram methods in display order.
+func AssistModes() []SpecMode { return assistModes }
+
+// IsDraftMode reports whether name is a draft method, so belongs in
+// ModelConfig.SpecType.
+func IsDraftMode(name string) bool { return specModeIn(draftModes, name) }
+
+// IsAssistMode reports whether name is a draftless n-gram method, so
+// belongs in ModelConfig.SpecAssist.
+func IsAssistMode(name string) bool { return specModeIn(assistModes, name) }
+
+// IsHeadBasedDraftMode reports whether the mode loads a converted head
+// through --model-draft.
+func IsHeadBasedDraftMode(name string) bool { return headBasedDraftModes[name] }
+
+// SpecModeLabel returns the display label for a mode, or the raw name for
+// one this build doesn't know — a config written by a newer build should
+// render as something rather than as an empty cell.
+func SpecModeLabel(name string) string {
+	for _, m := range draftModes {
+		if m.Name == name {
+			return m.Label
+		}
+	}
+	for _, m := range assistModes {
+		if m.Name == name {
+			return m.Label
+		}
+	}
+	return name
+}
+
+func specModeIn(modes []SpecMode, name string) bool {
+	for _, m := range modes {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeSpec moves a draftless mode found in SpecType into SpecAssist,
+// carrying its parameters onto the assist fields.
+//
+// Before the two slots existed, SpecType held whichever single mode was
+// selected and DraftMax/DraftMin/NgramSizeN/NgramSizeM changed meaning
+// depending on which one it was. Saved model configs, stored benchmark
+// jobs and completed run records all still carry that shape, so every
+// read path runs this: the launch path (specDecodingParams), the
+// benchmark override merge, and the one-shot registry backfill.
+//
+// It is idempotent, and does nothing when SpecType is empty or already a
+// draft method.
+func NormalizeSpec(c *ModelConfig) {
+	if c == nil || !IsAssistMode(c.SpecType) {
+		return
+	}
+	mode := c.SpecType
+	c.SpecType = ""
+	c.SpecAssist = mode
+
+	// ngram-mod's lengths are n-max/n-min, and the field the form
+	// labelled "N-gram size N" was always its match length — the value
+	// specDecodingParams never emitted. The other four use size-n/size-m
+	// and have no match length.
+	c.AssistNMax, c.AssistNMin = c.DraftMax, c.DraftMin
+	if mode == "ngram-mod" {
+		// ngram-mod has no m-gram size, so NgramSizeM is dropped rather
+		// than migrated: the form offered it, but the mode has no such
+		// parameter.
+		c.AssistNMatch = c.NgramSizeN
+	} else {
+		c.AssistSizeN, c.AssistSizeM = c.NgramSizeN, c.NgramSizeM
+	}
+
+	c.DraftMax, c.DraftMin = 0, 0
+	c.NgramSizeN, c.NgramSizeM = 0, 0
+	// DraftPMin is left alone: it is a draft-method knob, and a draftless
+	// config that carries one was never emitting it anyway.
+	c.DraftPMin = ""
+}

--- a/internal/models/specparams.go
+++ b/internal/models/specparams.go
@@ -6,19 +6,21 @@ package models
 // with the same defaults under each mode, so the two surfaces cannot
 // disagree about what a mode's settings are.
 type SpecModeParam struct {
-	Key     string // form key: draft_max, draft_min, draft_p_min, ngram_size_n, ngram_size_m
+	Key     string // form key: draft_max, draft_min, draft_p_min, assist_n_max, …
 	Label   string
 	Default string // recommended default as entered in a form field; "" = leave llama.cpp's default
 }
 
-// SpecModeParams returns the tunable parameters for a speculative
-// decoding mode, in display order. An unknown or empty mode has none.
-func SpecModeParams(mode string) []SpecModeParam {
+// SpecDraftParams returns the tunable parameters of a draft method, in
+// display order. An unknown or empty mode has none.
+//
+// The keys are all draft_*, and the assist keys are all assist_*, so a
+// caller handed one list can never mistake a key for a field it doesn't
+// have. That separation is the whole reason these are two functions.
+func SpecDraftParams(mode string) []SpecModeParam {
 	draftMax := func(d string) SpecModeParam { return SpecModeParam{"draft_max", "Draft tokens max", d} }
 	draftMin := func(d string) SpecModeParam { return SpecModeParam{"draft_min", "Draft tokens min", d} }
 	pMin := func(d string) SpecModeParam { return SpecModeParam{"draft_p_min", "Draft probability min", d} }
-	ngramN := func(d string) SpecModeParam { return SpecModeParam{"ngram_size_n", "N-gram size N", d} }
-	ngramM := func(d string) SpecModeParam { return SpecModeParam{"ngram_size_m", "N-gram size M", d} }
 
 	switch mode {
 	case "draft":
@@ -28,11 +30,37 @@ func SpecModeParams(mode string) []SpecModeParam {
 		// at llama.cpp's default — MTP heads have their own acceptance
 		// logic.
 		return []SpecModeParam{draftMax("6"), draftMin("0"), pMin("")}
-	case "ngram-simple", "ngram-cache", "ngram-map-k", "ngram-map-k4v":
-		return []SpecModeParam{draftMax("16"), ngramN("12"), ngramM("48")}
-	case "ngram-mod":
-		return []SpecModeParam{draftMax("64"), draftMin("48"), ngramN("24"), ngramM("48")}
+	case "draft-eagle3", "draft-dflash", "draft-dspark":
+		// Deliberately blank: llama.cpp's own defaults (n-max 3, n-min 0)
+		// apply, and there is no measured guidance for these three to
+		// present as a recommendation. The benchmark sweep is where good
+		// values come from, not a guess in this table.
+		return []SpecModeParam{draftMax(""), draftMin(""), pMin("")}
 	default:
+		return nil
+	}
+}
+
+// SpecAssistParams returns the tunable parameters of a draftless n-gram
+// method, in display order. An unknown or empty mode has none, and so
+// does ngram-cache, which takes no settings.
+func SpecAssistParams(mode string) []SpecModeParam {
+	nMax := func(d string) SpecModeParam { return SpecModeParam{"assist_n_max", "Draft tokens max", d} }
+	nMin := func(d string) SpecModeParam { return SpecModeParam{"assist_n_min", "Draft tokens min", d} }
+	nMatch := func(d string) SpecModeParam { return SpecModeParam{"assist_n_match", "Match length", d} }
+	sizeN := func(d string) SpecModeParam { return SpecModeParam{"assist_size_n", "Lookup size", d} }
+	sizeM := func(d string) SpecModeParam { return SpecModeParam{"assist_size_m", "Draft size", d} }
+	minHits := func(d string) SpecModeParam { return SpecModeParam{"assist_min_hits", "Minimum hits", d} }
+
+	switch mode {
+	case "ngram-mod":
+		// ngram-mod has no m-gram size — the old table offered one, and
+		// it meant nothing for this mode.
+		return []SpecModeParam{nMax("64"), nMin("48"), nMatch("24")}
+	case "ngram-simple", "ngram-map-k", "ngram-map-k4v":
+		return []SpecModeParam{sizeN("12"), sizeM("48"), minHits("1")}
+	default:
+		// ngram-cache takes no settings.
 		return nil
 	}
 }

--- a/internal/models/vram.go
+++ b/internal/models/vram.go
@@ -250,7 +250,15 @@ func AuxFilesVRAMGB(cfg *ModelConfig) float64 {
 	if cfg.MtpPath != "" && !cfg.MtpDisabled {
 		gb += fileSizeGB(cfg.MtpPath)
 	}
-	if cfg.SpecType == "draft" && cfg.DraftModelPath != "" {
+	// Every draft method except draft-mtp loads its drafter — a smaller
+	// model of the same family, or a converted EAGLE-3 / DFlash / DSpark
+	// head — from DraftModelPath. draft-mtp is excluded because its head
+	// comes from MtpPath and is already counted just above, so each
+	// method contributes exactly once.
+	//
+	// The n-gram assist is deliberately absent: it matches text already in
+	// the context and loads no file, so it adds nothing here.
+	if IsDraftMode(cfg.SpecType) && cfg.SpecType != "draft-mtp" && cfg.DraftModelPath != "" {
 		gb += fileSizeGB(cfg.DraftModelPath)
 	}
 	return gb

--- a/internal/models/vram_test.go
+++ b/internal/models/vram_test.go
@@ -139,6 +139,17 @@ func TestAuxFilesVRAMGB(t *testing.T) {
 		{"mtp disabled", ModelConfig{MtpPath: mtp, MtpDisabled: true}, 0},
 		{"draft path but not draft mode", ModelConfig{SpecType: "draft-mtp", DraftModelPath: draft}, 0},
 		{"mtp head under draft-mtp", ModelConfig{SpecType: "draft-mtp", MtpPath: mtp}, 2},
+		// The head-based methods load their converted head from
+		// DraftModelPath, so it has to be counted the same way "draft" is.
+		{"eagle3 head", ModelConfig{SpecType: "draft-eagle3", DraftModelPath: draft}, 3},
+		{"dflash head", ModelConfig{SpecType: "draft-dflash", DraftModelPath: draft}, 3},
+		{"dspark head", ModelConfig{SpecType: "draft-dspark", DraftModelPath: draft}, 3},
+		// draft-mtp's head comes from MtpPath and is counted there; a
+		// stray DraftModelPath must not be counted a second time.
+		{"draft-mtp counts its head once", ModelConfig{SpecType: "draft-mtp", MtpPath: mtp, DraftModelPath: draft}, 2},
+		// The n-gram assist loads no file at all.
+		{"assist alone", ModelConfig{SpecAssist: "ngram-mod", AssistNMax: 64}, 0},
+		{"assist adds nothing to a draft method", ModelConfig{SpecType: "draft", DraftModelPath: draft, SpecAssist: "ngram-mod"}, 3},
 		{"missing file counts zero", ModelConfig{MmprojPath: filepath.Join(dir, "nope.gguf")}, 0},
 	}
 	for _, tc := range cases {

--- a/plan/speculative-multi-mode/overview.md
+++ b/plan/speculative-multi-mode/overview.md
@@ -1,0 +1,252 @@
+# Multiple speculative decoding modes — Project Overview
+
+Source report: [`report.md`](report.md)
+(written 2026-09-07, verified against the managed llama.cpp clone at `b10453`).
+
+## Problem
+
+llama.cpp has accepted a comma-separated `--spec-type` list for some time. A
+draft-model method and a draftless n-gram method can run together, and the
+measured effect is large: on PR #27210's benchmark table — run on hardware close
+to ours — MTP alone reaches 82 tokens/second on echo-heavy work, while
+MTP + N-gram Mod reaches 324, with no measurable cost on novel generation
+(51.65 vs 51.68 reasoning, 68.36 vs 69.28 code). Echo-heavy work is file
+rewrites, structured output and tool-call loops, which is a large share of how
+these servers are actually used.
+
+llama-toolchest cannot express that. `ModelConfig.SpecType` is a single string,
+and the four draft-length fields around it (`DraftMax`, `DraftMin`,
+`NgramSizeN`, `NgramSizeM`) change meaning depending on which mode is selected —
+`specflags.go` switches on `SpecType` to decide whether `DraftMax` becomes
+`--spec-draft-n-max` or `--spec-ngram-mod-n-max`. A configuration with MTP
+drafting 3 tokens and N-gram Mod drafting 64 is not merely unsupported, it is
+inexpressible in the current struct.
+
+Two smaller defects sit in the same code. `--spec-ngram-mod-n-match` is offered
+in the config form and stored, but `specDecodingParams` never emits it, so
+tuning it does nothing; and `ngram_size_m` is offered for `ngram-mod`, which has
+no m-gram size at all. Separately, three merged and documented spec types —
+`draft-eagle3`, `draft-dflash`, `draft-dspark` — are present in the build we
+ship, have converted checkpoints on Hugging Face for models we run, and appear
+in neither the mode picker nor the benchmark axis.
+
+## Goals
+
+- Let a model configuration run one draft-model method together with one
+  draftless n-gram method, with independent parameters for each.
+- Emit a single comma-joined `spec-type` line in the preset INI, since
+  `common/preset.cpp` parses a section into a map and silently keeps only the
+  last value of a repeated key.
+- Make the combination sweepable on the benchmark axis so its effect on this
+  hardware is measurable rather than argued about.
+- Add `draft-eagle3`, `draft-dflash` and `draft-dspark` to the mode picker and
+  the benchmark axis choices.
+- Emit `--spec-ngram-mod-n-match` and `--spec-<mode>-min-hits`, both of which
+  are offered or defaulted today but never passed to llama-server, and stop
+  offering the meaningless m-gram field for `ngram-mod`.
+- Add a recall-workload benchmark preset, so the combination's main benefit can
+  be measured here at all — every existing internal preset asks the model to
+  produce new text, which is exactly the workload where an n-gram method
+  measures nothing.
+- Make it structurally impossible for the UI to select two draft-model methods
+  at once, which is the open upstream startup crash
+  ([#27897](https://github.com/ggml-org/llama.cpp/issues/27897)).
+- Keep every existing configuration working: a config naming one mode must emit
+  exactly the flags it emits today, with the single deliberate exception of the
+  two flags that were dropped by the bugs above and now appear.
+- Measure the combination on this hardware and record the result.
+
+## Non-goals
+
+- **`--spec-chain` is not built.** The flag does not exist anywhere in
+  llama.cpp; the underlying feature request
+  ([#23184](https://github.com/ggml-org/llama.cpp/issues/23184)) is closed as not
+  planned. There is nothing to wrap.
+- **`draft-mtp-adaptive` is not added.** It is an open, merge-blocked PR
+  ([#27210](https://github.com/ggml-org/llama.cpp/pull/27210)). An unknown mode
+  name is a hard llama-server startup failure, and the toolchest has no
+  build-aware capability gating. It is revisited when
+  [`../builder-refs.md`](../builder-refs.md) lands, as the first customer for
+  that gating. Until then a user can put `--spec-type draft-mtp-adaptive` in
+  Extra Flags against a hand-built binary.
+- **No general N-mode list.** llama.cpp's own rule is "a draft method may be
+  mixed with a draftless method", not "any set of modes". The data model encodes
+  exactly that rule; three simultaneous modes are not supported and nothing asks
+  for them.
+- **No user-controllable mode ordering.** `common_speculative_init` turns the
+  list into a bitmask and walks a fixed priority order, so `draft-mtp,ngram-mod`
+  and `ngram-mod,draft-mtp` are byte-identical. There is no ordering to expose.
+- **Stored benchmark history is not rewritten.** Old jobs and results keep their
+  `spec_type: ngram-mod` shape on disk and are normalised on read.
+- **No build-capability detection.** The three new spec types are added
+  unconditionally because they are in the build we ship.
+
+## Users & primary flow
+
+The user is the operator of this llama-toolchest instance, configuring and
+benchmarking local llama-server deployments.
+
+**Configuring a model.** In the model config form's Speculative Decoding
+section, two pickers now sit side by side and are always visible:
+
+1. **Draft method** — Disabled, Draft Model, MTP (self-speculation), EAGLE-3,
+   DFlash, DSpark. Its parameters (draft tokens max/min, draft probability min)
+   and its model/head path appear underneath when a method is chosen.
+2. **N-gram assist** — None, N-gram Mod, N-gram Simple, N-gram Cache,
+   N-gram Map-K, N-gram Map-K4V. Its own parameters appear underneath.
+
+Because the draft methods live in one picker and the n-gram methods in the
+other, two draft methods cannot be selected. Leaving Draft method on Disabled
+and choosing an N-gram assist is the draftless-only configuration that
+`spec_type: ngram-mod` expresses today. An effective-flags line under the
+section shows the resulting `--spec-type` value so the user can see the
+comma-joined list they have built.
+
+**Benchmarking a combination.** On the benchmark job form, each draft-method
+choice's expandable section gains an "N-gram assist" dropdown alongside its own
+parameters, with the assist's parameters below it. Checking MTP with the assist
+set to N-gram Mod produces the sweep value
+`draft-mtp+ngram-mod:draft_max=6,assist_n_max=64,assist_n_min=48,assist_n_match=24`
+— each slot's own recommended defaults, pre-encoded, exactly as the mode choices
+already work today. Running that against MTP alone on a novel-generation prompt
+set and an echo-heavy one is the C1-vs-C7 comparison from the source report, on
+local hardware.
+
+**Launching.** Nothing changes for the user. The launch path emits
+`--spec-type draft-mtp,ngram-mod` plus each mode's own flags, and the preset INI
+carries one `spec-type` line.
+
+## Constraints
+
+- **Go backend, `html/template` + htmx frontend.** No build step for the web
+  assets; JS tests live in `web/jstest/` and run against a small DOM shim.
+- **`none` must never appear in a list.** `common_speculative_types_from_names`
+  returns `{NONE}` and discards everything else the moment it sees `none`. The
+  emitter never writes `none` as a list member — an empty slot contributes
+  nothing to the list.
+- **An unknown mode name is fatal.** llama-server refuses to start with
+  `unknown speculative type: <name>`. There is no graceful degradation, which is
+  why only merged, shipped mode names are offered.
+- **One `spec-type` line in the INI.** `common/preset.cpp` parses an INI section
+  into a `std::map<common_arg, std::string>`; a repeated `spec-type =` line
+  keeps only the last value.
+- **The sweep encoding already uses commas.** `spec_type` sweep values are
+  `mode:key=value,key=value` and the field's `Separator` is `","`, so the two
+  mode names are joined with `+` instead.
+- **`spec_type` has no custom-entry box** in the benchmark job form
+  (`web/jstest/params_test.js:49` pins this), so every reachable value must come
+  from the choices table and its expandable controls.
+- **The three new draft methods load a head that fails the draft-candidate
+  filter.** `FindDraftCandidates` requires the same architecture and under 40%
+  of the target's size; a converted EAGLE-3 / DFlash / DSpark head passes
+  neither.
+- **17 non-test files reference `SpecType`**, plus 4 templates and 2 JS test
+  fixtures. The work is wide rather than deep.
+- **Plain language throughout.** No slang in labels, help copy or tooltips;
+  written for a non-developer, ESL-inclusive reader.
+- **UI conventions.** Tooltips carry the explanation rather than static prose;
+  the effective `--spec-type` value is always visible, not revealed on hover.
+
+## Success criteria
+
+- A model configured with MTP at 3 draft tokens and N-gram Mod at 64/48/24
+  launches llama-server with `--spec-type draft-mtp,ngram-mod`,
+  `--spec-draft-n-max 3`, `--spec-ngram-mod-n-max 64`,
+  `--spec-ngram-mod-n-min 48` and `--spec-ngram-mod-n-match 24`.
+- The preset INI for that model contains exactly one `spec-type` line, reading
+  `spec-type = draft-mtp,ngram-mod`. A test pins this.
+- Every configuration that exists before the change emits an identical flag set
+  after it — verified by a test over the existing spec smoke-test fixtures —
+  except that an `ngram-mod` config now also emits `--spec-ngram-mod-n-match`,
+  carrying the value the form has been storing and discarding. That one addition
+  is the bug fix; every other flag is byte-identical. `--spec-<mode>-min-hits`
+  becomes tunable and is emitted for configs saved after the change; a migrated
+  config leaves it unset, because there is no legacy field to migrate from and
+  llama.cpp's own default is the 1 the form now offers, so nothing changes for
+  it either.
+- A draftless-only config saved before the change (`spec_type: ngram-mod`) still
+  launches with the same flags plus that one `n-match` addition, and its saved
+  parameters land on the new fields after the one-shot backfill.
+- Saved benchmark jobs and results that carry `spec_type: ngram-mod` still
+  render their labels and still re-run correctly.
+- The mode picker offers `draft-eagle3`, `draft-dflash` and `draft-dspark`, and
+  each launches with a head selected from a picker that no longer filters by
+  architecture and size.
+- Selecting two draft-model methods is impossible from the UI.
+- A benchmark job can sweep MTP alone against MTP + N-gram Mod in one run, and
+  the compare table labels the two cells distinguishably.
+- VRAM accounting counts a draft head for every draft method that loads one —
+  `DraftModelPath` for `draft`, `draft-eagle3`, `draft-dflash` and
+  `draft-dspark`, and `MtpPath` for `draft-mtp`, which is already counted —
+  rather than only for `draft`; the n-gram assist loads no file and adds
+  nothing.
+- Tuning "match length" for N-gram Mod changes the launched command, as does
+  "minimum hits" for N-gram Simple / Map-K / Map-K4V; the m-gram field is no
+  longer offered for N-gram Mod.
+- An `internal-echo` benchmark preset exists whose generation is recall of text
+  already in the prompt, and `ngram-mod` alone measures at baseline under
+  `internal-standard` while measuring well above it under `internal-echo`.
+- The C1-vs-C7 sweep has been run on this hardware and its numbers are recorded
+  in this plan folder.
+- `make build`, `go test ./...` and `make js-test` pass. (There is no
+  `make test` target; the JS suite runs inside `go test ./internal/api/` when
+  node is present, and `make js-test` fails loudly when it is not.)
+
+## Decisions
+
+- **Scope** → All three buildable items: add the three merged-but-unreachable
+  spec types, fix the N-gram Mod parameter bugs, and build the draft + assist
+  combination. Skip `--spec-chain`; defer `draft-mtp-adaptive`.
+- **Data model** → `SpecType` stays the draft method; a new `SpecAssist` holds
+  the draftless one, with its own six fields: `AssistNMax`, `AssistNMin`,
+  `AssistNMatch`, `AssistSizeN`, `AssistSizeM`, `AssistMinHits`. Not a general
+  list of mode blocks.
+- **Assist modes and visibility** → All five draftless modes are offered; the
+  assist picker pairs with a draft method, so two draft methods cannot be
+  selected. This is what makes the upstream crash structurally unreachable.
+- **Sweep axis encoding** → One axis. `+` joins the two mode names, `,` keeps
+  separating parameters: `draft-mtp+ngram-mod:draft_max=3,assist_n_max=64`.
+  Parameter keys are unique across the draft and assist blocks, so one flat
+  key=value list still works.
+- **Head path for the new draft methods** → Reuse `DraftModelPath`, and relax
+  `FindDraftCandidates` when the mode is `draft-eagle3`, `draft-dflash` or
+  `draft-dspark`: drop the architecture-match and 40%-size checks, keep the
+  embedding-model and MTP-head exclusions. No new path field, no auto-detection
+  pass.
+- **Draftless parameter fields** → One shared block. `SpecType` becomes strictly
+  the draft method (or empty); `SpecAssist` strictly the draftless one. A
+  draftless-only config becomes `spec_type: ""` + `spec_assist: ngram-mod`,
+  which costs a one-time config migration and gives one place to fix the
+  n-match bug.
+- **Migration mechanics** → A one-shot backfill at registry load rewrites model
+  configs and saves, following the `BackfillGGUFMeta` pattern. A separate
+  tolerant `models.NormalizeSpec` helper on the read path maps a draftless name found
+  in `SpecType` into `SpecAssist`, so stored benchmark jobs and results keep
+  working without their history being rewritten.
+- **Model config form layout** → Two always-visible pickers, "Draft method" and
+  "N-gram assist", each with its parameters revealed underneath.
+- **Benchmark job form** → Each draft-method choice's expandable section gains
+  an "N-gram assist" dropdown plus the assist's parameter fields. The choices
+  list is eleven entries — five draft methods, five n-gram methods and off, up
+  from the eight offered today — and every combination remains reachable.
+- **Naming** → "Draft method" and "N-gram assist".
+- **Validation** → A final phase runs the C1-vs-C7 sweep on this hardware — MTP
+  alone against MTP + N-gram Mod, across a novel-generation and an echo-heavy
+  prompt set — and records the numbers in this plan folder.
+- **Params table shape** → Split `SpecModeParams` into `SpecDraftParams(mode)`
+  and `SpecAssistParams(mode)`, each with one key namespace, so a caller can
+  never be handed a key it has no field for.
+- **Defaults for the three new draft methods** → All fields blank, inheriting
+  llama.cpp's own `--spec-draft-n-max 3` / `-n-min 0`. There is no verified
+  guidance for EAGLE-3, DFlash or DSpark, and the benchmark axis is the right
+  place to find good values rather than guessing them into the table.
+- **`--spec-<mode>-min-hits`** → Fixed in the same work. It is the same class of
+  gap as `n-match`, in the same function, and the assist parameter block is
+  being written from scratch anyway.
+- **Phase order** → Data model first, with the three new draft methods riding
+  along in phase 01 rather than shipping ahead of it. The shared-block decision
+  rewrites the mode picker and the choices table regardless, so this writes
+  every surface once, in its final shape.
+- **Echo workload** → Add an `internal-echo` preset (phase 05) before
+  validating. The existing presets can only measure the half of the claim where
+  the combination changes nothing.

--- a/plan/speculative-multi-mode/phase-01-data-model.md
+++ b/plan/speculative-multi-mode/phase-01-data-model.md
@@ -51,6 +51,22 @@ nothing breaks between phases.
   parser routes a draftless `spec_type` through `NormalizeSpec`. The two-picker
   rework is phase 03.
 
+The benchmark package cannot be left out of this phase, because the sweep axis
+renders parameter *keys* from the shared table into its encoded values and maps
+them onto `ConfigOverrides`. Splitting the table changes the keys for draftless
+modes, so the override fields must split with it or a swept assist setting is
+silently dropped:
+
+- `internal/benchmark/job.go` — `ConfigOverrides` gains `SpecAssist` and the six
+  `Assist*` pointers; `NgramSizeN` / `NgramSizeM` stay for stored jobs.
+- `internal/benchmark/benchmark.go` — `ConfigSnapshot` gains the matching value
+  fields, so a run records what it ran with.
+- `internal/benchmark/job_runner.go` — apply the new overrides.
+- `internal/benchmark/sweep.go` — `specModeParams` picks the right table;
+  mode validity becomes membership in the two lists rather than "has settings"
+  (`ngram-cache` is a real mode with no settings); `applySpecValue` writes both
+  slot pointers and the six assist keys; `specParamTags` lists the new tags.
+
 ## Steps
 
 1. **Create `internal/models/specmodes.go`.**
@@ -239,7 +255,21 @@ nothing breaks between phases.
    this with the two pickers' own field names; the two default functions and the
    ordering survive unchanged.
 
-7. **Tests.** In `internal/models/spec_smoke_test.go`:
+7. **Benchmark plumbing.** `parseSpecValue` currently rejects a mode whose
+   parameter list is empty, which would start rejecting `ngram-cache` the
+   moment `SpecAssistParams` returns nil for it — check
+   `IsDraftMode || IsAssistMode` instead. `applySpecValue` must set *both* slot
+   pointers, clearing the one the value does not name, so a cell that selects a
+   mode runs that mode alone. Do not normalise in `applyOverrides`: it returns a
+   `ConfigSnapshot`, which is a record of what was requested, and the launch
+   path normalises anyway.
+
+   `TestKeepUnsweepableDropsExpressibleFields` will fail until every new
+   `ConfigOverrides` field is listed in `specParamTags` — that guard exists
+   precisely to catch a field the sweep can express but the registry does not
+   name.
+
+8. **Tests.** In `internal/models/spec_smoke_test.go`:
    - `TestSpecCombinedFlags` — `draft-mtp` + `ngram-mod` produces exactly one
      `--spec-type draft-mtp,ngram-mod`, plus `--spec-draft-n-max 3`,
      `--spec-ngram-mod-n-max 64`, `--spec-ngram-mod-n-min 48`,

--- a/plan/speculative-multi-mode/phase-01-data-model.md
+++ b/plan/speculative-multi-mode/phase-01-data-model.md
@@ -1,0 +1,324 @@
+# Phase 01 — Data model, flag emission, and the three new draft methods
+
+**Depends on:** nothing · **Enables:** phases 02, 03, 04 and 06 (phase 05 is
+independent of it). This is the foundation: `SpecType` becomes strictly the draft method, `SpecAssist` strictly
+the draftless one, and `specDecodingParams` emits one comma-joined `spec-type`
+value plus each slot's own flags.
+
+## Goal
+
+Split speculative decoding into two independent slots in `ModelConfig` and make
+the launch path emit both. After this phase a config with
+`spec_type: draft-mtp`, `draft_max: 3`, `spec_assist: ngram-mod`,
+`assist_n_max: 64`, `assist_n_min: 48`, `assist_n_match: 24` produces
+`--spec-type draft-mtp,ngram-mod --spec-draft-n-max 3
+--spec-ngram-mod-n-max 64 --spec-ngram-mod-n-min 48 --spec-ngram-mod-n-match 24`
+on the command line and a single `spec-type = draft-mtp,ngram-mod` line in the
+preset INI. The three merged-but-unreachable draft methods
+(`draft-eagle3`, `draft-dflash`, `draft-dspark`) are added here, because under
+the new model they are just three more rows in the draft table. The dead
+`--spec-ngram-mod-n-match` and the never-offered `--spec-<mode>-min-hits` are
+fixed as part of writing the assist emitter, and the m-gram parameter is dropped
+from `ngram-mod`'s row in the parameter table, so nothing downstream offers it
+for that mode. The form still renders its own hard-coded m-gram input until
+phase 03 rewrites the section; until then the posted value is migrated by
+`NormalizeSpec` into `AssistSizeM` and — for `ngram-mod` — discarded, which is
+exactly what it was worth before.
+
+No new UI in this phase. The form keeps its single Mode picker and still posts
+`spec_type` with a draftless name for a draftless-only model; the tolerant
+reader added here turns that into the new shape as the value is parsed, so
+nothing breaks between phases.
+
+## Files touched
+
+- `internal/models/specmodes.go` — **new**. Mode classification and the two
+  ordered name lists both forms and the sweep will render from.
+- `internal/models/registry.go` — add `SpecAssist` and the six `Assist*`
+  fields to `ModelConfig`; add `BackfillSpecAssist`; update the `SpecType`
+  field comment.
+- `internal/models/specparams.go` — replace `SpecModeParams` with
+  `SpecDraftParams` and `SpecAssistParams`.
+- `internal/models/specflags.go` — rewrite `specDecodingParams` as a draft
+  block plus an assist block feeding one joined `spec-type` param.
+- `internal/api/server.go` — call `BackfillSpecAssist` alongside
+  `BackfillGGUFMeta` at startup.
+- `internal/models/spec_smoke_test.go` — extend with combination, new-mode and
+  migration cases.
+- `internal/models/preset_test.go` — pin the single `spec-type` INI line.
+- `internal/api/service.go` — `applySpecDefaults` splits into
+  `applyDraftDefaults` and `applyAssistDefaults`; the interim single-picker form
+  parser routes a draftless `spec_type` through `NormalizeSpec`. The two-picker
+  rework is phase 03.
+
+## Steps
+
+1. **Create `internal/models/specmodes.go`.**
+
+   ```go
+   // DraftModes are the speculative modes that load a drafter through
+   // --model-draft or a head baked into the main GGUF. At most one may be
+   // active: llama.cpp crashes at startup on two (upstream issue #27897).
+   func DraftModes() []SpecMode   // draft, draft-mtp, draft-eagle3,
+                                  // draft-dflash, draft-dspark
+   // AssistModes are the draftless n-gram methods. llama.cpp sanctions
+   // mixing exactly one of these with one draft mode.
+   func AssistModes() []SpecMode  // ngram-mod, ngram-simple, ngram-cache,
+                                  // ngram-map-k, ngram-map-k4v
+   func IsDraftMode(name string) bool
+   func IsAssistMode(name string) bool
+   // HeadBasedDraftModes are the draft modes whose --model-draft target is a
+   // converted head rather than a smaller model of the same architecture.
+   func IsHeadBasedDraftMode(name string) bool // eagle3, dflash, dspark
+   ```
+
+   `SpecMode` carries `Name` and `Label` (`"draft"` → `"Draft Model"`,
+   `"draft-mtp"` → `"MTP (self-speculation)"`, `"draft-eagle3"` → `"EAGLE-3"`,
+   `"draft-dflash"` → `"DFlash"`, `"draft-dspark"` → `"DSpark"`,
+   `"ngram-mod"` → `"N-gram Mod"`, `"ngram-simple"` → `"N-gram Simple"`,
+   `"ngram-cache"` → `"N-gram Cache"`, `"ngram-map-k"` → `"N-gram Map-K"`,
+   `"ngram-map-k4v"` → `"N-gram Map-K4V"`). These labels are the single source
+   for every mode *name* the two forms and the sweep render, so those cannot
+   drift. The empty slot deliberately has no `SpecMode` entry, because it reads
+   differently in each place: "Disabled" in the draft picker, "None" in the
+   assist picker, "Off (no speculative decoding)" in the sweep choices list.
+   Each surface writes its own.
+
+   Add `NormalizeSpec(c *ModelConfig)`: if `c.SpecType` holds an assist mode
+   name, move it to `c.SpecAssist`, move `DraftMax`→`AssistNMax`,
+   `DraftMin`→`AssistNMin`, `NgramSizeN`→`AssistNMatch` for `ngram-mod` or
+   `AssistSizeN` for the other four, `NgramSizeM`→`AssistSizeM` (dropped for
+   `ngram-mod`, which has no m-gram size), clear the four legacy fields and
+   clear `SpecType`. It is idempotent and does nothing when `SpecType` is
+   already a draft mode or empty. This is the tolerant reader; it runs on
+   configs reconstructed from stored benchmark history as well as on live ones.
+
+2. **Extend `ModelConfig`** in `internal/models/registry.go`, immediately after
+   the existing speculative block:
+
+   ```go
+   // Draftless n-gram assist. Runs alongside the draft method above:
+   // llama.cpp accepts a comma-separated --spec-type list mixing one draft
+   // method with one draftless one, and each has its own draft-length flags.
+   SpecAssist     string `json:"spec_assist,omitempty"`      // "", "ngram-mod", "ngram-simple", …
+   AssistNMax     int    `json:"assist_n_max,omitempty"`     // --spec-ngram-mod-n-max
+   AssistNMin     int    `json:"assist_n_min,omitempty"`     // --spec-ngram-mod-n-min
+   AssistNMatch   int    `json:"assist_n_match,omitempty"`   // --spec-ngram-mod-n-match
+   AssistSizeN    int    `json:"assist_size_n,omitempty"`    // --spec-<mode>-size-n
+   AssistSizeM    int    `json:"assist_size_m,omitempty"`    // --spec-<mode>-size-m
+   AssistMinHits  int    `json:"assist_min_hits,omitempty"`  // --spec-<mode>-min-hits
+   ```
+
+   Leave `DraftMax`, `DraftMin`, `DraftPMin` where they are — they now belong
+   unambiguously to the draft method. Leave `NgramSizeN` and `NgramSizeM` in
+   the struct as legacy fields, marked
+   `// legacy; the form posts these until phase 03, and NormalizeSpec migrates them into Assist*`.
+   They must keep being written by the interim form parser (step 6) — that is
+   how a draftless save made between this phase and phase 03 reaches
+   `NormalizeSpec` at all. Nothing else reads them, and phase 03 removes the
+   inputs that post them. Update the `SpecType` comment to
+   `// "", "draft", "draft-mtp", "draft-eagle3", "draft-dflash", "draft-dspark" — draft methods only; the draftless mode lives in SpecAssist`.
+
+3. **Rewrite `internal/models/specparams.go`** as two functions with disjoint
+   key namespaces:
+
+   ```go
+   func SpecDraftParams(mode string) []SpecModeParam
+     "draft"         -> draft_max=16, draft_min=0, draft_p_min=0.75
+     "draft-mtp"     -> draft_max=6,  draft_min=0, draft_p_min=""
+     "draft-eagle3"  -> draft_max="", draft_min="", draft_p_min=""
+     "draft-dflash"  -> draft_max="", draft_min="", draft_p_min=""
+     "draft-dspark"  -> draft_max="", draft_min="", draft_p_min=""
+
+   func SpecAssistParams(mode string) []SpecModeParam
+     "ngram-mod"     -> assist_n_max=64, assist_n_min=48, assist_n_match=24
+     "ngram-simple"  -> assist_size_n=12, assist_size_m=48, assist_min_hits=1
+     "ngram-map-k"   -> assist_size_n=12, assist_size_m=48, assist_min_hits=1
+     "ngram-map-k4v" -> assist_size_n=12, assist_size_m=48, assist_min_hits=1
+     "ngram-cache"   -> (none; the mode takes no tunables)
+   ```
+
+   The three new draft modes deliberately carry empty defaults: llama.cpp's own
+   `--spec-draft-n-max 3` / `-n-min 0` apply, and there is no verified guidance
+   to present as a recommendation. The labels are "Draft tokens max",
+   "Draft tokens min", "Draft probability min" for the draft block and
+   "Draft tokens max", "Draft tokens min", "Match length", "Lookup size",
+   "Draft size", "Minimum hits" for the assist block.
+
+4. **Rewrite `specDecodingParams`** in `internal/models/specflags.go`:
+
+   ```go
+   func specDecodingParams(c *ModelConfig) []specParam {
+       cfg := *c
+       NormalizeSpec(&cfg)          // tolerate a legacy draftless SpecType
+       var modes []string
+       var params []specParam
+       if IsDraftMode(cfg.SpecType) {
+           modes = append(modes, draftTypeName(cfg.SpecType))
+           params = appendDraftParams(params, &cfg)
+       }
+       if IsAssistMode(cfg.SpecAssist) {
+           modes = append(modes, cfg.SpecAssist)
+           params = appendAssistParams(params, &cfg)
+       }
+       if len(modes) == 0 {
+           return nil          // never emit "none" — an empty slot contributes nothing
+       }
+       return append([]specParam{{"spec-type", strings.Join(modes, ",")}}, params...)
+   }
+   ```
+
+   The draft method comes first in the joined value. Order is behaviourally
+   irrelevant (`common_speculative_init` builds a bitmask and walks a fixed
+   priority order) but fixing it keeps INI diffs stable.
+
+   `draftTypeName` maps the internal `"draft"` to llama.cpp's `"draft-simple"`
+   and passes the other four through — the existing legacy-compat rename, moved
+   out of the switch.
+
+   `appendDraftParams` is today's `draft` / `draft-mtp` bodies merged: emit
+   `model-draft` from `MtpPath` when the mode is `draft-mtp` and `MtpPath` is
+   set and not disabled, from `DraftModelPath` for the other four modes when
+   set; then `appendDraftResourceParams` whenever a `model-draft` was emitted;
+   then `appendDraftSamplingParams` always. Self-speculation MTP (empty
+   `MtpPath`) keeps emitting sampling flags only, exactly as today.
+
+   `appendAssistParams` is new:
+
+   ```go
+   case "ngram-mod":
+       assist_n_max   -> spec-ngram-mod-n-max
+       assist_n_min   -> spec-ngram-mod-n-min
+       assist_n_match -> spec-ngram-mod-n-match   // fixes the dead field
+   case "ngram-simple", "ngram-map-k", "ngram-map-k4v":
+       prefix := "spec-" + mode
+       assist_size_n   -> prefix + "-size-n"
+       assist_size_m   -> prefix + "-size-m"
+       assist_min_hits -> prefix + "-min-hits"    // fixes the second dead field
+   case "ngram-cache":
+       // no tunables
+   ```
+
+5. **Add `BackfillSpecAssist`** to `internal/models/registry.go`, modelled on
+   `BackfillGGUFMeta`: take the write lock, run `NormalizeSpec` over every
+   entry in `r.data.Configs`, count the ones it changed, and `r.save()` if the
+   count is non-zero. Return the count so the caller can log it. Call it from
+   `internal/api/server.go` next to the existing `BackfillGGUFMeta()` call at
+   line 217, logging `"migrated draftless speculative configs", "configs", n`
+   when non-zero.
+
+6. **Update `internal/api/service.go` for the interim single-picker form.**
+   Replace `applySpecDefaults` with the two functions phase 03 will wire to the
+   two pickers, since they are needed here anyway:
+
+   - `applyDraftDefaults(cfg)` zeroes `DraftMax`, `DraftMin`, `DraftPMin` and
+     refills them from `SpecDraftParams(cfg.SpecType)`.
+   - `applyAssistDefaults(cfg)` zeroes the six assist fields and refills them
+     from `SpecAssistParams(cfg.SpecAssist)`.
+
+   In the form parser, keep parsing `draft_max`, `draft_min`, `draft_p_min`,
+   `ngram_size_n` and `ngram_size_m` from the request exactly as today — the
+   form still posts those names. Then, in this order:
+
+   ```go
+   prevSpecType, prevSpecAssist := cfg.SpecType, cfg.SpecAssist
+   cfg.SpecType = r.FormValue("spec_type")
+   // … parse the numeric fields as today, into the legacy field names …
+   models.NormalizeSpec(cfg)   // routes a draftless choice into SpecAssist
+                               // and its values into the Assist* fields
+   if cfg.SpecType != prevSpecType     { applyDraftDefaults(cfg) }
+   if cfg.SpecAssist != prevSpecAssist { applyAssistDefaults(cfg) }
+   ```
+
+   `NormalizeSpec` runs *before* the two comparisons, so both see the normalised
+   slots and a draftless mode change applies assist defaults rather than none —
+   which is what keeps the app behaving as it does today at the end of this
+   phase. Splitting the defaults in two is what stops a change in one slot
+   wiping the other's tuned values, the bug a single `applySpecDefaults` would
+   cause the moment a second slot exists. Phase 03 replaces the parsing half of
+   this with the two pickers' own field names; the two default functions and the
+   ordering survive unchanged.
+
+7. **Tests.** In `internal/models/spec_smoke_test.go`:
+   - `TestSpecCombinedFlags` — `draft-mtp` + `ngram-mod` produces exactly one
+     `--spec-type draft-mtp,ngram-mod`, plus `--spec-draft-n-max 3`,
+     `--spec-ngram-mod-n-max 64`, `--spec-ngram-mod-n-min 48`,
+     `--spec-ngram-mod-n-match 24`, and contains no `none`.
+   - `TestSpecNgramModMatchEmitted` — `assist_n_match` reaches the command line
+     (the bug this fixes).
+   - `TestSpecMinHitsEmitted` — `ngram-simple` emits
+     `--spec-ngram-simple-min-hits`.
+   - `TestSpecNewDraftModes` — each of `draft-eagle3`, `draft-dflash`,
+     `draft-dspark` with a `DraftModelPath` emits its own `--spec-type` name
+     and `--model-draft`.
+   - `TestSpecLegacyDraftlessConfig` — a config built with
+     `SpecType: "ngram-mod"`, `DraftMax: 64`, `DraftMin: 48`, `NgramSizeN: 24`
+     emits byte-identical flags before and after normalisation, except that
+     `--spec-ngram-mod-n-match 24` is now present.
+   - `TestSpecUnchangedForExistingModes` — table over the existing smoke-test
+     fixtures asserting each emits the same flag set it did before, with one
+     allowed addition: an `ngram-mod` fixture also emits
+     `--spec-ngram-mod-n-match`, the bug fix. No fixture gains a `min-hits`
+     flag: nothing migrates into `AssistMinHits`, because no legacy field feeds
+     it. The flag reaches the command line only once a config is re-saved
+     through the form, at which point `applyAssistDefaults` (step 6) fills in
+     the 1 — which is llama.cpp's own default, so the launch does not change
+     either way.
+   In `internal/models/preset_test.go`, `TestPresetSingleSpecTypeLine` — the
+   generated INI for a combined config contains exactly one line starting
+   `spec-type` and its value is `draft-mtp,ngram-mod`.
+
+## Build gate
+
+```
+make build
+go test ./internal/models/... ./internal/api/...
+go vet ./...
+```
+
+There is no `make test` target in this project: `go test ./...` is the suite,
+and `make js-test` runs the page JavaScript.
+
+## Test plan
+
+- The unit tests above.
+- Manually: load an existing instance whose registry has a
+  `spec_type: ngram-mod` model, start the server, confirm the startup log
+  reports the migration count once and not on the second start, and confirm
+  `~/.config/llama-toolchest/` (or the configured registry path) now holds
+  `spec_assist: ngram-mod` with `assist_n_max: 64`, `assist_n_min: 48`,
+  `assist_n_match: 24` and no `ngram_size_m`.
+- Diff the generated preset INI before and after for a model using each
+  existing mode; only the `ngram-mod` model should change, gaining one
+  `n-match` flag.
+
+## Commit
+
+```
+feat(spec): split speculative decoding into a draft method and an n-gram assist
+
+llama.cpp accepts a comma-separated --spec-type list mixing one draft method
+with one draftless method, and each has its own draft-length flags. SpecType
+now holds only the draft method; the new SpecAssist holds the draftless one
+with its own parameters, so MTP at 3 tokens alongside ngram-mod at 64 is
+expressible for the first time.
+
+Adds the three merged draft methods that were unreachable (draft-eagle3,
+draft-dflash, draft-dspark), emits --spec-ngram-mod-n-match and
+--spec-<mode>-min-hits, which were offered or defaulted but never passed to
+llama-server, and drops the m-gram field from ngram-mod, which has no m-gram
+size.
+
+A one-shot backfill migrates saved draftless configs; NormalizeSpec keeps
+reading the old shape wherever it survives.
+```
+
+## Rollback
+
+Revert the commit. The `Assist*` JSON fields are `omitempty`, so a registry
+already migrated by `BackfillSpecAssist` loses its n-gram parameters on the
+reverted build — `spec_assist` and `assist_*` become unknown keys and the mode
+reads as disabled. Back the registry file up before first running the migrated
+build if that matters. Nothing else in this phase is stateful; leaving it
+partially applied is safe as long as `specmodes.go` and the struct fields land
+together.

--- a/plan/speculative-multi-mode/phase-02-call-sites.md
+++ b/plan/speculative-multi-mode/phase-02-call-sites.md
@@ -28,11 +28,12 @@ fields to `ConfigOverrides`, so phase 04 is purely encoding and UI.
   slot.
 - `internal/api/service.go` — pass the selected mode to `FindDraftCandidates`.
 - `internal/api/jobs_env.go` — snapshot, restore and diff the assist fields.
-- `internal/benchmark/job.go` — `ConfigOverrides` gains the assist pointers.
-- `internal/benchmark/job_runner.go` — apply them.
-- `internal/benchmark/benchmark.go` — `RunConfig` records them.
 - `internal/benchmark/compare_labels.go` — the speculative label shows both
   slots.
+
+`ConfigOverrides`, `ConfigSnapshot` and the override merge already gained their
+assist fields in phase 01, which could not split the shared parameter table
+without them.
 - `internal/evaluate/evaluate.go` — update the field list in the comment at
   line 176.
 - `web/templates/partials/job_detail.html` — show the assist alongside the mode.
@@ -82,34 +83,7 @@ fields to `ConfigOverrides`, so phase 04 is purely encoding and UI.
    there are no stale stored values to invalidate. The comment above the
    function says so — leave it accurate.
 
-6. **`internal/benchmark/job.go`.** Add to `ConfigOverrides`, after
-   `NgramSizeM`:
-
-   ```go
-   SpecAssist    *string `json:"spec_assist,omitempty"`
-   AssistNMax    *int    `json:"assist_n_max,omitempty"`
-   AssistNMin    *int    `json:"assist_n_min,omitempty"`
-   AssistNMatch  *int    `json:"assist_n_match,omitempty"`
-   AssistSizeN   *int    `json:"assist_size_n,omitempty"`
-   AssistSizeM   *int    `json:"assist_size_m,omitempty"`
-   AssistMinHits *int    `json:"assist_min_hits,omitempty"`
-   ```
-
-   Keep `NgramSizeN` and `NgramSizeM` — stored jobs still carry them, and the
-   runner must keep honouring them.
-
-7. **`internal/benchmark/job_runner.go:848`.** Add the seven
-   `if overrides.X != nil { out.X = *overrides.X }` blocks alongside the
-   existing ones, then call `models.NormalizeSpec(&out)` once at the end of the
-   merge. That single call is what makes a stored job carrying
-   `spec_type: ngram-mod` produce the same launch as a new job carrying
-   `spec_assist: ngram-mod` — the tolerant read path, applied where history
-   actually enters the system.
-
-8. **`internal/benchmark/benchmark.go:153`.** Add the matching value fields to
-   `RunConfig` so a completed run records what it actually ran with.
-
-9. **`internal/benchmark/compare_labels.go:100`.** Replace
+6. **`internal/benchmark/compare_labels.go:100`.** Replace
    `func(r BenchmarkRun) string { return r.Config.SpecType }` with a helper that
    joins the two slots the way the flag does:
 
@@ -132,11 +106,11 @@ fields to `ConfigOverrides`, so phase 04 is purely encoding and UI.
    this change have `SpecAssist` empty and a draftless name in `SpecType`, so
    they keep rendering exactly as they did.
 
-10. **`web/templates/partials/job_detail.html:31`.** Extend the override summary
+7. **`web/templates/partials/job_detail.html:31`.** Extend the override summary
     line: `{{if .SpecAssist}} · spec_assist={{deref .SpecAssist}}{{end}}` after
     the existing `spec_type` clause.
 
-11. **`internal/api/jobs_env.go`.** Add `SpecAssist` and the six assist values to
+8. **`internal/api/jobs_env.go`.** Add `SpecAssist` and the six assist values to
     the snapshot struct (near line 398), to the restore path (near line 669),
     and to the flag diff (near line 805) as
     `add("spec-assist", base.SpecAssist, merged.SpecAssist)` plus
@@ -144,7 +118,7 @@ fields to `ConfigOverrides`, so phase 04 is purely encoding and UI.
     `add("ngram-mod-n-match", …)`, `add("size-n", …)`, `add("size-m", …)`,
     `add("min-hits", …)`.
 
-12. **`internal/evaluate/evaluate.go:176`.** The comment lists the config fields
+9. **`internal/evaluate/evaluate.go:176`.** The comment lists the config fields
     the evaluation path deliberately ignores. Add `SpecAssist` and the assist
     parameters to that list — speculative decoding is excluded from capability
     evaluations, and the comment is the only record of why.
@@ -167,9 +141,10 @@ go vet ./...
   differs from the target and whose size is 90% of it, `mode: "draft"` returns
   nothing and `mode: "draft-eagle3"` returns it.
 - A `job_runner` round-trip test: `ConfigOverrides{SpecType: ptr("ngram-mod"),
-  DraftMax: ptr(64)}` — the shape a stored job holds — merges to a config that
-  emits `--spec-type ngram-mod --spec-ngram-mod-n-max 64`, unchanged from
-  before.
+  DraftMax: ptr(64)}` — the shape a stored job holds — merges to a snapshot that
+  launches as `--spec-type ngram-mod --spec-ngram-mod-n-max 64`, unchanged from
+  before. The snapshot itself keeps the legacy shape: it records what was
+  requested, and the launch path normalises.
 - Manually: open a saved benchmark job that used `ngram-mod` and confirm the
   job detail page still renders its override summary; re-run one cell and
   confirm the launched command is unchanged.

--- a/plan/speculative-multi-mode/phase-02-call-sites.md
+++ b/plan/speculative-multi-mode/phase-02-call-sites.md
@@ -1,0 +1,200 @@
+# Phase 02 — Downstream Go call sites
+
+**Depends on:** phase 01 · **Enables:** phases 03 and 04. Everything that reads
+`SpecType` as a single value learns about the second slot, and
+`ConfigOverrides` grows the fields the sweep will set.
+
+## Goal
+
+Phase 01 changed what `SpecType` means; this phase updates every consumer that
+compared it to a literal or assumed one mode. Three of those comparisons are
+now wrong rather than merely narrow: VRAM accounting only counts a draft head
+for `spec_type == "draft"`, so an EAGLE-3 head would be invisible to the
+placement estimate; the measured-memory load signature would treat two
+different assist settings as the same load; and the run comparison label would
+show only half of a combined configuration. This phase also relaxes
+`FindDraftCandidates` for the three head-based methods and adds the assist
+fields to `ConfigOverrides`, so phase 04 is purely encoding and UI.
+
+## Files touched
+
+- `internal/models/vram.go` — `AuxFilesVRAMGB` counts the draft head for all
+  five draft methods.
+- `internal/models/registry.go` — `FindDraftCandidates` takes the mode and
+  relaxes its filter for head-based methods.
+- `internal/api/vram_corpus.go` — the fixture emitter records the mode-agnostic
+  draft path.
+- `internal/api/memory_measured.go` — the load signature includes the assist
+  slot.
+- `internal/api/service.go` — pass the selected mode to `FindDraftCandidates`.
+- `internal/api/jobs_env.go` — snapshot, restore and diff the assist fields.
+- `internal/benchmark/job.go` — `ConfigOverrides` gains the assist pointers.
+- `internal/benchmark/job_runner.go` — apply them.
+- `internal/benchmark/benchmark.go` — `RunConfig` records them.
+- `internal/benchmark/compare_labels.go` — the speculative label shows both
+  slots.
+- `internal/evaluate/evaluate.go` — update the field list in the comment at
+  line 176.
+- `web/templates/partials/job_detail.html` — show the assist alongside the mode.
+- `internal/models/vram_test.go` — draft-head accounting for the new methods.
+- `internal/models/registry_test.go` — the relaxed `FindDraftCandidates` filter.
+- `internal/benchmark/job_runner_test.go` — the override round trip for a stored
+  job carrying the legacy shape.
+
+## Steps
+
+1. **`AuxFilesVRAMGB` (`internal/models/vram.go:253`).** Replace
+   `if cfg.SpecType == "draft" && cfg.DraftModelPath != ""` with
+   `if IsDraftMode(cfg.SpecType) && cfg.SpecType != "draft-mtp" && cfg.DraftModelPath != ""`
+   — unqualified, since `vram.go` and `specmodes.go` are both package `models`.
+   `draft-mtp` is excluded because its head is already counted from `MtpPath`
+   two lines above — so every draft method that loads a head still contributes
+   exactly once. The other four all load `DraftModelPath` through
+   `--model-draft`. The n-gram assist loads no file and adds nothing here —
+   state that in a comment so the omission reads as deliberate.
+
+2. **`FindDraftCandidates` (`internal/models/registry.go:1265`).** Change the
+   signature to `FindDraftCandidates(id, mode string)`. When
+   `IsHeadBasedDraftMode(mode)` is true, skip the architecture-match and the
+   40%-size checks — a converted EAGLE-3 / DFlash / DSpark head passes neither
+   — and keep only the embedding-model and MTP-head exclusions. For every other
+   mode the behaviour is exactly as today. Document why: the head is not a
+   smaller model of the same family, it is a trained extra layer, so the filter
+   that makes `draft` safe makes these three empty.
+
+3. **`internal/api/service.go:724`.** Pass `cfg.SpecType` to the new signature.
+
+4. **`internal/api/vram_corpus.go:184`.** The emitted fixture line currently
+   tests `SpecType == "draft"`. Use `models.IsDraftMode(cfg.SpecType)` so a
+   corpus entry captured under any draft method records its path. Regenerate no
+   fixtures — existing corpus files stay valid, since the condition only widens.
+
+5. **`internal/api/memory_measured.go:203`.** `memoryFingerprint` formats the
+   memory-relevant config fields into a readable string; extend its format with
+   `assist=%s/%d/%d/%d/%d/%d/%d` carrying `cfg.SpecAssist`, `cfg.AssistNMax`,
+   `cfg.AssistNMin`, `cfg.AssistNMatch`, `cfg.AssistSizeN`, `cfg.AssistSizeM`,
+   `cfg.AssistMinHits`, placed after the existing `spec=`/`draft=`/`mtp=`
+   entries. Without it, a measurement taken with the assist on is reported for a
+   launch with it off.
+
+   No version or salt is needed: the fingerprint is computed at load time and
+   compared against the current config in the same process, never persisted, so
+   there are no stale stored values to invalidate. The comment above the
+   function says so — leave it accurate.
+
+6. **`internal/benchmark/job.go`.** Add to `ConfigOverrides`, after
+   `NgramSizeM`:
+
+   ```go
+   SpecAssist    *string `json:"spec_assist,omitempty"`
+   AssistNMax    *int    `json:"assist_n_max,omitempty"`
+   AssistNMin    *int    `json:"assist_n_min,omitempty"`
+   AssistNMatch  *int    `json:"assist_n_match,omitempty"`
+   AssistSizeN   *int    `json:"assist_size_n,omitempty"`
+   AssistSizeM   *int    `json:"assist_size_m,omitempty"`
+   AssistMinHits *int    `json:"assist_min_hits,omitempty"`
+   ```
+
+   Keep `NgramSizeN` and `NgramSizeM` — stored jobs still carry them, and the
+   runner must keep honouring them.
+
+7. **`internal/benchmark/job_runner.go:848`.** Add the seven
+   `if overrides.X != nil { out.X = *overrides.X }` blocks alongside the
+   existing ones, then call `models.NormalizeSpec(&out)` once at the end of the
+   merge. That single call is what makes a stored job carrying
+   `spec_type: ngram-mod` produce the same launch as a new job carrying
+   `spec_assist: ngram-mod` — the tolerant read path, applied where history
+   actually enters the system.
+
+8. **`internal/benchmark/benchmark.go:153`.** Add the matching value fields to
+   `RunConfig` so a completed run records what it actually ran with.
+
+9. **`internal/benchmark/compare_labels.go:100`.** Replace
+   `func(r BenchmarkRun) string { return r.Config.SpecType }` with a helper that
+   joins the two slots the way the flag does:
+
+   ```go
+   func specLabel(c RunConfig) string {
+       switch {
+       case c.SpecType != "" && c.SpecAssist != "":
+           return c.SpecType + " + " + c.SpecAssist
+       case c.SpecType != "":
+           return c.SpecType
+       case c.SpecAssist != "":
+           return c.SpecAssist
+       }
+       return ""
+   }
+   ```
+
+   The `" + "` separator (not `","`) keeps the comparison table readable and
+   matches the `+` the sweep encoding uses in phase 04. Runs recorded before
+   this change have `SpecAssist` empty and a draftless name in `SpecType`, so
+   they keep rendering exactly as they did.
+
+10. **`web/templates/partials/job_detail.html:31`.** Extend the override summary
+    line: `{{if .SpecAssist}} · spec_assist={{deref .SpecAssist}}{{end}}` after
+    the existing `spec_type` clause.
+
+11. **`internal/api/jobs_env.go`.** Add `SpecAssist` and the six assist values to
+    the snapshot struct (near line 398), to the restore path (near line 669),
+    and to the flag diff (near line 805) as
+    `add("spec-assist", base.SpecAssist, merged.SpecAssist)` plus
+    `add("ngram-mod-n-max", …)`, `add("ngram-mod-n-min", …)`,
+    `add("ngram-mod-n-match", …)`, `add("size-n", …)`, `add("size-m", …)`,
+    `add("min-hits", …)`.
+
+12. **`internal/evaluate/evaluate.go:176`.** The comment lists the config fields
+    the evaluation path deliberately ignores. Add `SpecAssist` and the assist
+    parameters to that list — speculative decoding is excluded from capability
+    evaluations, and the comment is the only record of why.
+
+## Build gate
+
+```
+make build
+go test ./...
+go vet ./...
+```
+
+## Test plan
+
+- `internal/models/vram_test.go`: a config with `SpecType: "draft-eagle3"` and
+  a `DraftModelPath` pointing at a temp file of known size reports that size in
+  `AuxFilesVRAMGB`; the same config with `SpecAssist: "ngram-mod"` and no draft
+  method reports zero.
+- A `FindDraftCandidates` test: with a registered model whose architecture
+  differs from the target and whose size is 90% of it, `mode: "draft"` returns
+  nothing and `mode: "draft-eagle3"` returns it.
+- A `job_runner` round-trip test: `ConfigOverrides{SpecType: ptr("ngram-mod"),
+  DraftMax: ptr(64)}` — the shape a stored job holds — merges to a config that
+  emits `--spec-type ngram-mod --spec-ngram-mod-n-max 64`, unchanged from
+  before.
+- Manually: open a saved benchmark job that used `ngram-mod` and confirm the
+  job detail page still renders its override summary; re-run one cell and
+  confirm the launched command is unchanged.
+
+## Commit
+
+```
+refactor(spec): teach every SpecType consumer about the n-gram assist slot
+
+VRAM accounting counted a draft head only for spec_type=draft, so an EAGLE-3,
+DFlash or DSpark head was invisible to the placement estimate. The measured-
+memory load signature ignored the assist entirely, so a measurement taken with
+it on would be reused for a launch with it off. The comparison label showed
+half of a combined run.
+
+Relaxes FindDraftCandidates for the three head-based methods, whose heads
+match neither the architecture nor the size filter that makes the draft-model
+picker safe.
+```
+
+## Rollback
+
+Revert the commit. Safe to leave partially applied only if the
+`ConfigOverrides` field additions land with `job_runner`'s use of them —
+otherwise a job saved with assist overrides silently drops them at run time,
+which produces a mislabeled result rather than a visible failure. The
+memory-signature change invalidates previously measured entries by design; on
+revert they are simply measured again.

--- a/plan/speculative-multi-mode/phase-03-model-config-form.md
+++ b/plan/speculative-multi-mode/phase-03-model-config-form.md
@@ -1,0 +1,222 @@
+# Phase 03 — Model config form: two pickers
+
+**Depends on:** phases 01, 02 · **Enables:** users can actually build a combined
+configuration. Independent of phase 04, which does the same job for the
+benchmark surface.
+
+## Goal
+
+Replace the single Mode dropdown with two always-visible pickers — "Draft
+method" and "N-gram assist" — each with its own parameters underneath, an
+always-visible effective `--spec-type` line, and help copy that explains the one
+rule a user must understand to read their own results: when both are active the
+draftless method takes precedence for a step. Because the five draft methods
+live in one dropdown and the five n-gram methods in the other, selecting two
+draft methods is impossible, which is what keeps the open upstream startup crash
+([#27897](https://github.com/ggml-org/llama.cpp/issues/27897)) out of reach.
+
+## Files touched
+
+- `web/templates/partials/model_config.html` — the speculative decoding section
+  (lines 275–400) is rewritten; the help dialog above it gains a paragraph.
+- `internal/api/service.go` — form parsing for the two slots, and the template
+  data gains the mode lists and the effective `--spec-type` string.
+  `applyDraftDefaults` / `applyAssistDefaults` already exist from phase 01.
+- `internal/models/registry.go` — `ValidateSpec` joins `ValidateBatchSizes`
+  (line 247) and `ValidateFlashAttention` (line 270) as a `*ModelConfig` method.
+- `internal/api/service_test.go` — the three handler tests below.
+- `internal/models/registry_test.go` — `ValidateSpec` accepts a draft name in
+  `SpecType` and an assist name in `SpecAssist`, and rejects each in the other
+  slot.
+
+## Steps
+
+1. **Template data.** In the handler that renders the config form
+   (`internal/api/service.go` around line 788), add to the struct:
+   `DraftModes []models.SpecMode`, `AssistModes []models.SpecMode`,
+   `DraftParams []models.SpecModeParam`, `AssistParams []models.SpecModeParam`,
+   and `EffectiveSpecType string`. Fill them from `models.DraftModes()`,
+   `models.AssistModes()`, `models.SpecDraftParams(cfg.SpecType)`,
+   `models.SpecAssistParams(cfg.SpecAssist)`, and the joined mode names
+   (`""` when neither slot is set). `DraftCandidates` is already there; it now
+   comes from `FindDraftCandidates(id, cfg.SpecType)`.
+
+2. **The two pickers.** Replace the single `<select name="spec_type">` with:
+
+   ```
+   Draft method   [ Disabled | Draft Model | MTP (self-speculation)
+                    | EAGLE-3 | DFlash | DSpark ]
+   N-gram assist  [ None | N-gram Mod | N-gram Simple | N-gram Cache
+                    | N-gram Map-K | N-gram Map-K4V ]
+   ```
+
+   Both `<select>`s are rendered by ranging over `.DraftModes` / `.AssistModes`
+   so the labels come from `specmodes.go`. Keep the existing
+   `{{if not .DraftCandidates}} (no compatible models){{end}}` suffix on the
+   Draft Model option. Both are always visible — a user cannot discover the
+   combination if the second picker only appears after choosing the first.
+
+   Per the project's UI conventions, the explanation lives in each picker's
+   `title` tooltip rather than as static prose:
+   - Draft method: "A model or trained head proposes tokens that the main model
+     verifies in parallel. Only one may run at a time."
+   - N-gram assist: "Matches repeated text in the prompt and the generation so
+     far, and proposes the continuation. Costs no extra memory and runs
+     alongside the draft method. When both propose tokens for the same step,
+     the n-gram proposal is used."
+
+3. **Draft slot body.** Shown when the draft picker is not Disabled:
+   - The draft model picker (`draft_model_path`) for `draft` and for the three
+     head-based methods. Its tooltip differs for the head-based ones: "The
+     converted EAGLE-3 / DFlash / DSpark head for this model. The list is not
+     filtered by architecture or size, because a head is a trained extra layer
+     rather than a smaller model of the same family."
+   - The MTP drafter head path and the Load MTP Head switch, unchanged, for
+     `draft-mtp` with `.HasMTP`.
+   - The parameters, rendered by ranging over `.DraftParams` so the fields and
+     their placeholders come from `SpecDraftParams`. For the three new methods
+     every default is empty, so each field shows llama.cpp's own default as its
+     placeholder ("3", "0", and blank).
+   - The draft-model resource block (ctx size, GPU layers, device, CPU MoE, KV
+     cache quant), shown whenever a `--model-draft` will actually be emitted:
+     `draft`, any head-based method with a path set, or `draft-mtp` with
+     `.HasMTP`.
+   - The existing MTP + parallel warning and the gemma-4 build note, unchanged,
+     under `draft-mtp`.
+
+4. **Assist slot body.** Shown when the assist picker is not None: range over
+   `.AssistParams` (the selected assist mode's parameters — a flat
+   `[]models.SpecModeParam`; phase 04's `SweepChoice.AssistParamsByMode` is a
+   different, per-mode-keyed thing with a deliberately different name). For `ngram-mod` that is Draft tokens max / Draft tokens min
+   / Match length; for `ngram-simple`, `ngram-map-k` and `ngram-map-k4v` it is
+   Lookup size / Draft size / Minimum hits; `ngram-cache` renders nothing and
+   shows the line "This mode takes no settings." The m-gram field no longer
+   appears under `ngram-mod` at all — it was meaningless there.
+
+   Field names are `assist_n_max`, `assist_n_min`, `assist_n_match`,
+   `assist_size_n`, `assist_size_m`, `assist_min_hits`.
+
+5. **Effective flags line.** Below both slots, always visible (not a tooltip, not
+   revealed on hover):
+
+   ```
+   Effective --spec-type: draft-mtp,ngram-mod
+   ```
+
+   When both slots are empty the line reads "Speculative decoding is off — no
+   `--spec-type` flag is passed." It must not print `none`: that is a real
+   llama.cpp value which discards every other mode in a list, the launch never
+   emits it, and showing it here would teach the wrong thing. This line is the
+   one place a user can see the comma-joined list they built, and the thing to
+   quote when a launch fails.
+
+6. **Re-rendering on change needs no new markup.** The config form already
+   carries `hx-trigger="submit, change delay:500ms"`
+   (`web/templates/partials/model_config.html:11`), so a change to either
+   `<select>` re-posts the form and the server re-renders the partial with the
+   right parameter fields. Add no `hx-post` or `hx-trigger` attributes to the
+   selects, and leave the 500 ms delay alone: it debounces, so changing both
+   pickers inside the window posts once carrying both values, which is the
+   behaviour we want rather than a problem to work around.
+
+7. **Form parsing (`internal/api/service.go`, around line 922).** Track the
+   previous value of each slot separately:
+
+   ```go
+   prevSpecType, prevSpecAssist := cfg.SpecType, cfg.SpecAssist
+   cfg.SpecType   = r.FormValue("spec_type")
+   cfg.SpecAssist = r.FormValue("spec_assist")
+   ```
+
+   Parse the three draft parameters as today, and the six assist parameters the
+   same way (`Atoi`, `> 0`, else zero). Then:
+
+   ```go
+   if cfg.SpecType != prevSpecType     { applyDraftDefaults(cfg) }
+   if cfg.SpecAssist != prevSpecAssist { applyAssistDefaults(cfg) }
+   ```
+
+   Both functions already exist from phase 01 step 6 and are unchanged here.
+   Remove the `models.NormalizeSpec(cfg)` call phase 01 put in this parser, and
+   remove the `ngram_size_n` / `ngram_size_m` parsing — the form now posts the
+   two slots and the six `assist_*` names directly, and can no longer put a
+   draftless name in `spec_type` or a value in a legacy field. `NormalizeSpec`
+   stays in `specDecodingParams` and in the benchmark merge path, where stored
+   history still arrives in the old shape.
+
+8. **Validation.** Add `func (c *ModelConfig) ValidateSpec() error` to
+   `internal/models/registry.go`, beside `ValidateBatchSizes` (line 247) and
+   `ValidateFlashAttention` (line 270), and call `cfg.ValidateSpec()` alongside the existing
+   `ValidateBatchSizes` / `ValidateFlashAttention` calls: reject a `spec_type`
+   that is not empty and not a draft mode, and a `spec_assist` that is not empty
+   and not an assist mode. The UI cannot produce either, but a hand-edited
+   registry or a crafted POST can, and an unknown name is a hard llama-server
+   startup failure with a message the user will not connect to this form.
+
+9. **Help dialog.** Add a section to the existing dialog above the section:
+
+   > **Running both at once.** A draft method and an n-gram assist can run
+   > together. They cost each other nothing on new text, and on text the model
+   > is repeating — a file it is rewriting, a structured response, a tool-call
+   > loop — the n-gram assist is much faster than a draft model alone.
+   >
+   > When both propose tokens for the same step, the n-gram proposal is the one
+   > that gets used. That is worth knowing when you read a benchmark result: if
+   > a combined run is slower than the draft method alone on new text, it is
+   > because low-quality n-gram matches are displacing good draft proposals. The
+   > benchmark sweep is how you find out.
+
+   Plain language, no slang, and it explains how to read the number rather than
+   only what the setting does.
+
+## Build gate
+
+```
+make build
+go test ./internal/models/... ./internal/api/...
+go vet ./...
+```
+
+## Test plan
+
+- A handler test posting `spec_type=draft-mtp`, `draft_max=3`,
+  `spec_assist=ngram-mod`, `assist_n_max=64`, `assist_n_min=48`,
+  `assist_n_match=24` saves a config whose `EffectiveFlags()` contains
+  `--spec-type draft-mtp,ngram-mod`.
+- A handler test that changing only `spec_assist` on an existing config leaves
+  `DraftMax` untouched — the regression `applySpecDefaults` would have caused.
+- A handler test posting `spec_type=ngram-mod` returns 400 from
+  `ValidateSpec`.
+- Manually, in the browser: select MTP, confirm the three draft fields appear
+  with 6/0/blank; select EAGLE-3, confirm they appear empty with placeholders
+  3/0 and the draft model list is no longer filtered; select N-gram Mod as the
+  assist and confirm Match length appears and the m-gram field does not;
+  confirm the effective line reads `draft-mtp,ngram-mod`; save, and check the
+  generated preset INI has one `spec-type` line.
+- Confirm a model migrated in phase 01 opens with Draft method on Disabled and
+  N-gram assist on N-gram Mod, its parameters intact.
+
+## Commit
+
+```
+feat(ui): pick a draft method and an n-gram assist independently
+
+The speculative decoding section now has two pickers instead of one. The five
+draft methods live in the first and the five n-gram methods in the second, so
+two draft methods cannot both be selected -- the combination that crashes
+llama-server at startup upstream.
+
+Changing one slot no longer resets the other's tuned values, and the effective
+--spec-type value is shown so a failing launch can be read off the form. Help
+copy explains that the n-gram proposal wins a contested step, which is what a
+combined benchmark result has to be read against.
+```
+
+## Rollback
+
+Revert the commit. The template and handler change together; reverting either
+alone leaves the form posting fields the handler ignores (values silently lost
+on save) or reading fields the form never posts (values silently zeroed). Config
+data written by this phase is the same shape phase 01 established, so a revert
+to phase 02 keeps every saved config launchable — only the form loses the second
+picker.

--- a/plan/speculative-multi-mode/phase-04-benchmark-axis.md
+++ b/plan/speculative-multi-mode/phase-04-benchmark-axis.md
@@ -8,8 +8,10 @@ the project.
 
 Extend the `spec_type` sweep axis so a cell can name a draft method, an n-gram
 assist, or both, with each slot's parameters. The encoded form joins the two
-mode names with `+` and keeps `,` between parameters, because the field's
-`Separator` is already `","` and the sweep splits value lists on it. In the job
+mode names with `+` and keeps `,` between parameters, because `,` already
+separates the parameters inside a value. (The field's own value separator is
+`";"` — it already had to be, for that same reason. The source report said `","`
+and that is wrong.) In the job
 form, each draft-method choice's expandable section gains an "N-gram assist"
 dropdown and the assist's parameter fields. Eleven choices (five draft methods, five n-gram
 methods, and off) then reach thirty-six values: off, each mode alone, and all
@@ -176,7 +178,7 @@ way in.
     checkbox, so old jobs restore unchanged.
 
 12. **Cell-count estimate.** No change needed: the field's `Separator` is still
-    `","`, and `+` appears only inside a single value. Add a case to the JS
+    `";"`, and `+` appears only inside a single value. Add a case to the JS
     tests that pins this, because it is exactly the kind of thing a later
     separator change would break silently.
 

--- a/plan/speculative-multi-mode/phase-04-benchmark-axis.md
+++ b/plan/speculative-multi-mode/phase-04-benchmark-axis.md
@@ -1,0 +1,248 @@
+# Phase 04 — Benchmark sweep axis and job form
+
+**Depends on:** phases 01, 02 · **Enables:** phase 06. This is what makes the
+combination measurable rather than argued about, and it is the fiddliest part of
+the project.
+
+## Goal
+
+Extend the `spec_type` sweep axis so a cell can name a draft method, an n-gram
+assist, or both, with each slot's parameters. The encoded form joins the two
+mode names with `+` and keeps `,` between parameters, because the field's
+`Separator` is already `","` and the sweep splits value lists on it. In the job
+form, each draft-method choice's expandable section gains an "N-gram assist"
+dropdown and the assist's parameter fields. Eleven choices (five draft methods, five n-gram
+methods, and off) then reach thirty-six values: off, each mode alone, and all
+twenty-five draft-plus-assist pairs. Keeping the list short matters because
+`spec_type` is registered without a custom-entry box, so the list is the only
+way in.
+
+## Files touched
+
+- `internal/benchmark/sweep.go` — `specValue`, `parseSpecValue`,
+  `applySpecValue`, `encodeSpecValue`, `canonicalSpecValue`, and the
+  `spec_type` choices table.
+- `internal/benchmark/sweep_test.go` — round-trip and rejection cases.
+- `web/templates/partials/job_form.html` — the assist sub-picker inside a
+  choice's settings block.
+- `web/templates/benchmarks.html` — `updateSpecValue` and `addParamValue`
+  handle two slots; the live cell-count estimate keeps splitting on `,`.
+- `web/jstest/dom.js`, `web/jstest/params_test.js` — fixtures and assertions
+  for the new value shape.
+
+## Steps
+
+1. **Encoding.** The accepted shapes become:
+
+   ```
+   none                                          speculative decoding off
+   draft-mtp                                     draft method, inherit params
+   draft-mtp:draft_max=3                         draft method with params
+   ngram-mod:assist_n_max=64                     assist alone
+   draft-mtp+ngram-mod                           both, inherit params
+   draft-mtp+ngram-mod:draft_max=3,assist_n_max=64,assist_n_match=24
+   ```
+
+   Parameter keys are globally unique across the two slots
+   (`draft_*` vs `assist_*`), so one flat `key=value` list after the single `:`
+   still works and no per-mode grouping is needed. The mode part is split on
+   `+`; at most two segments, at most one from `DraftModes()` and at most one
+   from `AssistModes()`.
+
+2. **`specValue`** grows a second mode field:
+
+   ```go
+   type specValue struct {
+       mode   string            // draft method, "" if none
+       assist string            // n-gram assist, "" if none
+       params map[string]string // draft_* and assist_* keys
+   }
+   ```
+
+   The raw value `"none"` parses to both fields empty and an empty map — the
+   same representation the current parser produces for it, and the reason
+   `applySpecValue` can write two empty slot pointers without a special case.
+
+3. **`parseSpecValue`.** Keep the existing `if v == "none"` early return at the
+   top, before any splitting: `none` is the choices table's off entry and is
+   never a mode name, so the mode-name validation below must not see it. Then,
+   after `strings.Cut(v, ":")`, split the mode part on `"+"`. Reject more than two segments; reject two draft modes with
+   `"%q and %q are both draft methods; only one can run at a time"`; reject two
+   assist modes with the matching message; reject a segment that is neither with
+   the existing `"%q is not a speculative decoding mode"`. Build the allowed-key
+   set from `models.SpecDraftParams(mode)` plus
+   `models.SpecAssistParams(assist)` so a key belonging to a slot the value does
+   not use is rejected — `draft-mtp:assist_n_max=64` is a mistake worth catching
+   at parse time rather than silently dropping. Keep the existing per-key type
+   check: `draft_p_min` parses as a float, everything else as an integer.
+
+4. **`applySpecValue`.** Write `o.SpecType = &sv.mode` and
+   `o.SpecAssist = &sv.assist` — both always, including when empty, since an
+   explicitly empty slot in a swept value means "off for this cell", not
+   "inherit". Extend the key switch with the six assist keys onto the pointers
+   phase 02 added.
+
+5. **`encodeSpecValue`.** Change the signature to
+   `encodeSpecValue(mode, assist string, params []models.SpecModeParam) string`.
+   Join the non-empty mode names with `+`, then append `":"` and the non-empty
+   parameter defaults joined with `","`. A choice with no parameters at all
+   encodes to the bare mode string, as today.
+
+6. **`canonicalSpecValue`.** Render `mode`, then `"+"+assist` if set, then the
+   sorted `key=value` list — so `draft-mtp+ngram-mod:assist_n_max=64,draft_max=3`
+   and the same value with the pairs reversed dedup to one cell. An unparseable
+   value still returns the trimmed raw string for the parser to reject with a
+   real message later.
+
+7. **Choices table** (`sweep.go:655`). Rebuild it from `specmodes.go` so the
+   labels cannot drift from the config form:
+
+   ```
+   none            Off (no speculative decoding)
+   draft           Draft Model
+   draft-mtp       MTP (self-speculation)
+   draft-eagle3    EAGLE-3
+   draft-dflash    DFlash
+   draft-dspark    DSpark
+   ngram-mod       N-gram Mod
+   ngram-simple    N-gram Simple
+   ngram-cache     N-gram Cache
+   ngram-map-k     N-gram Map-K
+   ngram-map-k4v   N-gram Map-K4V
+   ```
+
+   Eleven entries: five draft, five assist, and off. The post-registration loop
+   that attaches `Params` and `Mode` to each choice now attaches
+   `SpecDraftParams` to a draft choice and `SpecAssistParams` to an assist
+   choice, and sets a new `SweepChoice.Slot` field (`"draft"` or `"assist"`) so
+   the template knows whether to render the assist sub-picker.
+
+8. **`SweepChoice`** gains `Slot string` and `AssistModes []models.SpecMode`
+   (populated only on draft choices, so the template can render the dropdown
+   without a template-side call), plus
+   `AssistParamsByMode map[string][]models.SpecModeParam`
+   keyed by assist mode name so every assist mode's fields can be rendered
+   hidden and revealed by the dropdown — the choices are rendered once, server
+   side, and the browser only re-encodes.
+
+9. **Job form template** (`web/templates/partials/job_form.html:150`). Inside
+   `<details class="spec-params">`, after the existing parameter inputs, and
+   only when `.Slot` is `"draft"`:
+
+   ```html
+   <label class="spec-param" title="Runs alongside the draft method. Costs no
+          extra memory. When both propose tokens for the same step, the n-gram
+          proposal is used.">
+     <small>N-gram assist</small>
+     <select class="spec-assist-select" onchange="updateSpecValue(this)">
+       <option value="">None</option>
+       {{range .AssistModes}}<option value="{{.Name}}">{{.Label}}</option>{{end}}
+     </select>
+   </label>
+   {{range $mode, $params := .AssistParamsByMode}}
+   <div class="spec-assist-params" data-assist="{{$mode}}" hidden>
+     {{range $params}}
+     <label class="spec-param" title="Clear the field to use the model's saved value.">
+       <small>{{.Label}}</small>
+       <input type="text" inputmode="decimal" class="spec-param-input"
+              data-key="{{.Key}}" value="{{.Default}}"
+              placeholder="model's saved value" oninput="updateSpecValue(this)">
+     </label>
+     {{end}}
+   </div>
+   {{end}}
+   ```
+
+   Toggle the blocks with `el.hidden`, and have `updateSpecValue` skip inputs
+   inside a hidden block so a non-selected assist's defaults never reach the
+   encoded value.
+
+10. **`updateSpecValue`** (`benchmarks.html:430`). Read the box's `data-mode` as
+    today, then read `.spec-assist-select` if present. Show the matching
+    `.spec-assist-params` block and hide the rest. Collect pairs from every
+    `.spec-param-input` that is not inside a hidden block. Build
+    `mode + (assist ? "+" + assist : "") + (pairs.length ? ":" + pairs.join(",") : "")`.
+    The rest of the function — find the checkbox by `data-mode`, set its value,
+    check it, `syncParamRow`, `updateMatrixCount` — is unchanged.
+
+11. **`addParamValue`** (`benchmarks.html:488`). This is the restore path when a
+    saved job is edited, and today it takes `raw.split(':')[0]` as the mode.
+    Split that on `"+"`: the segment matching a checkbox's `data-mode` selects
+    the checkbox; the other segment, if any, is set on that choice's
+    `.spec-assist-select` and its params block revealed before the `key=value`
+    pairs are distributed. Distribute each pair to whichever input carries that
+    `data-key`, in the draft block or the revealed assist block. A saved job
+    holding a bare `ngram-mod` value still matches the `ngram-mod` choice's own
+    checkbox, so old jobs restore unchanged.
+
+12. **Cell-count estimate.** No change needed: the field's `Separator` is still
+    `","`, and `+` appears only inside a single value. Add a case to the JS
+    tests that pins this, because it is exactly the kind of thing a later
+    separator change would break silently.
+
+13. **JS tests** (`web/jstest/`). In `dom.js`, extend the `spec_type` row
+    fixture with an assist select and an assist params block on the `draft-mtp`
+    choice. In `params_test.js`:
+    - `spec_type` still has no custom box (the existing assertion, kept).
+    - Editing an assist parameter produces
+      `draft-mtp+ngram-mod:draft_max=3,assist_n_max=64`.
+    - Setting the assist select back to None drops the `+ngram-mod` segment and
+      the `assist_*` pairs.
+    - A saved value `draft-mtp+ngram-mod:draft_max=3,assist_n_max=64` restores
+      onto the checkbox, the assist select and both inputs.
+    - A saved bare `ngram-cache` value still survives a round trip (the existing
+      assertion, kept).
+
+## Build gate
+
+```
+make build
+make js-test
+go test ./internal/benchmark/...
+go vet ./...
+```
+
+## Test plan
+
+- Go round-trip tests in `sweep_test.go`: every shape in step 1 parses, encodes
+  back to itself under `canonicalSpecValue`, and applies to the expected
+  `ConfigOverrides` pointers.
+- Rejection tests: `draft+draft-mtp`, `ngram-mod+ngram-simple`,
+  `draft-mtp+ngram-mod+ngram-simple`, `draft-mtp:assist_n_max=64`,
+  `ngram-mod:draft_p_min=0.5`, and `draft-mtp:draft_max=abc` each return an
+  error naming the problem.
+- `none` never appears in an emitted value, and a value with an empty draft slot
+  encodes as `ngram-mod…` rather than `none+ngram-mod` — the poison-value rule
+  from `common_speculative_types_from_names`.
+- Manually: build a job with MTP checked and its assist set to N-gram Mod, plus
+  MTP checked with assist None — confirm the cell count reads 2, submit, and
+  confirm the two cells launch with and without `,ngram-mod` in `--spec-type`.
+  Then edit the saved job and confirm both values restore into the form
+  unchanged.
+
+## Commit
+
+```
+feat(benchmarks): sweep a draft method and an n-gram assist together
+
+spec_type sweep values now name both slots, joined with "+" so the field's
+existing "," separator keeps splitting value lists:
+draft-mtp+ngram-mod:draft_max=3,assist_n_max=64. Parameter keys are unique
+across the two slots, so one flat key=value list still covers both.
+
+Each draft-method choice in the job form gains an n-gram assist dropdown with
+that mode's own settings. Eleven choices then reach thirty-six values -- off,
+each mode alone, and all twenty-five draft-plus-assist pairs -- without growing
+a choices list that has no custom-entry box to fall back on. The five draft
+methods and five n-gram methods replace the eight choices offered before.
+```
+
+## Rollback
+
+Revert the commit. A benchmark job saved with a combined value becomes
+unparseable on the reverted build — `parseSpecValue` rejects
+`draft-mtp+ngram-mod` with "is not a speculative decoding mode" — so such a job
+fails to load rather than running the wrong thing, which is the right failure.
+Delete or edit those jobs before reverting. Jobs saved before this phase are
+unaffected. Safe to leave the Go half applied without the template half: the
+parser accepts more shapes than the form can produce.

--- a/plan/speculative-multi-mode/phase-05-echo-preset.md
+++ b/plan/speculative-multi-mode/phase-05-echo-preset.md
@@ -1,0 +1,156 @@
+# Phase 05 — An echo-heavy benchmark preset
+
+**Depends on:** nothing (independent of phases 01–04; must land before phase 06)
+· **Enables:** phase 06. Without it the validation sweep can only measure the
+half of the claim where the combination changes nothing.
+
+## Goal
+
+Every internal benchmark preset builds its prompt with `buildPromptFor`
+(`internal/benchmark/runner.go:395`), which repeats a fixed prose passage and
+prefixes it with *"Please analyze the following text carefully and provide a
+detailed response."* The model then generates novel prose. That is the workload
+where an n-gram assist does nothing at all — `ngram-mod` alone measured exactly
+baseline (30.03 vs 30.03 tokens/second) in the source report's table.
+
+The whole case for combining modes rests on the other workload: text the model
+has already seen and is reproducing, where the same table shows 324 against 82
+tokens/second. Nothing in the toolchest currently produces that workload, so the
+4× claim cannot be checked on this hardware. This phase adds a prompt style that
+asks the model to reproduce its input verbatim, and an `internal-echo` preset
+that uses it. It is useful well beyond this project: it makes every future
+n-gram change measurable instead of assumed.
+
+## Files touched
+
+- `internal/benchmark/runner.go` — a `PromptStyle` type, an echo prefix
+  template, `buildPromptFor` takes the style, and the call chain threads it.
+- `internal/benchmark/benchmark.go` — `Preset` gains `PromptStyle`; the
+  `internal-echo` preset is added to `Presets()`.
+- `internal/api/bench_about.go` — the About modal discloses both prefixes.
+- `web/templates/partials/bench_about.html` — render both.
+- `internal/benchmark/runner_test.go` — prompt construction tests.
+
+## Steps
+
+1. **Prompt style.** In `runner.go`, next to the existing constants:
+
+   ```go
+   // PromptStyle selects the instruction wrapped around the benchmark
+   // passage. The two styles produce opposite generation workloads, which
+   // is the point: an n-gram speculative method is worth nothing on
+   // PromptStyleAnalyze and worth several times baseline on
+   // PromptStyleEcho.
+   type PromptStyle string
+
+   const (
+       PromptStyleAnalyze PromptStyle = ""      // default; existing behaviour
+       PromptStyleEcho    PromptStyle = "echo"
+   )
+
+   // BenchPromptEchoPrefixTemplate asks the model to reproduce the passage
+   // rather than respond to it, so generation is recall of text already in
+   // the context. Exposed so the About modal can show the actual template.
+   const BenchPromptEchoPrefixTemplate = "This is benchmark repetition number %d. Reproduce the following text exactly, character for character, with no commentary.\n\n"
+   ```
+
+2. **`buildPromptFor`** takes a `style PromptStyle` parameter and selects the
+   prefix template from it. Everything else is unchanged and must stay
+   unchanged: the nonce-and-size line still goes first, before the shared
+   boilerplate, so two prompts diverge within the first few tokens. That
+   discipline matters more here, not less — an echo prompt is by construction
+   the most cacheable thing the benchmark sends, and a cached prefill would
+   report a meaningless number as a measurement, which is the exact failure the
+   existing comment at line 380 documents.
+
+   Update `buildPrompt` (the nonce-free warmup form) to pass
+   `PromptStyleAnalyze`.
+
+3. **Thread the style** through `sendCompletionWithTimings` → `runOneTest` →
+   the loop at `runner.go:236`, which already has `cfg.Preset` in hand and
+   passes `cfg.Preset.GenTokens`. Pass `cfg.Preset.PromptStyle` the same way.
+   `sendCompletion` (warmup) passes `PromptStyleAnalyze`.
+
+4. **`Preset` gains `PromptStyle PromptStyle`.** Every existing preset leaves it
+   zero, which is `PromptStyleAnalyze` — no existing preset changes behaviour,
+   and no stored result is invalidated.
+
+5. **Add the preset** to `Presets()`, after `internal-standard`:
+
+   ```go
+   {
+       Name:  "internal-echo",
+       Label: "internal-echo — 3 reps × 2048-token prompt, 512 gen, recall workload (~2 min)",
+       Description: "Three repetitions of a 2048-token prompt asking the model to reproduce the passage verbatim, with 512 generated tokens. Generation is recall of text already in the context rather than new prose, which is the workload where n-gram speculative decoding pays off: a file being rewritten, a structured response, a tool-call loop. Compare against internal-standard, whose prompts ask for new text, to see what a speculative setting costs and what it earns.",
+       Source:       PresetSourceInternal,
+       PromptTokens: []int{2048}, GenTokens: 512, Repetitions: 3,
+       PromptStyle:  PromptStyleEcho,
+   },
+   ```
+
+   2048 prompt tokens gives roughly 8000 characters of passage to echo, and 512
+   generated tokens is comfortably inside it, so the model is reproducing
+   throughout the measured window rather than running out of source text and
+   drifting into invention.
+
+6. **About modal.** `AboutBenchmarks.InternalPrompt` currently carries one
+   `RepetitionPrefix`. Add `EchoPrefix` beside it, filled from
+   `benchmark.BenchPromptEchoPrefixTemplate`, and render both in
+   `bench_about.html` under labels "Analysis prefix (most internal presets)" and
+   "Recall prefix (internal-echo)". The modal exists so a reader can see exactly
+   what was sent; one preset sending something different and the modal not
+   saying so would undo that.
+
+## Build gate
+
+```
+make build
+go test ./internal/benchmark/... ./internal/api/...
+go vet ./...
+```
+
+## Test plan
+
+- `runner_test.go`: `buildPromptFor("n", 2048, 1, PromptStyleEcho)` contains the
+  echo instruction and not the analyze instruction, and vice versa for
+  `PromptStyleAnalyze`.
+- Two prompts differing only in style, or only in nonce, or only in target size,
+  differ within their first 80 characters — the existing cache-defeating
+  property, re-pinned now that a second template exists.
+- Length is still `targetTokens * BenchPromptCharsPerToken` for both styles.
+- Manually: run `internal-echo` against a model with speculative decoding off,
+  and confirm from the response that the generation is in fact reproducing the
+  passage rather than commenting on it. A model that refuses or paraphrases
+  makes the preset useless for its purpose, so check this before phase 06 —
+  if it happens, tighten the instruction rather than changing the measurement.
+- Confirm `prompt_n` in the results is near 2048 and does not collapse across
+  repetitions, which would mean the prompt cache is being hit.
+
+## Commit
+
+```
+feat(benchmarks): add internal-echo, a recall-workload preset
+
+Every internal preset asks the model to analyze a passage, so generation is
+always new prose -- the workload where n-gram speculative decoding measures
+exactly baseline. The workload where it pays off, text the model is
+reproducing, had no preset at all, so the setting's main benefit could not be
+measured here.
+
+internal-echo asks the model to reproduce the passage verbatim, keeping the
+same nonce and sizing machinery so the prompt cache stays defeated. The About
+modal now shows both prompt prefixes.
+```
+
+## Rollback
+
+Revert the commit, then delete any benchmark run recorded under
+`internal-echo`. Those runs keep their preset name, which no longer resolves, so
+`GetPreset` falls back to `internal-standard` and would present a recall
+measurement under a new-text label — a mislabeled result, which is the failure
+this package guards against everywhere else. Deleting them is the fix; do not
+try to keep the preset definition around to make them resolve, because it would
+then resolve to a preset that no longer runs the workload it names. Safe to leave partially
+applied only with the `PromptStyle` field and the preset landing together; the
+field defaulting to the analyze style means a half-applied state runs the wrong
+workload under the right name.

--- a/plan/speculative-multi-mode/phase-06-validation.md
+++ b/plan/speculative-multi-mode/phase-06-validation.md
@@ -1,0 +1,125 @@
+# Phase 06 — Measure the combination on this hardware
+
+**Depends on:** phases 01, 02, 03, 04, 05 · **Enables:** nothing further. This
+is the phase that turns the project's central claim into a local number.
+
+## Goal
+
+Run the C1-vs-C7 comparison from the source report on this machine, using the
+benchmark surface phases 04 and 05 built, and write the result into this plan
+folder. Two questions get answered: does the n-gram assist cost anything on new
+text (the report's unresolved ~4 tokens/second regression), and how much does it
+earn on recall (the report's 4×). No code is written in this phase.
+
+## Files touched
+
+- `plan/speculative-multi-mode/results.md` — **new**. The numbers, the exact job
+  configuration, and what they mean. This is the only file this phase writes.
+
+## Steps
+
+1. **The model is `unsloth--Qwen3.5-9B-MTP-GGUF--Qwen3.5-9B-UD-Q8_K_XL`.** It is
+   the largest model installed on this machine that carries an MTP head
+   (12.3 GiB), so generation is the bottleneck — the condition under which
+   speculative decoding matters at all. Its MTP head is baked into the main
+   GGUF, so `draft-mtp` runs as self-speculation with no separate head file,
+   which is the configuration the report's C1 and C7 rows used. Record the build
+   ID and the GPU configuration in `results.md` alongside it; a throughput
+   number without them is not reusable.
+
+2. **Build the job.** One benchmark job, one model, one build, sweeping two
+   axes:
+
+   - **Preset:** `internal-standard` (new text) and `internal-echo` (recall).
+   - **spec_type:** four values —
+     - `none` (the report's C0 row)
+     - `draft-mtp:draft_max=3` (C1)
+     - `ngram-mod:assist_n_max=64,assist_n_min=48,assist_n_match=24` (C5)
+     - `draft-mtp+ngram-mod:draft_max=3,assist_n_max=64,assist_n_min=48,assist_n_match=24` (C7)
+
+   Eight cells. The `draft_max=3` matches the report's C1/C7 rows rather than
+   the toolchest's own MTP default of 6, so the numbers are comparable to the
+   table the project was justified on. The C5 row is not optional: n-gram alone
+   should sit at baseline under `internal-standard` and near the combined value
+   under `internal-echo`, and that is the cheapest available check that the echo
+   preset is really producing a recall workload rather than something the model
+   is inventing.
+
+3. **Sanity-check before trusting anything.** In the completed job's results,
+   confirm for every cell that the recorded prompt-token count — llama.cpp's
+   `timings.prompt_n`, stored as `prompt_tokens` on each result — is close to
+   the nominal 2048 and does not collapse between repetitions. A collapsed
+   count means the prompt cache was hit and the throughput figure is
+   meaningless: the failure the nonce machinery exists to prevent, and the one
+   to rule out first.
+
+4. **Read the two rows.** The result is one of three, and each says something
+   different:
+
+   - **Combined ≈ MTP alone on `internal-standard`, and much faster on
+     `internal-echo`.** The report's finding reproduces. Nothing changes.
+   - **Combined slower than MTP alone on `internal-standard` beyond the run-to-
+     run error bar.** The report predicted this is possible and explained it:
+     the draftless method wins a contested step, so a poor n-gram match displaces
+     a good MTP draft. Record the size of the cost against the size of the echo
+     gain. This does not change the feature — it is a per-workload tuning
+     decision, and the point of building it as an independent slot is that a
+     user can turn it off for one model and on for another.
+   - **Combined no faster on `internal-echo`.** Then either the preset is not
+     producing recall (check step 3 and the actual generated text) or the assist
+     is not reaching llama-server (check the launched command line in the job
+     detail's flag diff for `--spec-type draft-mtp,ngram-mod`). Fix the cause
+     before recording anything; this outcome is a bug report, not a result.
+
+5. **Write `results.md`.** Model, quantization, build ID, GPU configuration,
+   date. The eight-cell table with generation tokens/second and its error bar
+   per cell. Three sentences on which of the three readings above occurred. If the
+   combination costs anything on new text, state the number plainly — the
+   project's own value section says making it measurable was the goal, so a
+   negative number is a result, not a failure.
+
+6. **Leave the help copy alone.** Phase 03's help dialog already tells the user
+   that a combined run can be slower on new text and that the sweep is how they
+   find out. That statement is true whichever way this measurement lands, so it
+   is not edited here — the measured figure goes in `results.md` and nowhere
+   else. This phase writes no code and changes no template.
+
+## Build gate
+
+No code changes, so no build gate. The gate is the job itself:
+
+```
+# in the UI: Benchmarks → New job, configured as in step 2 (8 cells)
+# every cell must reach "completed"; a failed cell means llama-server
+# refused the flags, which is a phase 01–04 bug, not a result
+```
+
+## Test plan
+
+- All eight cells complete. A failed cell is a defect in an earlier
+  phase — read the cell's error, which surfaces llama-server's own startup
+  message.
+- The `none` cell's generation throughput matches this machine's known baseline
+  for that model. If it does not, the measurement environment is wrong and
+  nothing else in the table can be trusted.
+- The `ngram-mod` alone cell sits at baseline on `internal-standard`. This is
+  the strongest available signal that the two presets really are producing
+  opposite workloads.
+- The compare table labels the combined cell distinguishably from the MTP-alone
+  cell — the `specLabel` helper from phase 02, seen in use.
+
+## Commit
+
+```
+docs(plan): record the measured cost and benefit of the n-gram assist
+
+Runs the C1-vs-C7 comparison from the design report on this hardware, across
+internal-standard (new text) and internal-echo (recall), with speculative
+decoding off, MTP alone, n-gram alone, and both.
+```
+
+## Rollback
+
+Nothing to roll back — the phase adds one document and runs a benchmark job. If
+the numbers turn out to be wrong, delete the job and `results.md` and re-run;
+stored benchmark runs are independent of every other phase.

--- a/plan/speculative-multi-mode/phase-06-validation.md
+++ b/plan/speculative-multi-mode/phase-06-validation.md
@@ -18,13 +18,21 @@ earn on recall (the report's 4×). No code is written in this phase.
 
 ## Steps
 
-1. **The model is `unsloth--Qwen3.5-9B-MTP-GGUF--Qwen3.5-9B-UD-Q8_K_XL`.** It is
-   the largest model installed on this machine that carries an MTP head
-   (12.3 GiB), so generation is the bottleneck — the condition under which
-   speculative decoding matters at all. Its MTP head is baked into the main
-   GGUF, so `draft-mtp` runs as self-speculation with no separate head file,
-   which is the configuration the report's C1 and C7 rows used. Record the build
-   ID and the GPU configuration in `results.md` alongside it; a throughput
+1. **The model is `unsloth--Qwen3.5-9B-MTP-GGUF--Qwen3.5-9B-IQ4_NL`** (5.3 GiB).
+   Its MTP head is baked into the main GGUF, so `draft-mtp` runs as
+   self-speculation with no separate head file — the configuration the report's
+   C1 and C7 rows used — and it is already configured that way here.
+
+   Not the 12.3 GiB `UD-Q8_K_XL` from the same repo, despite generation being
+   more clearly the bottleneck on a larger model: GPU 0 is a Radeon RX 9070 XT
+   with 15.9 GiB total and about 2.4 GiB already in use, so a 12.3 GiB model
+   would leave no room for the KV cache and compute buffers and would end up
+   partially offloaded. Partial offload dominates generation throughput, which
+   would swamp the effect being measured. The second device has 2 GiB and is not
+   a candidate.
+
+   Record the build ID (`b10453-rocm-optimized` is the build the source report
+   was verified against) and the GPU configuration in `results.md`; a throughput
    number without them is not reusable.
 
 2. **Build the job.** One benchmark job, one model, one build, sweeping two

--- a/plan/speculative-multi-mode/report.md
+++ b/plan/speculative-multi-mode/report.md
@@ -1,0 +1,304 @@
+# Report: multiple speculative modes, `--spec-chain`, and adaptive MTP
+
+Written 2026-09-07. Verified against the managed llama.cpp clone at
+`b10453` (`3cb7ffb1a`, 16 Aug 2026), upstream `master` docs, and the
+GitHub issue/PR state on the day of writing.
+
+## Bottom line
+
+Three separate things were suggested. They are in three different states,
+and only one of them is worth building now.
+
+| Feature | Exists upstream? | Worth adding? |
+|---|---|---|
+| Several speculative modes at once (`--spec-type a,b`) | **Yes** — merged, documented, in the build we already ship | **Yes.** Real speed on echo-heavy work, and the toolchest cannot express it today. |
+| `--spec-chain N` | **No.** The flag does not exist anywhere in llama.cpp. The feature request (#23184) is closed as not planned. | No. Nothing to wrap. |
+| `draft-mtp-adaptive` | **Not merged.** Open PR [#27210](https://github.com/ggml-org/llama.cpp/pull/27210), 83 comments, merge blocked. | Not yet — but it is cheap to add later, and it is a good first customer for the "build from a PR" work. |
+
+The claim that started this — that llama.cpp accepts a comma-separated
+`--spec-type` list — is correct. The claims about `--spec-chain` and a
+merged `draft-mtp-adaptive` are not.
+
+---
+
+## 1. What llama.cpp actually does today
+
+### Multiple modes are a merged, supported feature
+
+`common/arg.cpp` splits the `--spec-type` value on commas and *appends*
+to a list, and repeating the flag is explicitly exempted from the
+"specified multiple times" deprecation warning:
+
+```cpp
+{"--spec-type"}, common_speculative_all_types_str(),
+"comma-separated list of types of speculative decoding to use ..."
+const auto types_str = string_split<std::string>(value, ',');
+params.speculative.types.insert(params.speculative.types.end(), ...);
+```
+
+`docs/speculative.md` states the rule plainly:
+
+> An implementation with draft model can be mixed with an implementation
+> without draft model.
+> […]
+> If a draft model is combined with a draftless decoding the draftless
+> decoding has higher precedence.
+
+Four details matter for how we would model this:
+
+1. **It is a set, not a chain.** `common_speculative_init` turns the list
+   into a bitmask and then walks a *fixed* priority order — all n-gram
+   methods first, then all draft-model methods. `draft-mtp,ngram-mod` and
+   `ngram-mod,draft-mtp` produce byte-identical behaviour. There is no
+   user-controllable ordering to expose.
+2. **At most one draft-model method.** The docs only sanction
+   draft + draftless. Combining `draft-mtp` with another draft-model type
+   while `--model-draft` is set currently crashes at startup — open issue
+   [#27897](https://github.com/ggml-org/llama.cpp/issues/27897),
+   "failed to create MTP context". This is a constraint the UI should
+   enforce, not a warning to print.
+3. **`none` is poison in a list.** `common_speculative_types_from_names`
+   returns `{NONE}` and discards everything else the moment it sees
+   `none`. We must never emit `none,` as a list member.
+4. **An unknown name is fatal.** It throws
+   `unknown speculative type: <name>` and llama-server refuses to start.
+   There is no graceful degradation for a mode a given build does not know.
+
+### Each mode has its own draft-length knobs
+
+This is the part that breaks our current data model. The modes do *not*
+share a draft length:
+
+| Mode | Draft length flags | Defaults |
+|---|---|---|
+| `draft-simple`, `draft-mtp`, `draft-eagle3`, … | `--spec-draft-n-max` / `-n-min` | 3 / 0 |
+| `ngram-mod` | `--spec-ngram-mod-n-max` / `-n-min` / `-n-match` | 64 / 48 / 24 |
+| `ngram-simple`, `ngram-map-k`, `ngram-map-k4v` | `--spec-<mode>-size-n` / `-size-m` / `-min-hits` | 12 / 48 / 1 |
+
+`common_speculative_n_max` takes the maximum across whatever is enabled,
+so the two lengths coexist deliberately: MTP drafts 3 tokens, ngram-mod
+drafts up to 64, both live.
+
+### `--spec-chain` does not exist
+
+Code search over `ggml-org/llama.cpp` returns zero hits for `spec-chain`
+and zero for `spec_chain`. The underlying idea — feed the MTP draft into
+ngram-mod so the n-gram *extends* it rather than replacing it — is
+[issue #23184](https://github.com/ggml-org/llama.cpp/issues/23184), and
+it is **closed as not planned**. The reporter's own estimate for the
+pipelined version was 5–10% extra throughput.
+
+Note also that the older PR "spec : allow for multiple spec types (chains
+of speculators)" ([#22546](https://github.com/ggml-org/llama.cpp/pull/22546))
+was closed unmerged; multi-type support arrived by another route. The word
+"chain" in that title is probably where the `--spec-chain` idea came from.
+
+### `draft-mtp-adaptive` is an open PR
+
+[PR #27210](https://github.com/ggml-org/llama.cpp/pull/27210) adds
+`--spec-type draft-mtp-adaptive` plus `--spec-draft-n-min-adaptive`. It
+raises draft depth after consecutive full accepts and drops it under a
+weighted miss pressure. Opened 17 Aug 2026, last touched today,
+`mergeable_state: blocked`, +451/−26 across 10 files. It is not in any
+released build, and the author's own guidance is hedged: worse on older
+hardware, weaker on MoE, and pointless below `n-max 7`.
+
+---
+
+## 2. Value
+
+The strongest evidence is the benchmark table in PR #27210 itself, which
+happens to be run on hardware close to ours (2× Radeon AI PRO R9700,
+ROCm, Qwen3.8-27B Q8_0, tokens/second, generation only):
+
+| config | reasoning | prose | code | recall |
+|---|---|---|---|---|
+| C0 no speculation | 30.03 | 30.08 | 30.03 | 29.93 |
+| C1 MTP fixed 3 | **51.68** | 55.89 | 69.28 | 81.94 |
+| C5 ngram-mod alone | 30.03 | 30.10 | 29.98 | 292.88 |
+| C7 **MTP fixed 3 + ngram-mod** | 51.65 | 55.90 | 68.36 | **324.10** |
+| C3 adaptive 3..12 | 51.42 | **56.64** | **78.03** | 147.46 |
+| C6 adaptive + ngram-mod | 51.48 | 56.61 | 73.06 | 321.25 |
+
+Read the two rows we can build today, C1 and C7:
+
+- **Combining costs nothing.** On reasoning, prose and code the combined
+  row is within noise of MTP alone (51.65 vs 51.68, 55.90 vs 55.89,
+  68.36 vs 69.28).
+- **Combining is worth 4× on echo-heavy work.** 324 vs 82 tokens/second
+  on the recall task — text the model has already seen and is repeating.
+  That is the file-rewrite, structured-output, tool-call-loop case, which
+  is a large share of how these servers actually get used.
+- **Neither mode alone gets both.** ngram-mod alone is *zero* help on
+  novel generation (30.0, exactly baseline). MTP alone gives up three
+  quarters of the echo speed.
+
+Set against that, the earlier report of `draft-mtp,ngram-mod` being ~4
+tokens/second *worse* than MTP alone on novel text is plausible and
+backend-dependent — the priority rule means a low-quality n-gram
+suggestion displaces a high-acceptance MTP draft for that step. It is a
+reason to make the combination measurable, not a reason to avoid it. We
+already have the instrument for that: the benchmark sweep.
+
+Adaptive MTP's own numbers are more interesting on paper (+13% on code
+over fixed-3, and it removes the depth-tuning problem) but it is not
+merged, and C6 vs C7 shows it adds nothing once ngram-mod is in the mix
+for the echo case.
+
+**Value verdict:** the combination is the one with a real, measured,
+workload-shifting payoff, and it needs no new upstream code.
+
+---
+
+## 3. Viability in llama-toolchest
+
+### What has to change
+
+`SpecType` is a single string today, and every consumer treats it as one.
+14 non-test Go files, 4 templates and the two JS test fixtures reference
+it. The work is not deep, but it is wide.
+
+**a. The data model is the real cost.** Today `DraftMax`, `DraftMin`,
+`NgramSizeN`, `NgramSizeM` are *one* set of fields whose meaning depends
+on the selected mode — `specflags.go` switches on `SpecType` to decide
+whether `DraftMax` becomes `--spec-draft-n-max` or
+`--spec-ngram-mod-n-max`. With two modes active, that same field would
+have to be two different flags at once. Config C7 above — MTP at 3,
+ngram-mod at 64 — is literally inexpressible in the current struct.
+
+There are two ways out:
+
+- *Per-mode parameter blocks.* `SpecModes []SpecModeConfig`, each with its
+  own mode name and values. Correct, and it makes `specDecodingParams` a
+  loop over blocks instead of a switch. Costs a config migration
+  (`spec_type` + flat fields → a list) and a rewrite of the benchmark
+  override plumbing, which passes each field as its own `*int`.
+- *Keep the flat fields, add a second mode.* `SpecType` stays the draft
+  method; a new `SpecAssist` holds the draftless one, with its own small
+  set of fields. Much cheaper, no migration, and it directly encodes the
+  "one draft method + one draftless method" rule that llama.cpp actually
+  sanctions. It does not generalise to three modes — which nothing asks
+  for.
+
+I would take the second. The upstream rule is not "any set of modes"; it
+is "a draft method may be mixed with a draftless method". Modelling
+exactly that is smaller *and* more honest than a general list.
+
+**b. The preset INI must emit one line.** `common/preset.cpp` parses an
+INI section into a `std::map<common_arg, std::string>`, so a repeated
+`spec-type =` line silently keeps only the last value. This is the router
+bug that was reported. `specDecodingParams` currently returns one
+`specParam` per flag and `preset.go` writes one line each, so emitting two
+`spec-type` entries would produce exactly that bug. The fix is trivial —
+join the mode names with a comma into a single entry — but it has to be
+done deliberately, and a test should pin it.
+
+**c. The benchmark axis has a comma collision.** `spec_type` sweep values
+are encoded as `mode:key=value,key=value`, and the field's `Separator` is
+`","` — commas already mean two different things in that string. A
+combined mode cannot be written as `draft-mtp,ngram-mod` there without
+choosing a new separator (`+` reads well: `draft-mtp+ngram-mod:...`) and
+updating `parseSpecValue`, `encodeSpecValue`, the choices table, the live
+cell-count estimate in `benchmarks.html`, and the JS param tests.
+
+**d. Equality checks on `SpecType` become substring checks.** Three
+places compare the mode by `==`: VRAM aux-file accounting
+(`vram.go:253`, `SpecType == "draft"`), the measured-memory load
+signature (`memory_measured.go:203`), and the run comparison label
+(`compare_labels.go:100`). Each needs a small helper rather than a
+literal comparison. The template conditionals in `model_config.html`
+have the same shape and the same fix.
+
+**e. The UI.** The mode picker becomes a draft-method picker plus a
+draftless "assist" picker, with the assist's own parameters revealed
+underneath. The help dialog needs a paragraph on what combining does and,
+importantly, that the draftless method wins each step — that precedence
+rule is the single thing a user needs to understand to read their own
+benchmark results.
+
+### Effort
+
+| Piece | Size |
+|---|---|
+| Config field + migration-free default, INI/CLI emission, tests | Small |
+| Model config form + help copy | Small |
+| Benchmark axis encoding, choices, cell-count estimate, JS tests | Medium — the fiddliest part |
+| VRAM / memory-signature / compare-label call sites | Small |
+
+Call it a focused day's work, most of it in the benchmark surface rather
+than in the launch path.
+
+### Risk
+
+Low, and mostly contained. The feature is additive: a config that names
+one mode emits exactly the flags it emits today. The failure mode of the
+combined path is a llama-server that will not start, which the job runner
+already surfaces as a failed cell. The one thing to guard is (a) above —
+never letting the UI offer two draft-model methods, since that is the
+open upstream crash.
+
+---
+
+## 4. `draft-mtp-adaptive` specifically
+
+Adding it is a two-line change *once it merges*: one entry in the mode
+list, one entry in `SpecModeParams` (and `--spec-draft-n-min-adaptive`
+as a fourth tunable). Adding it before it merges is a different question,
+because an unknown mode name is a hard startup failure and the toolchest
+has no build-capability gating — the gemma-4 note in the config form is a
+static sentence of prose, not a check against the active build's commit.
+
+The natural time to revisit is when
+[`plan/builder-refs.md`](builder-refs.md) lands. Building
+`refs/pull/27210/head` is exactly the case that plan exists for, and a
+mode that only appears when the active build knows it would be the first
+real use of build-aware capability gating. Until then, a user who wants
+to try it can already put `--spec-type draft-mtp-adaptive` in Extra Flags
+against a hand-built binary.
+
+---
+
+## 5. Two things found while checking this
+
+Unrelated to the request, but in the same code:
+
+1. **`--spec-ngram-mod-n-match` is never emitted.**
+   `SpecModeParams` (`internal/models/specparams.go:33`) offers "N-gram
+   size N" with a default of 24 for `ngram-mod`, and the config form
+   renders the field (`web/templates/partials/model_config.html:380`),
+   but the `ngram-mod` case in `specDecodingParams`
+   (`internal/models/specflags.go:86-93`) only emits `n-max` and
+   `n-min`. Whatever the user types in that
+   box is stored and ignored. It happens to be harmless right now because
+   llama.cpp's own `n_match` default is also 24 — so the field is dead
+   rather than wrong — but a user who tunes it gets silence.
+   `ngram_size_m` is worse: `ngram-mod` has no m-gram size at all, so
+   that field is meaningless for the mode and should not be offered.
+2. **Three merged spec types are unreachable.** `draft-eagle3`,
+   `draft-dflash` and `draft-dspark` (`common/common.h:170-182` in the
+   managed clone) are all in the build we ship, all
+   documented, all with converted checkpoints on Hugging Face for models
+   we run (Qwen3, gpt-oss, gemma-4). None appears in the mode picker
+   (`web/templates/partials/model_config.html:277-287`) or in the
+   benchmark axis choices (`internal/benchmark/sweep.go:654-661`).
+   EAGLE-3 in particular claims higher acceptance than a same-size draft
+   model, and it reuses the draft-model plumbing we already have. This
+   may be a larger win than anything in this report and is cheaper than
+   all of it.
+
+---
+
+## 6. Recommendation
+
+1. **Build the combination** (`draft-mtp` or `draft` plus one draftless
+   method), modelled as draft-method + assist rather than a general list.
+   The upside is measured, large on the workloads these servers see most,
+   and needs nothing from upstream.
+2. **Fix the ngram-mod parameters** while in the file — emit `n-match`,
+   drop the meaningless m-gram field.
+3. **Add the three missing merged spec types** as a separate, smaller
+   change. Probably do this first; it is the best value per hour here.
+4. **Skip `--spec-chain`.** It does not exist and is not planned.
+5. **Defer `draft-mtp-adaptive`** until it merges, and treat it as the
+   first customer for build-aware capability gating once
+   `plan/builder-refs.md` lands.

--- a/plan/speculative-multi-mode/results.md
+++ b/plan/speculative-multi-mode/results.md
@@ -39,6 +39,10 @@ measuring a cache hit.
 
 Generation tokens/second, mean ± standard deviation over 3 repetitions.
 
+Every figure below was measured with the model's saved sampling, which includes
+`presence_penalty: 1.5`. That materially understates the recall case — see
+[Follow-up](#follow-up-draft-depth-and-the-presence-penalty).
+
 ### internal-echo — recall, 1610-token prompt, 512 generated
 
 | config | gen tok/s | vs off | vs MTP alone |
@@ -114,3 +118,64 @@ mechanism the model's chat template exposes, which the registry already
 detects. Every number in this document is from the corrected run. The lesson
 generalises past this preset — any benchmark that means to measure recall has
 to make sure the model is not reasoning instead.
+
+## Follow-up: draft depth and the presence penalty
+
+Two settings the main run left unverified, measured afterwards on the same
+model and build. Jobs `job-1788826127514-4318a888` and
+`job-1788826192867-9f0eb4a8`, `draft_max` 3 vs 6 crossed with
+`presence_penalty` 1.5 vs 0, the assist held at 64/48/24 throughout.
+
+Generation tokens/second, mean ± standard deviation.
+
+### internal-standard — new text
+
+| | draft_max=3 | draft_max=6 |
+|---|---:|---:|
+| presence 1.5 | 121.2 ± 13.5 | 115.2 ± 18.3 |
+| presence 0 | 138.3 ± 19.8 | 140.3 ± 51.4 |
+
+### internal-echo — recall
+
+| | draft_max=3 | draft_max=6 |
+|---|---:|---:|
+| presence 1.5 | 476.4 ± 39.2 | **550.3 ± 33.7** |
+| presence 0 | **947.1 ± 114.5** | 940.4 ± 116.2 |
+
+**`draft_max: 6` beats 3 on recall at the saved sampling** — 550 against 476,
+a gap outside both error bars. That is the form's default and it is the right
+one here. The advantage disappears once the presence penalty is off (940
+against 947, a tie), so the two settings interact rather than being
+independently tunable.
+
+**The presence penalty is the larger effect by far.** Setting it to 0 nearly
+doubles recall throughput (947 against 476 at `draft_max` 3) and adds roughly
+15-20% on new text. The mechanism follows directly from the precedence rule
+already documented above: speculative decoding is lossless, so a drafted token
+is accepted only if the target model would have sampled it anyway, and a
+presence penalty of 1.5 suppresses exactly the already-seen tokens the n-gram
+assist drafts.
+
+**This is a speed/quality trade, not a free win.** `presence_penalty: 1.5` is
+Qwen3's recommended value for thinking mode and exists to stop the model
+looping. Part of the measured speedup *is* the model repeating itself more
+readily — which is why the assist hits more often. On `internal-echo` that is
+legitimate, because verbatim reproduction is the task. On `internal-standard`
+some of the gain may be degenerate repetition rather than useful output, and
+throughput cannot tell those apart. A middle value is the thing to try; the
+judgement is about the outputs, not the number.
+
+**The main table understates recall.** Because it was measured at
+`presence_penalty: 1.5`, its headline 5.73× over baseline for the combination
+is a floor. At `presence_penalty: 0` the same configuration reaches roughly 12×
+over the 78 tok/s baseline.
+
+### A gap this follow-up ran into
+
+`presence_penalty` is not in `ConfigOverrides` and is not a sweep axis — it
+reaches llama-server only as a preset-INI server default. The two jobs above
+therefore had to be run either side of an edit to the model's saved config
+rather than as one four-cell sweep. That is the same shape of gap this project
+just closed for the n-gram parameters: the model config can express the
+setting, the benchmark cannot vary it. Worth closing the same way if sampling
+is ever swept in earnest.

--- a/plan/speculative-multi-mode/results.md
+++ b/plan/speculative-multi-mode/results.md
@@ -1,0 +1,116 @@
+# Results — measuring the draft method + n-gram assist combination
+
+Run 2026-09-07 on this machine. Phase 06 of [`overview.md`](overview.md).
+
+## What was run
+
+| | |
+|---|---|
+| Model | `unsloth--Qwen3.5-9B-MTP-GGUF--Qwen3.5-9B-IQ4_NL`, 5.3 GiB, MTP head baked into the main GGUF (self-speculation) |
+| Build | `b10453-rocm-optimized`, ref `b10453`, ROCm profile |
+| GPU | AMD Radeon RX 9070 XT, 15.9 GiB, all layers offloaded (`gpu-layers 999`, `device ROCm0`) |
+| Context | 131072, flash attention on, KV cache `q8_0` |
+| Job | `job-1788821931442-469f5504`, 8 cells = 4 speculative configs × 2 presets |
+
+The four configurations, matching the source report's C0/C1/C5/C7 rows:
+
+- `none`
+- `draft-mtp:draft_max=3`
+- `ngram-mod:assist_n_max=64,assist_n_min=48,assist_n_match=24`
+- `draft-mtp+ngram-mod:` both of the above
+
+The flags reached llama-server. The generated `bench-preset.ini` for the
+combined cell carried exactly one `spec-type` line:
+
+```ini
+spec-type = draft-mtp,ngram-mod
+spec-draft-n-max = 3
+spec-ngram-mod-n-max = 64
+spec-ngram-mod-n-min = 48
+spec-ngram-mod-n-match = 24
+```
+
+`prompt_tokens` held steady across repetitions in every cell (1610 for every
+`internal-echo` cell, 127/421/1607 for the three `internal-standard` sizes), so
+no cell was served from the prompt cache and no throughput figure here is
+measuring a cache hit.
+
+## The numbers
+
+Generation tokens/second, mean ± standard deviation over 3 repetitions.
+
+### internal-echo — recall, 1610-token prompt, 512 generated
+
+| config | gen tok/s | vs off | vs MTP alone |
+|---|---:|---:|---:|
+| off | 78.0 ± 0.4 | 1.00× | — |
+| MTP alone | 153.3 ± 1.0 | 1.96× | 1.00× |
+| N-gram Mod alone | 436.5 ± 51.4 | 5.59× | 2.85× |
+| **MTP + N-gram Mod** | **447.1 ± 8.4** | **5.73×** | **2.92×** |
+
+### internal-standard — new text, by prompt size
+
+| config | 127 tok | 421 tok | 1607 tok |
+|---|---:|---:|---:|
+| off | 77.5 ± 2.8 | 77.9 ± 0.7 | 77.8 ± 0.3 |
+| MTP alone | 133.9 ± 12.6 | 124.5 ± 14.7 | 125.1 ± 7.9 |
+| N-gram Mod alone | 92.5 ± 17.4 | 81.4 ± 9.3 | 82.3 ± 6.2 |
+| MTP + N-gram Mod | 120.5 ± 15.9 | 118.2 ± 14.7 | 112.4 ± 12.9 |
+
+## What it says
+
+**The recall win is real and larger here than the report predicted.** The
+report's table showed 4× on its 27B model; this 9B reaches 5.7× over baseline
+and 2.9× over MTP alone. That is the case the project was built for — a file
+being rewritten, a structured response, a tool-call loop — and it is the case
+neither mode reaches on its own: MTP alone gets 1.96×, and N-gram Mod is where
+almost all of the remaining speed comes from.
+
+**The combination is the best configuration on recall, but only just.** 447.1
+against N-gram Mod's 436.5 is inside the n-gram cell's own error bar (±51.4).
+What the combination buys on this workload is not extra recall speed, it is
+that the *same* configuration is also 1.6× on new text where N-gram Mod alone
+is 1.06×. One setting covers both workloads; that is the argument for it.
+
+**The combination costs something on new text.** At every prompt size the
+combined row sits below MTP alone — 120.5 vs 133.9, 118.2 vs 124.5, 112.4 vs
+125.1, about 8-10%. The error bars overlap at each size individually, so no
+single comparison is conclusive, but the direction is consistent across all
+three sizes and matches both the earlier informal report of roughly 4 tok/s and
+the mechanism: llama.cpp gives the draftless method precedence for a contested
+step, so a weak n-gram match displaces a good MTP draft. This is exactly what
+the help copy in the model config form warns about, and it is measured now
+rather than argued about.
+
+**N-gram Mod alone is not baseline on new text.** The report predicted exactly
+baseline (its table showed 30.03 against a 30.03 baseline); here it is 85.4
+against 77.7, about 1.10×. The cause is the benchmark's own prompt: it repeats
+a fixed passage to reach the target length, so even the "analysis" prompt
+contains repetition an n-gram method can exploit. Worth knowing before reading
+the `internal-standard` n-gram row as a measure of genuinely novel text.
+
+## Practical upshot
+
+For this model on this hardware:
+
+- Leave **MTP alone** on if the work is mostly new prose or reasoning.
+- Turn the **N-gram Mod assist** on as well if any meaningful share of the work
+  is the model reproducing text it has already seen. Paying ~8-10% on new text
+  to gain 2.9× on recall is a good trade for anything doing file rewrites,
+  structured output, or tool-call loops; it is a bad trade for pure chat.
+- The setting is per model, which is what makes that choice available at all.
+
+## One defect this phase found
+
+The first run measured `internal-echo` at almost exactly `internal-standard`'s
+numbers, which looked like the combination doing nothing. It was not a
+speculative-decoding result. Qwen3.5 is a reasoning model, and with thinking on
+it spent all 512 generated tokens in `reasoning_content` — deliberating about
+how to reproduce the passage rather than reproducing it. That is new prose, so
+the recall workload was never actually exercised.
+
+Fixed in `f104f24`: the echo prompt style now turns thinking off using whichever
+mechanism the model's chat template exposes, which the registry already
+detects. Every number in this document is from the corrected run. The lesson
+generalises past this preset — any benchmark that means to measure recall has
+to make sure the model is not reasoning instead.

--- a/web/jstest/dom.js
+++ b/web/jstest/dom.js
@@ -70,6 +70,59 @@ function mkTextRow(param, sep){
   return row;
 }
 
+
+// A spec_type row as the job form renders it: each mode choice carries a
+// data-mode checkbox and an expandable settings box, and a draft choice's
+// box also carries the n-gram assist dropdown with every assist mode's
+// settings, rendered hidden and revealed by that dropdown.
+function mkSpecRow(){
+  const row=new El('div'); row.className='param-row';
+  row.setAttribute('data-param','spec_type');
+  row.setAttribute('data-sep',';');
+  row.setAttribute('data-restarts','1');
+  const menu=new El('details'); menu.className='param-menu'; row.appendChild(menu);
+  const summary=new El('span'); summary.className='param-summary';
+  summary.setAttribute('data-summary-for','spec_type'); menu.appendChild(summary);
+  const optsEl=new El('div'); optsEl.className='param-options'; menu.appendChild(optsEl);
+  const inh=new El('input'); inh.type='checkbox'; inh.className='param-inherit'; inh.checked=true;
+  inh.setAttribute('data-param-inherit','spec_type'); optsEl.appendChild(inh);
+
+  const assistParams={'ngram-mod':[['assist_n_max','64'],['assist_n_min','48'],['assist_n_match','24']],
+                      'ngram-simple':[['assist_size_n','12'],['assist_size_m','48'],['assist_min_hits','1']],
+                      'ngram-cache':[]};
+  const modes=[['none','',[],null],
+               ['draft-mtp','draft-mtp',[['draft_max','6'],['draft_min','0']],'draft'],
+               ['ngram-mod:assist_n_max=64,assist_n_min=48,assist_n_match=24','ngram-mod',
+                [['assist_n_max','64'],['assist_n_min','48'],['assist_n_match','24']],'assist'],
+               ['ngram-cache','ngram-cache',[],'assist']];
+
+  for(const [value,mode,params,slot] of modes){
+    const cb=new El('input'); cb.type='checkbox'; cb.className='param-value'; cb.value=value;
+    cb.setAttribute('data-param-value','spec_type');
+    if(mode) cb.setAttribute('data-mode',mode);
+    optsEl.appendChild(cb);
+    if(!mode) continue;
+    const box=new El('details'); box.className='spec-params';
+    box.setAttribute('data-mode',mode); optsEl.appendChild(box);
+    for(const [key,def] of params){
+      const inp=new El('input'); inp.className='spec-param-input';
+      inp.setAttribute('data-key',key); inp.value=def; box.appendChild(inp);
+    }
+    if(slot!=='draft') continue;
+    const sel=new El('select'); sel.className='spec-assist-select'; sel.value='';
+    box.appendChild(sel);
+    for(const am of Object.keys(assistParams)){
+      const d=new El('div'); d.className='spec-assist-params';
+      d.setAttribute('data-assist',am); d.hidden=true; box.appendChild(d);
+      for(const [key,def] of assistParams[am]){
+        const inp=new El('input'); inp.className='spec-param-input';
+        inp.setAttribute('data-key',key); inp.value=def; d.appendChild(inp);
+      }
+    }
+  }
+  return row;
+}
+
 const form=new El('form');
 form.setAttribute('data-max-cells','500');
 // Matrix selections, without which updateMatrixCount bails immediately.
@@ -79,7 +132,7 @@ form.appendChild(mkCheck('build','b1',true));
 form.appendChild(mkCheck('preset','internal-quick',true));
 form.appendChild(mkRow('ubatch_size',['64','128','256','512','1024','2048'],{restarts:1,custom:1}));
 form.appendChild(mkRow('gpu_assign',['all','0','1','0-1'],{restarts:1,custom:1}));
-form.appendChild(mkRow('spec_type',['draft','draft-mtp'],{restarts:1}));         // no custom box
+form.appendChild(mkSpecRow());                                                   // no custom box
 form.appendChild(mkRow('temperature',['0','0.7','1.0'],{custom:1}));
 form.appendChild(mkTextRow('tensor_split','|'));
 const _byId={};

--- a/web/jstest/params_test.js
+++ b/web/jstest/params_test.js
@@ -141,5 +141,53 @@ ok(JSON.stringify(back.spec_type)==='["ngram-cache"]',
 ok(unmappedOverrides.draft_model_path==='/d.gguf',
    'an override with no control is carried through, not deleted');
 
+// 12. Speculative decoding: a draft method and an n-gram assist combine
+// inside one checkbox, which is the only way all twenty-five pairings are
+// reachable on a row that has no custom-entry box.
+const sp=row('spec_type');
+sp.querySelector('.param-inherit').checked=true;
+sp.querySelectorAll('.param-value').forEach(c=>{ c.checked=false; });
+
+const mtpBox=sp.querySelectorAll('.spec-params').find(b=>b.getAttribute('data-mode')==='draft-mtp');
+const mtpSel=mtpBox.querySelector('.spec-assist-select');
+const mtpMax=mtpBox.querySelectorAll('.spec-param-input').find(i=>i.getAttribute('data-key')==='draft_max');
+
+// Editing a setting selects the mode, and encodes only that slot.
+mtpMax.value='3'; updateSpecValue(mtpMax);
+ok(JSON.stringify(readParams(form).spec_type)==='["draft-mtp:draft_max=3,draft_min=0"]',
+   'draft slot alone encodes without a "+", got '+JSON.stringify(readParams(form).spec_type));
+
+// Choosing an assist appends it and reveals only that mode's settings.
+mtpSel.value='ngram-mod'; updateSpecValue(mtpSel);
+ok(readParams(form).spec_type[0]==='draft-mtp+ngram-mod:draft_max=3,draft_min=0,assist_n_max=64,assist_n_min=48,assist_n_match=24',
+   'assist joins with "+" and contributes its own keys, got '+JSON.stringify(readParams(form).spec_type));
+ok(mtpBox.querySelectorAll('.spec-assist-params').find(d=>d.getAttribute('data-assist')==='ngram-simple').hidden===true,
+   'a non-selected assist stays hidden so its defaults never reach the value');
+
+// Switching the assist swaps which keys appear.
+mtpSel.value='ngram-simple'; updateSpecValue(mtpSel);
+ok(readParams(form).spec_type[0].indexOf('assist_size_n=12')!==-1 &&
+   readParams(form).spec_type[0].indexOf('assist_n_max')===-1,
+   'switching the assist swaps its settings, got '+JSON.stringify(readParams(form).spec_type));
+
+// Back to None drops the segment and every assist key.
+mtpSel.value=''; updateSpecValue(mtpSel);
+ok(readParams(form).spec_type[0]==='draft-mtp:draft_max=3,draft_min=0',
+   'clearing the assist drops the "+" segment, got '+JSON.stringify(readParams(form).spec_type));
+
+// 13. A saved combined value restores onto the checkbox, the dropdown and
+// both slots' inputs.
+sp.querySelectorAll('.param-value').forEach(c=>{ c.checked=false; });
+addParamValue(sp, 'draft-mtp+ngram-mod:draft_max=5,assist_n_max=32');
+ok(readParams(form).spec_type[0]==='draft-mtp+ngram-mod:draft_max=5,assist_n_max=32',
+   'a combined value round-trips, got '+JSON.stringify(readParams(form).spec_type));
+ok(mtpSel.value==='ngram-mod', 'restore selects the assist dropdown, got '+mtpSel.value);
+ok(mtpMax.value==='5', 'restore fills the draft input, got '+mtpMax.value);
+const modBox=mtpBox.querySelectorAll('.spec-assist-params').find(d=>d.getAttribute('data-assist')==='ngram-mod');
+ok(modBox.querySelectorAll('.spec-param-input').find(i=>i.getAttribute('data-key')==='assist_n_max').value==='32',
+   'restore fills the assist input');
+ok(modBox.querySelectorAll('.spec-param-input').find(i=>i.getAttribute('data-key')==='assist_n_min').value==='',
+   'a key the saved value omits is cleared, not left at its default');
+
 console.log(fails===0 ? '\nALL PASS' : '\n'+fails+' FAILURES');
 process.exit(fails?1:0);

--- a/web/templates/benchmarks.html
+++ b/web/templates/benchmarks.html
@@ -423,24 +423,40 @@ function onParamInheritToggle(cb) {
 }
 
 // updateSpecValue re-encodes a speculative mode's checkbox value from
-// its settings inputs: "mode:key=value,..." with empty inputs omitted
-// (empty = use the model's saved value), bare "mode" when all are
-// empty. Editing a setting selects the mode, since editing expresses
-// intent to use it.
+// its settings inputs and its n-gram assist dropdown:
+// "mode+assist:key=value,..." with empty inputs omitted (empty = use the
+// model's saved value), bare mode names when all are empty. Editing a
+// setting selects the mode, since editing expresses intent to use it.
+//
+// "+" joins the two modes because the field's value separator is ",",
+// which already splits one cell's value from the next.
 function updateSpecValue(input) {
     var box = input.closest('.spec-params');
     var row = input.closest('.param-row');
     if (!box || !row) return;
     var mode = box.getAttribute('data-mode');
+
+    // Reveal only the selected assist's settings, so a mode the user did
+    // not choose cannot contribute its defaults to the encoded value.
+    var sel = box.querySelector('.spec-assist-select');
+    var assist = sel ? sel.value : '';
+    box.querySelectorAll('.spec-assist-params').forEach(function (d) {
+        d.hidden = d.getAttribute('data-assist') !== assist;
+    });
+
     var pairs = [];
     box.querySelectorAll('.spec-param-input').forEach(function (inp) {
+        var hiddenBlock = inp.closest('.spec-assist-params');
+        if (hiddenBlock && hiddenBlock.hidden) return;
         var v = (inp.value || '').trim();
         if (v !== '') pairs.push(inp.getAttribute('data-key') + '=' + v);
     });
+
     var cb = Array.from(row.querySelectorAll('.param-value'))
         .find(function (c) { return c.getAttribute('data-mode') === mode; });
     if (!cb) return;
-    cb.value = pairs.length ? mode + ':' + pairs.join(',') : mode;
+    var names = assist ? mode + '+' + assist : mode;
+    cb.value = pairs.length ? names + ':' + pairs.join(',') : names;
     if (!cb.checked) {
         cb.checked = true;
         onParamValueToggle(cb);
@@ -483,12 +499,27 @@ function addParamCustom(el) {
 // silently deleting the setting when the job was edited.
 function addParamValue(row, raw) {
     // Speculative decoding values restore onto their mode's checkbox and
-    // settings inputs rather than becoming custom entries: the mode is
-    // the text before ":", the settings are key=value pairs after it.
-    var specMode = raw.split(':')[0].trim();
-    var specCb = Array.from(row.querySelectorAll('.param-value'))
-        .find(function (c) { return c.getAttribute('data-mode') === specMode; });
+    // settings inputs rather than becoming custom entries: the modes are
+    // the "+"-joined text before ":", the settings are key=value pairs
+    // after it. One of the two names owns the checkbox; the other, if
+    // present, is the n-gram assist selected inside it.
+    var specNames = raw.split(':')[0].trim().split('+').map(function (n) { return n.trim(); });
+    var specCb = null, specMode = '';
+    for (var si = 0; si < specNames.length; si++) {
+        var found = Array.from(row.querySelectorAll('.param-value'))
+            .find(function (c) { return c.getAttribute('data-mode') === specNames[si]; });
+        if (!found) continue;
+        // A draft choice owns the checkbox when both names are present,
+        // since only a draft choice carries the assist dropdown.
+        var foundBox = row.querySelector('.spec-params[data-mode="' + specNames[si] + '"]');
+        var ownsAssist = !!(foundBox && foundBox.querySelector('.spec-assist-select'));
+        if (!specCb || ownsAssist) {
+            specCb = found;
+            specMode = specNames[si];
+        }
+    }
     if (specCb) {
+        var specAssist = specNames.filter(function (n) { return n !== specMode; })[0] || '';
         var box = row.querySelector('.spec-params[data-mode="' + specMode + '"]');
         if (box) {
             var settings = {};
@@ -496,7 +527,17 @@ function addParamValue(row, raw) {
                 var kv = pair.split('=');
                 if (kv.length === 2) settings[kv[0].trim()] = kv[1].trim();
             });
+            var sel = box.querySelector('.spec-assist-select');
+            if (sel) sel.value = specAssist;
+            box.querySelectorAll('.spec-assist-params').forEach(function (d) {
+                d.hidden = d.getAttribute('data-assist') !== specAssist;
+            });
             box.querySelectorAll('.spec-param-input').forEach(function (inp) {
+                var hiddenBlock = inp.closest('.spec-assist-params');
+                if (hiddenBlock && hiddenBlock.hidden) {
+                    inp.value = '';
+                    return;
+                }
                 var k = inp.getAttribute('data-key');
                 inp.value = (k in settings) ? settings[k] : '';
             });

--- a/web/templates/partials/bench_about.html
+++ b/web/templates/partials/bench_about.html
@@ -9,9 +9,14 @@
 
 <h5>Internal prompt</h5>
 <p>Every internal request is built by repeating a fixed prose passage until it hits the target character count, prefixed with a per-rep header to defeat llama.cpp's prompt cache. Approximate sizing: <code>{{.InternalPrompt.CharsPerToken}}</code> chars/token (English BPE average).</p>
+<p>Two prefixes are in use, and they ask for opposite work. Most presets ask the model to <strong>analyse</strong> the passage, so it generates new prose. <strong>internal-echo</strong> asks it to <strong>reproduce</strong> the passage, so generation is recall of text already in the context — the workload where n-gram speculative decoding pays off and where an analysis prompt shows nothing.</p>
 <details>
-    <summary><small>Per-repetition prefix template</small></summary>
+    <summary><small>Analysis prefix (most internal presets)</small></summary>
     <pre style="font-size:0.75rem;white-space:pre-wrap;margin:0.25rem 0 0;">{{.InternalPrompt.RepetitionPrefix}}</pre>
+</details>
+<details>
+    <summary><small>Recall prefix (internal-echo)</small></summary>
+    <pre style="font-size:0.75rem;white-space:pre-wrap;margin:0.25rem 0 0;">{{.InternalPrompt.EchoPrefix}}</pre>
 </details>
 <details>
     <summary><small>Prose passage</small></summary>

--- a/web/templates/partials/job_detail.html
+++ b/web/templates/partials/job_detail.html
@@ -28,7 +28,7 @@
         {{if .DirectIO}} · direct_io={{deref .DirectIO}}{{end}}
         {{if .GPUAssign}} · gpu_assign={{deref .GPUAssign}}{{end}}
         {{if .TensorSplit}} · tensor_split={{deref .TensorSplit}}{{end}}
-        {{if .SpecType}} · spec_type={{deref .SpecType}}{{end}}
+        {{if .SpecType}} · spec_type={{deref .SpecType}}{{end}}{{if .SpecAssist}} · spec_assist={{deref .SpecAssist}}{{end}}
         {{end}}
     </small>
     {{end}}

--- a/web/templates/partials/job_form.html
+++ b/web/templates/partials/job_form.html
@@ -42,6 +42,8 @@
 .spec-params .spec-param { display: flex; align-items: center; gap: 0.5rem; margin: 0.15rem 0; }
 .spec-params .spec-param small { min-width: 10rem; color: var(--pico-muted-color); }
 .spec-params .spec-param-input { margin: 0; width: 7rem; font-size: 0.85rem; padding: 0.1rem 0.4rem; height: auto; }
+.spec-params .spec-assist-select { margin: 0; width: 11rem; font-size: 0.85rem; padding: 0.1rem 0.4rem; height: auto; }
+.spec-params .spec-assist-params { margin-left: 1rem; border-left: 2px solid var(--pico-muted-border-color); padding-left: 0.5rem; }
 
 </style>
 
@@ -143,10 +145,10 @@
                     {{range .Choices}}
                     <label>
                         <input type="checkbox" class="param-value" data-param-value="{{$p.Name}}"
-                               value="{{.Value}}"{{if .Params}} data-mode="{{.Mode}}"{{end}} onchange="onParamValueToggle(this)">
+                               value="{{.Value}}"{{if .Mode}} data-mode="{{.Mode}}"{{end}} onchange="onParamValueToggle(this)">
                         {{.Label}}
                     </label>
-                    {{if .Params}}
+                    {{if .Mode}}
                     <details class="spec-params" data-mode="{{.Mode}}">
                         <summary><small>settings</small></summary>
                         {{range .Params}}
@@ -157,6 +159,28 @@
                                    placeholder="model's saved value"
                                    oninput="updateSpecValue(this)">
                         </label>
+                        {{end}}
+                        {{if eq .Slot "draft"}}
+                        <label class="spec-param" title="Runs alongside the draft method. Loads no extra file and uses no extra memory. When both propose tokens for the same step, the n-gram proposal is the one used.">
+                            <small>N-gram assist</small>
+                            <select class="spec-assist-select" onchange="updateSpecValue(this)">
+                                <option value="">None</option>
+                                {{range .AssistModes}}<option value="{{.Name}}">{{.Label}}</option>{{end}}
+                            </select>
+                        </label>
+                        {{range $mode, $params := .AssistParamsByMode}}
+                        <div class="spec-assist-params" data-assist="{{$mode}}" hidden>
+                            {{range $params}}
+                            <label class="spec-param" title="Clear the field to use the model's saved value.">
+                                <small>{{.Label}}</small>
+                                <input type="text" inputmode="decimal" class="spec-param-input"
+                                       data-key="{{.Key}}" value="{{.Default}}"
+                                       placeholder="model's saved value"
+                                       oninput="updateSpecValue(this)">
+                            </label>
+                            {{end}}
+                        </div>
+                        {{end}}
                         {{end}}
                     </details>
                     {{end}}

--- a/web/templates/partials/model_config.html
+++ b/web/templates/partials/model_config.html
@@ -234,26 +234,40 @@
                 <dt><strong>N-gram Map-K4V</strong></dt>
                 <dd>Experimental variant that tracks up to 4 different continuations per pattern and picks the most frequent one. Useful for patterns that lead to a few different outputs.</dd>
 
-                <dt><strong>N-gram Mod</strong> (recommended draftless)</dt>
-                <dd>Uses a lightweight shared hash pool (~16 MB) to learn patterns across requests. Patterns from one conversation benefit the next. Best general-purpose draftless mode — especially good for reasoning models, code, and multi-turn chat. Cold start is slow but improves over time.</dd>
+                <dt><strong>N-gram Mod</strong> (recommended n-gram assist)</dt>
+                <dd>Uses a lightweight shared hash pool (~16 MB) to learn patterns across requests. Patterns from one conversation benefit the next. Best general-purpose n-gram method — especially good for reasoning models, code, and multi-turn chat. Cold start is slow but improves over time.</dd>
+
+                <dt><strong>EAGLE-3</strong>, <strong>DFlash</strong>, <strong>DSpark</strong></dt>
+                <dd>Each loads a small trained head built for one specific model, published alongside it. A head is not a smaller model of the same family, so the drafter list for these modes is not filtered by architecture or size — pick the converted head for this model. They claim higher acceptance than a same-size draft model at a fraction of the memory. The settings are left blank because there is no measured guidance for them here; run a benchmark sweep to find good values rather than trusting a guess.</dd>
             </dl>
 
+            <h5>Running both at once</h5>
+            <p>A draft method and an n-gram assist can run together, and they cost each other nothing on new text. On text the model is repeating — a file it is rewriting, a structured response, a tool-call loop — the n-gram assist is several times faster than a draft method alone. Neither one gives you both: an n-gram method is no help at all on genuinely new text, and a draft method gives up most of the speed on repeated text.</p>
+            <p>When both propose tokens for the same step, <strong>the n-gram proposal is the one used</strong>. That is worth knowing when you read a benchmark result: if a combined run comes out slower than the draft method alone on new text, it is because weak n-gram matches are displacing good draft proposals. Whether that happens depends on the model and the hardware, so measure it — the benchmark sweep can run the same model with the draft method alone and with both, side by side.</p>
+
             <h5>Parameters</h5>
+            <p>Each slot has its own settings, because the two do not share a draft length: MTP might draft 3 tokens while N-gram Mod drafts 64, and both are in effect at once.</p>
             <dl>
-                <dt><strong>Draft Max</strong> (default: 16)</dt>
-                <dd>Maximum tokens to draft per step. Higher = more aggressive speculation. Use 32-64 for MoE models. Reduce for dense models if acceptance is low.</dd>
+                <dt><strong>Draft tokens max / min</strong> (draft method)</dt>
+                <dd>How many tokens the draft method proposes per step, and how many it always proposes before verifying. Higher maximums mean more aggressive speculation; 32-64 suits MoE models, less for dense ones if acceptance is low. Leave blank to use llama.cpp's own defaults of 3 and 0.</dd>
 
-                <dt><strong>Draft Min</strong> (default: 0)</dt>
-                <dd>Minimum tokens to always draft before verification. For N-gram Mod with dense models, try 48.</dd>
+                <dt><strong>Draft probability min</strong> (draft method)</dt>
+                <dd>Stops drafting once a token's probability falls below this. Lower drafts more tokens at a lower acceptance rate; higher drafts fewer, more accurate ones. Mainly useful for Draft Model — MTP and the trained heads have their own acceptance logic.</dd>
 
-                <dt><strong>Min Probability</strong> (default: 0.75)</dt>
-                <dd>Only for Draft Model mode. Stops drafting when token probability drops below this threshold. Lower = more aggressive (more tokens drafted, lower acceptance). Higher = conservative (fewer but more accurate drafts).</dd>
+                <dt><strong>Assist tokens max / min</strong> (N-gram Mod)</dt>
+                <dd>How long a continuation N-gram Mod proposes. Much larger than a draft model's, because a matched pattern can be replayed at length: 64 and 48 are the recommended starting values.</dd>
 
-                <dt><strong>N-gram Lookup Size</strong> (default: 12)</dt>
-                <dd>How many recent tokens to use as the search key. Larger = fewer but more precise matches. For N-gram Mod, use 24.</dd>
+                <dt><strong>Match length</strong> (N-gram Mod, default: 24)</dt>
+                <dd>How many recent tokens must match before a continuation is proposed. Longer means fewer but more reliable matches.</dd>
 
-                <dt><strong>N-gram Draft Size</strong> (default: 48)</dt>
-                <dd>How many tokens following a match to propose as the draft. Larger values give bigger speedups when patterns repeat extensively.</dd>
+                <dt><strong>Lookup size</strong> (other n-gram methods, default: 12)</dt>
+                <dd>How many recent tokens are used as the search key. Larger means fewer but more precise matches.</dd>
+
+                <dt><strong>Draft size</strong> (other n-gram methods, default: 48)</dt>
+                <dd>How many tokens following a match are proposed. Larger values pay off more when patterns repeat at length.</dd>
+
+                <dt><strong>Minimum hits</strong> (other n-gram methods, default: 1)</dt>
+                <dd>How many times a pattern must have been seen before it is proposed. Higher is more selective: fewer drafts, higher acceptance.</dd>
             </dl>
 
             <h5>When to use it</h5>
@@ -265,29 +279,47 @@
             <h5>When to skip it</h5>
             <ul>
                 <li>Small/fast models — overhead exceeds gains</li>
-                <li>VRAM-constrained and no draft model — try N-gram Mod instead</li>
+                <li>VRAM-constrained and no draft model — try N-gram Mod on its own, with the draft method left Disabled</li>
                 <li>Very short completions (few tokens) — not enough to amortize</li>
                 <li>Acceptance rate consistently below ~50% — will slow things down</li>
             </ul>
         </article>
     </dialog>
     <div class="grid">
-        <label title="Speculative decoding mode. Draft model uses a smaller model to propose tokens. N-gram modes use pattern matching from the prompt — no extra model needed.">
-            Mode
+        <label title="A model or trained head proposes tokens that the main model verifies in parallel. Only one draft method can run at a time.">
+            Draft method
             <select name="spec_type">
                 <option value="" {{if eq .Config.SpecType ""}}selected{{end}}>Disabled</option>
-                <option value="draft" {{if eq .Config.SpecType "draft"}}selected{{end}}>Draft Model{{if not .DraftCandidates}} (no compatible models){{end}}</option>
-                <option value="draft-mtp" {{if eq .Config.SpecType "draft-mtp"}}selected{{end}}>MTP (self-speculation)</option>
-                <option value="ngram-simple" {{if eq .Config.SpecType "ngram-simple"}}selected{{end}}>N-gram Simple</option>
-                <option value="ngram-cache" {{if eq .Config.SpecType "ngram-cache"}}selected{{end}}>N-gram Cache</option>
-                <option value="ngram-map-k" {{if eq .Config.SpecType "ngram-map-k"}}selected{{end}}>N-gram Map-K</option>
-                <option value="ngram-map-k4v" {{if eq .Config.SpecType "ngram-map-k4v"}}selected{{end}}>N-gram Map-K4V</option>
-                <option value="ngram-mod" {{if eq .Config.SpecType "ngram-mod"}}selected{{end}}>N-gram Mod</option>
+                {{range .DraftModes}}
+                <option value="{{.Name}}" {{if eq $.Config.SpecType .Name}}selected{{end}}>{{.Label}}{{if and (eq .Name "draft") (not $.DraftCandidates)}} (no compatible models){{end}}</option>
+                {{end}}
+            </select>
+        </label>
+        <label title="Matches repeated text in the prompt and the generation so far, and proposes what came next. Loads no extra file and uses no extra memory, and runs alongside the draft method. When both propose tokens for the same step, the n-gram proposal is the one used.">
+            N-gram assist
+            <select name="spec_assist">
+                <option value="" {{if eq .Config.SpecAssist ""}}selected{{end}}>None</option>
+                {{range .AssistModes}}
+                <option value="{{.Name}}" {{if eq $.Config.SpecAssist .Name}}selected{{end}}>{{.Label}}</option>
+                {{end}}
             </select>
         </label>
         {{if eq .Config.SpecType "draft"}}
         <label title="A smaller model of the same architecture proposes tokens that the main model verifies in parallel.">
             Draft Model
+            <select name="draft_model_path">
+                <option value="">None</option>
+                {{range .DraftCandidates}}
+                <option value="{{.FilePath}}" {{if eq $.Config.DraftModelPath .FilePath}}selected{{end}}>
+                    {{.Filename}} ({{printf "%.1f" .SizeGB}} GiB)
+                </option>
+                {{end}}
+            </select>
+        </label>
+        {{end}}
+        {{if or (eq .Config.SpecType "draft-eagle3") (or (eq .Config.SpecType "draft-dflash") (eq .Config.SpecType "draft-dspark"))}}
+        <label title="The converted head for this model. The list is not filtered by architecture or size, because a head is a trained extra layer rather than a smaller model of the same family.">
+            Drafter Head
             <select name="draft_model_path">
                 <option value="">None</option>
                 {{range .DraftCandidates}}
@@ -311,28 +343,28 @@
         </label>
         {{end}}
     </div>
-    {{if ne .Config.SpecType ""}}
+    {{if .DraftParams}}
     <div class="grid">
-        <label title="Maximum tokens to draft per step. Higher = more aggressive speculation. MoE models benefit from longer drafts. Default: 16">
-            Draft Max
-            <input type="number" name="draft_max" value="{{.Config.DraftMax}}"
-                   min="0" max="128" placeholder="16">
+        <label title="Maximum tokens the draft method proposes per step. Higher means more aggressive speculation. MoE models benefit from longer drafts. llama.cpp default: 3">
+            Draft tokens max
+            <input type="number" name="draft_max" value="{{if gt .Config.DraftMax 0}}{{.Config.DraftMax}}{{end}}"
+                   min="0" max="128" placeholder="3">
         </label>
-        <label title="Minimum tokens to draft before verification. Dense models can use lower values. Default: 0">
-            Draft Min
-            <input type="number" name="draft_min" value="{{.Config.DraftMin}}"
+        <label title="Minimum tokens to draft before verification. Dense models can use lower values. llama.cpp default: 0">
+            Draft tokens min
+            <input type="number" name="draft_min" value="{{if gt .Config.DraftMin 0}}{{.Config.DraftMin}}{{end}}"
                    min="0" max="64" placeholder="0">
         </label>
-        <label title="Minimum probability for accepting a drafted token. Lower = accept more drafts. Default: 0.75">
-            Min Probability
+        <label title="Stop drafting once a token's probability falls below this. Lower drafts more tokens at a lower acceptance rate; higher drafts fewer, more accurate ones. Leave blank to use llama.cpp's default.">
+            Draft probability min
             <input type="number" name="draft_p_min" step="0.05" min="0" max="1"
                    value="{{.Config.DraftPMin}}"
-                   placeholder="0.75">
+                   placeholder="server default">
         </label>
     </div>
     {{end}}
-    {{if or (eq .Config.SpecType "draft") (and (eq .Config.SpecType "draft-mtp") .HasMTP)}}
-    <small><strong>Draft model resources</strong> — leave blank to inherit llama-server defaults. Set these when the draft/MTP head needs its own GPU offload, context, or cache type (e.g. <code>--device-draft CUDA0</code> on multi-GPU).</small>
+    {{if or (eq .Config.SpecType "draft") (or (and (eq .Config.SpecType "draft-mtp") .HasMTP) (or (eq .Config.SpecType "draft-eagle3") (or (eq .Config.SpecType "draft-dflash") (eq .Config.SpecType "draft-dspark"))))}}
+    <small><strong>Draft model resources</strong> — leave blank to inherit llama-server defaults. Set these when the draft model or head needs its own GPU offload, context, or cache type (e.g. <code>--device-draft CUDA0</code> on multi-GPU). They apply whenever a drafter is loaded through <code>--model-draft</code>, so not to self-speculation MTP, where the draft <em>is</em> the main model.</small>
     <div class="grid">
         <label title="Context size for the draft model. Default: inherits from main ctx-size.">
             Draft Ctx Size
@@ -377,20 +409,50 @@
     <small>gemma-4's separate <code>gemma4-assistant</code> head needs a llama.cpp build of <strong>b9549 or newer</strong>. Older builds report <em>"model type gemma4_assistant not supported"</em> — rebuild from the Builds tab if needed.</small>
     {{end}}
     {{end}}
-    {{if and (ne .Config.SpecType "") (ne .Config.SpecType "draft") (ne .Config.SpecType "draft-mtp")}}
+    {{if eq .Config.SpecAssist "ngram-mod"}}
     <div class="grid">
-        <label title="Length of the n-gram used for lookup in generation history. Default: 12">
-            N-gram Lookup Size
-            <input type="number" name="ngram_size_n" value="{{.Config.NgramSizeN}}"
-                   min="0" max="64" placeholder="12">
+        <label title="Maximum tokens the n-gram assist proposes per step. N-gram Mod drafts much longer sequences than a draft model does. Default: 64">
+            Assist tokens max
+            <input type="number" name="assist_n_max" value="{{if gt .Config.AssistNMax 0}}{{.Config.AssistNMax}}{{end}}"
+                   min="0" max="512" placeholder="64">
         </label>
-        <label title="Length of the draft sequence generated from n-gram matches. Default: 48">
-            N-gram Draft Size
-            <input type="number" name="ngram_size_m" value="{{.Config.NgramSizeM}}"
-                   min="0" max="128" placeholder="48">
+        <label title="Minimum tokens the n-gram assist proposes before verification. Default: 48">
+            Assist tokens min
+            <input type="number" name="assist_n_min" value="{{if gt .Config.AssistNMin 0}}{{.Config.AssistNMin}}{{end}}"
+                   min="0" max="512" placeholder="48">
+        </label>
+        <label title="How many recent tokens must match before the assist proposes a continuation. Longer means fewer but more reliable matches. Default: 24">
+            Match length
+            <input type="number" name="assist_n_match" value="{{if gt .Config.AssistNMatch 0}}{{.Config.AssistNMatch}}{{end}}"
+                   min="0" max="128" placeholder="24">
         </label>
     </div>
     {{end}}
+    {{if and (ne .Config.SpecAssist "") (ne .Config.SpecAssist "ngram-mod") (ne .Config.SpecAssist "ngram-cache")}}
+    <div class="grid">
+        <label title="How many recent tokens are used as the search key. Larger means fewer but more precise matches. Default: 12">
+            Lookup size
+            <input type="number" name="assist_size_n" value="{{if gt .Config.AssistSizeN 0}}{{.Config.AssistSizeN}}{{end}}"
+                   min="0" max="64" placeholder="12">
+        </label>
+        <label title="How many tokens following a match are proposed as the draft. Larger values pay off more when patterns repeat at length. Default: 48">
+            Draft size
+            <input type="number" name="assist_size_m" value="{{if gt .Config.AssistSizeM 0}}{{.Config.AssistSizeM}}{{end}}"
+                   min="0" max="128" placeholder="48">
+        </label>
+        <label title="How many times a pattern must have been seen before the assist will propose it. Higher is more selective. Default: 1">
+            Minimum hits
+            <input type="number" name="assist_min_hits" value="{{if gt .Config.AssistMinHits 0}}{{.Config.AssistMinHits}}{{end}}"
+                   min="0" max="64" placeholder="1">
+        </label>
+    </div>
+    {{end}}
+    {{if eq .Config.SpecAssist "ngram-cache"}}
+    <small>N-gram Cache takes no settings.</small>
+    {{end}}
+    <small><strong>Effective <code>--spec-type</code>:</strong>
+        {{if .EffectiveSpecType}}<code>{{.EffectiveSpecType}}</code>{{else}}speculative decoding is off — no <code>--spec-type</code> flag is passed{{end}}
+    </small>
 
     <hr style="margin: 1rem 0 0.5rem;">
     <small><strong>Sampling</strong> — applied per-request, no restart needed. Leave blank for server defaults.


### PR DESCRIPTION
## Summary

Splits speculative decoding into two independent slots — a **draft method** (one of `draft-model`, `draft-mtp`, `draft-eagle3`, `draft-dflash`, `draft-dspark`) and a **draftless n-gram assist** (`ngram`, `ngram-mod`) — so a model configuration can run both at once, with independent parameters for each.

llama.cpp has accepted a comma-separated `--spec-type` list for a while, and running a draft method alongside an n-gram method is a large win on recall-heavy work. The toolchest couldn't express it: `ModelConfig.SpecType` was a single string, and the four draft-length fields around it changed meaning depending on which mode was selected, so "MTP drafting 3 tokens and N-gram Mod drafting 64" was not merely unsupported, it was inexpressible.

The preset INI emits a single comma-joined `spec-type` line, because `common/preset.cpp` parses a section into a map and silently keeps only the last value of a repeated key.

## Also fixed along the way

- `--spec-ngram-mod-n-match` was offered in the config form and stored, but never emitted — tuning it did nothing.
- `ngram_size_m` was offered for `ngram-mod`, which has no m-gram size.
- `--spec-<mode>-min-hits` was defaulted but never passed to llama-server.
- `draft-eagle3`, `draft-dflash` and `draft-dspark` are merged and shipped in our build but appeared in neither the mode picker nor the benchmark axis.

The UI now makes it structurally impossible to select two draft methods at once, which is the open upstream startup crash ([#27897](https://github.com/ggml-org/llama.cpp/issues/27897)).

## Measured on this hardware

Qwen3.5-9B-MTP IQ4_NL, RX 9070 XT, build `b10453-rocm-optimized`. Generation tok/s, mean ± sd over 3 repetitions.

`internal-echo` (recall workload, new in this branch — every existing preset asks for new text, which is exactly where an n-gram method measures nothing):

| config | gen tok/s | vs off |
|---|---:|---:|
| off | 78.0 ± 0.4 | 1.00× |
| MTP alone | 153.3 ± 1.0 | 1.96× |
| N-gram Mod alone | 436.5 ± 51.4 | 5.59× |
| **MTP + N-gram Mod** | **447.1 ± 8.4** | **5.73×** |

On new text (`internal-standard`) the combination costs about 8-10% against MTP alone — consistent across all three prompt sizes, and matching the mechanism: llama.cpp gives the draftless method precedence for a contested step, so a weak n-gram match can displace a good MTP draft. The config form's help copy warns about this; it is now measured rather than argued about.

The argument for the combination is that one setting covers both workloads: 5.7× on recall *and* 1.6× on new text, where N-gram Mod alone is only 1.06× on new text.

Full write-up in `plan/speculative-multi-mode/results.md`.

## Compatibility

Every existing configuration keeps working — a config naming one mode emits exactly the flags it emits today, with the deliberate exception of the two flags dropped by the bugs above, which now appear. Stored benchmark history keeps its old `spec_type: ngram-mod` shape on disk and is normalised on read.

## Not in scope

`--spec-chain` (flag doesn't exist upstream; the feature request is closed as not planned), `draft-mtp-adaptive` (open, merge-blocked PR — an unknown mode name is a hard llama-server startup failure and we have no build-aware capability gating yet), a general N-mode list, and user-controllable mode ordering (`common_speculative_init` walks a fixed priority order, so the two orderings are byte-identical).

## Test plan

- `go test ./...` — new coverage in `spec_smoke_test.go`, `spec_form_test.go`, `sweep_test.go`, `overrides_test.go`, `split_params_test.go`
- `web/jstest/params_test.js` for the config form's mode interlocks
- Benchmark job `job-1788821931442-469f5504` run end to end: 8 cells, flags verified in the generated `bench-preset.ini`, `prompt_tokens` steady across repetitions so no cell was served from the prompt cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWiscP8ZRwSc9Cs7Vx38nq
