### PR TITLE
Stop Ad-Hoc Runs claiming completed while a run is going

### DIFF
--- a/internal/api/bench_adhoc_status_test.go
+++ b/internal/api/bench_adhoc_status_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tmac1973/llama-toolchest/internal/benchmark"
+)
+
+// adhocServer is a Server with a real store holding the given adhoc runs.
+func adhocServer(t *testing.T, statuses ...string) *Server {
+	t.Helper()
+	s := benchListServer(t)
+	s.bench = benchmark.NewStore(t.TempDir(), nil)
+	for i, st := range statuses {
+		// JobID left empty, which is how an ad-hoc run actually arrives:
+		// Save assigns it and creates the synthetic job on first use.
+		s.bench.Save(benchmark.BenchmarkRun{
+			ID:        "r" + string(rune('1'+i)),
+			Status:    st,
+			CreatedAt: time.Unix(0, 0).UTC(),
+			ModelID:   "m", ModelName: "M", Quant: "Q4_K_M", Preset: "quick",
+		})
+	}
+	return s
+}
+
+// The synthetic adhoc job is built with a fixed "completed" status, so the
+// collapsed row claimed completed while a run inside it was still going —
+// and expanding it showed the running run directly under the badge
+// contradicting it.
+func TestAdhocRowStatusFollowsItsRuns(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []string
+		want     string
+	}{
+		{"nothing running", []string{benchmark.StatusCompleted}, benchmark.JobStatusCompleted},
+		{"one running", []string{benchmark.StatusCompleted, benchmark.StatusRunning}, benchmark.JobStatusRunning},
+		{"several, one running", []string{
+			benchmark.StatusCompleted, benchmark.StatusFailed, benchmark.StatusRunning,
+		}, benchmark.JobStatusRunning},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := adhocServer(t, tc.statuses...)
+			rec := httptest.NewRecorder()
+			s.renderJobList(rec, s.bench.ListJobs())
+			out := rec.Body.String()
+
+			want := `id="job-status-adhoc" class="job-status status-` + tc.want
+			if !strings.Contains(out, want) {
+				t.Errorf("adhoc row should read %q\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
+// There is no ad-hoc row until an ad-hoc run exists — the job is synthesized
+// on first use, not seeded — so an empty store shows no row rather than an
+// idle one.
+func TestAdhocRowAbsentUntilARunExists(t *testing.T) {
+	s := adhocServer(t)
+	rec := httptest.NewRecorder()
+	s.renderJobList(rec, s.bench.ListJobs())
+	if strings.Contains(rec.Body.String(), "job-status-adhoc") {
+		t.Errorf("no runs should mean no ad-hoc row\n%s", rec.Body.String())
+	}
+}
+
+// The row is drawn by the job list, which has no idea a run started. Without
+// these the badge stays stale until a full refresh.
+func TestAdhocDetailUpdatesTheRowOutOfBand(t *testing.T) {
+	s := adhocServer(t, benchmark.StatusRunning)
+	rec := httptest.NewRecorder()
+	s.renderAdhocDetail(rec)
+	out := rec.Body.String()
+
+	if !strings.Contains(out, `id="job-status-adhoc" hx-swap-oob="true"`) {
+		t.Errorf("no out-of-band status update\n%s", out)
+	}
+	if !strings.Contains(out, "status-running") {
+		t.Errorf("the out-of-band badge should read running\n%s", out)
+	}
+	if !strings.Contains(out, `id="job-progress-adhoc" hx-swap-oob="true"`) {
+		t.Errorf("no out-of-band progress update\n%s", out)
+	}
+	if !strings.Contains(out, ">1 run<") {
+		t.Errorf("progress should read the run count, singular\n%s", out)
+	}
+}
+
+// Polling only while something is running: an idle history of hundreds of
+// runs should not re-render itself every two seconds forever.
+func TestAdhocDetailPollsOnlyWhileRunning(t *testing.T) {
+	running := httptest.NewRecorder()
+	adhocServer(t, benchmark.StatusRunning).renderAdhocDetail(running)
+	if !strings.Contains(running.Body.String(), `hx-trigger="every 2s"`) {
+		t.Error("a running list should poll so the rows and badge stay current")
+	}
+
+	idle := httptest.NewRecorder()
+	adhocServer(t, benchmark.StatusCompleted).renderAdhocDetail(idle)
+	if strings.Contains(idle.Body.String(), `hx-trigger="every 2s"`) {
+		t.Error("an idle list should not poll")
+	}
+}
+
+// The run list itself still renders — the wrapper must not replace it.
+func TestAdhocDetailStillRendersTheRuns(t *testing.T) {
+	s := adhocServer(t, benchmark.StatusCompleted)
+	rec := httptest.NewRecorder()
+	s.renderAdhocDetail(rec)
+	if !strings.Contains(rec.Body.String(), "bench-runs-container") {
+		t.Errorf("the run list is missing\n%s", rec.Body.String())
+	}
+}
+
+// The shared renderer serves GET /api/benchmarks/ as well, where an adhoc
+// badge update would target a row that view knows nothing about.
+func TestBenchmarkListItselfEmitsNoAdhocUpdates(t *testing.T) {
+	s := adhocServer(t, benchmark.StatusRunning)
+	rec := httptest.NewRecorder()
+	s.renderBenchmarkList(rec, s.bench.RunsForJob(benchmark.AdhocJobID))
+	if strings.Contains(rec.Body.String(), "job-status-adhoc") {
+		t.Error("the shared list renderer should not emit adhoc row updates")
+	}
+}

--- a/internal/api/bench_jobs.go
+++ b/internal/api/bench_jobs.go
@@ -57,9 +57,25 @@ func (s *Server) renderJobList(w http.ResponseWriter, jobs []benchmark.Benchmark
 	if len(enriched) > 0 {
 		// The synthetic adhoc job carries no Cells, so its progress
 		// column should show the total run count instead.
+		//
+		// Its status needs deriving for the same reason. newAdhocJob
+		// synthesizes it as "completed" — it is a container for
+		// individually-started runs, not something that runs — and nothing
+		// revisits that, so the row claimed completed while a run inside it
+		// was still going, with the expanded list showing the running run
+		// directly under the badge contradicting it.
 		for i := range enriched {
-			if enriched[i].Job.ID == benchmark.AdhocJobID {
-				enriched[i].AdhocRuns = len(s.bench.RunsForJob(benchmark.AdhocJobID))
+			if enriched[i].Job.ID != benchmark.AdhocJobID {
+				continue
+			}
+			runs := s.bench.RunsForJob(benchmark.AdhocJobID)
+			enriched[i].AdhocRuns = len(runs)
+			enriched[i].Job.Status = benchmark.JobStatusCompleted
+			for _, r := range runs {
+				if r.Status == benchmark.StatusRunning {
+					enriched[i].Job.Status = benchmark.JobStatusRunning
+					break
+				}
 			}
 		}
 	}
@@ -590,13 +606,58 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 		// existing flat run list instead so legacy + quick-bench runs
 		// stay visible.
 		if job.ID == benchmark.AdhocJobID {
-			s.renderBenchmarkList(w, s.bench.RunsForJob(benchmark.AdhocJobID))
+			s.renderAdhocDetail(w)
 			return
 		}
 		s.renderJobDetail(w, job)
 		return
 	}
 	respondJSON(w, job)
+}
+
+// renderAdhocDetail renders the adhoc job's expanded view: the shared run
+// list, wrapped in the bits that keep its collapsed row honest.
+//
+// The row is drawn by the job list, which has no idea a run has started, so
+// without the out-of-band updates below it keeps whatever badge it was
+// rendered with — "completed" over a running run, which the list underneath
+// then contradicts. Polling while a run is in flight is what keeps both
+// current; an idle list does not poll, since a history of hundreds of runs
+// should not re-render itself every two seconds forever.
+//
+// This lives here rather than inside renderBenchmarkList because that
+// renderer also serves GET /api/benchmarks/, and these updates are specific
+// to being the adhoc job's detail.
+func (s *Server) renderAdhocDetail(w http.ResponseWriter) {
+	runs := s.bench.RunsForJob(benchmark.AdhocJobID)
+
+	running := false
+	for _, r := range runs {
+		if r.Status == benchmark.StatusRunning {
+			running = true
+			break
+		}
+	}
+
+	status := benchmark.JobStatusCompleted
+	if running {
+		status = benchmark.JobStatusRunning
+	}
+	fmt.Fprintf(w,
+		`<span id="job-status-%[1]s" hx-swap-oob="true" class="job-status status-%[2]s" title="status: %[2]s">%[2]s</span>`,
+		benchmark.AdhocJobID, status)
+	fmt.Fprintf(w,
+		`<span id="job-progress-%s" hx-swap-oob="true" class="job-progress">%d run%s</span>`,
+		benchmark.AdhocJobID, len(runs), pluralS(len(runs)))
+
+	if running {
+		fmt.Fprintf(w,
+			`<div hx-get="/api/benchmark-jobs/%s" hx-trigger="every 2s" hx-swap="outerHTML">`,
+			benchmark.AdhocJobID)
+		defer w.Write([]byte(`</div>`))
+	}
+
+	s.renderBenchmarkList(w, runs)
 }
 
 // renderJobDetail enriches a job's cells with their linked run summary


### PR DESCRIPTION
The Ad-Hoc Runs row reads "completed" whatever is inside it. Expanding it
during a run shows a running run directly under a badge saying the opposite.

`newAdhocJob` synthesizes the entry with a fixed completed status — it is a
container for individually-started runs, not something that runs — and nothing
ever revisited it. `renderJobList` now derives it from the runs the container
holds.

That alone would have been stale until the next full list refresh, because the
row is drawn by the job list and the list has no idea a run started. So the
ad-hoc detail also carries out-of-band updates for the row's badge and run
count, and polls itself while a run is in flight. An idle list does not poll —
a history of hundreds of runs should not re-render every two seconds forever.

The wrapper is a new `renderAdhocDetail` rather than something inside
`renderBenchmarkList`, because that renderer also serves `GET /api/benchmarks/`,
where an ad-hoc badge update would target a row that view knows nothing about.
A test pins that separation.

## Verification

`go test ./...` passes. New tests cover the status derivation (nothing running,
one running, several with one running), the absence of a row before any ad-hoc
run exists, the out-of-band updates, that polling is conditional, and that the
shared renderer stays free of ad-hoc concerns. Reverting the derivation fails
them.

Found while bringing vllm-toolchest to parity, where the same code had the same
bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5DEEQi1hr4cuf8UfdghmZ